### PR TITLE
Feat: API 공통 응답 형식 및 global exception 세팅

### DIFF
--- a/src/main/java/com/cocos/cocos/common/exception/CocosException.java
+++ b/src/main/java/com/cocos/cocos/common/exception/CocosException.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.common.exception;
+
+import com.cocos.cocos.common.response.message.FailMessage;
+import lombok.Getter;
+
+@Getter
+public class CocosException extends RuntimeException {
+    private final FailMessage failMessage;
+
+    public CocosException(final FailMessage failMessage) {
+        super(failMessage.getMessage());
+        this.failMessage = failMessage;
+    }
+}

--- a/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.cocos.cocos.common.handler;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.message.FailMessage;
+import com.cocos.cocos.common.response.FailResponse;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CocosException.class)
+    public ResponseEntity<BaseResponse<?>> handleAgodaException(final CocosException e) {
+        return FailResponse.failure(e.getFailMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        final String errorMessage = e.getBindingResult().getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining("\n"));
+
+        return FailResponse.failure(FailMessage.BAD_REQUEST_REQUEST_BODY_VALID, errorMessage);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse<?>> handleMissingParamException(final MissingServletRequestParameterException e) {
+        final String errorMessage = "누락된 파라미터 : " + e.getParameterName();
+        return FailResponse.failure(FailMessage.BAD_REQUEST_MISSING_PARAM, errorMessage);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<?>> handleMethodArgumentTypeMismatchException(final MethodArgumentTypeMismatchException e) {
+        final String errorMessage = "잘못된 인자값 : " + e.getParameter().getParameterName();
+        return FailResponse.failure(FailMessage.BAD_REQUEST_METHOD_ARGUMENT_TYPE, errorMessage);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(final HttpMessageNotReadableException e) {
+        if (e.getCause() instanceof JsonMappingException jsonMappingException) {
+            final String errorMessage = jsonMappingException.getPath().stream()
+                    .map(ref -> String.format("잘못된 필드 값 : '%s'", ref.getFieldName()))
+                    .collect(Collectors.joining("\n"));
+            return FailResponse.failure(FailMessage.BAD_REQUEST_NOT_READABLE, errorMessage);
+        } else {
+            return FailResponse.failure(FailMessage.BAD_REQUEST_NOT_READABLE);
+        }
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<BaseResponse<?>> handleEntityNotFoundException(final EntityNotFoundException e) {
+        return FailResponse.failure(FailMessage.NOT_FOUND_ENTITY);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<BaseResponse<?>> handleNoResourceFoundException(final NoResourceFoundException e) {
+        return FailResponse.failure(FailMessage.NOT_FOUND_API);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<BaseResponse<?>> handleNoHandlerFoundException(final NoHandlerFoundException e) {
+        return FailResponse.failure(FailMessage.NOT_FOUND_API);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<BaseResponse<?>> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
+        return FailResponse.failure(FailMessage.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<BaseResponse<?>> handleDataIntegrityViolationException(final DataIntegrityViolationException e) {
+        if (e.getCause() instanceof ConstraintViolationException constraintViolationException) {
+            final String constraintName = constraintViolationException.getConstraintViolations().toString();
+            final String errorMessage = String.format("제약 조건 '%s' 위반이 발생했습니다.", constraintName);
+            return FailResponse.failure(FailMessage.INTEGRITY_CONFLICT, errorMessage);
+        } else {
+            return FailResponse.failure(FailMessage.INTEGRITY_CONFLICT);
+        }
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<?>> handleGeneralException(Exception e) {
+        return FailResponse.failure(FailMessage.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/cocos/cocos/common/response/BaseResponse.java
+++ b/src/main/java/com/cocos/cocos/common/response/BaseResponse.java
@@ -1,0 +1,17 @@
+package com.cocos.cocos.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record BaseResponse<T>(
+        int code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data
+) {
+    public static BaseResponse<?> of(final int code, final String message) {
+        return new BaseResponse<>(code, message, null);
+    }
+
+    public static <T> BaseResponse<T> of(final int code, final String message, final T data) {
+        return new BaseResponse<>(code, message, data);
+    }
+}

--- a/src/main/java/com/cocos/cocos/common/response/FailResponse.java
+++ b/src/main/java/com/cocos/cocos/common/response/FailResponse.java
@@ -1,0 +1,17 @@
+package com.cocos.cocos.common.response;
+
+import com.cocos.cocos.common.response.message.FailMessage;
+import org.springframework.http.ResponseEntity;
+
+public class FailResponse {
+
+    public static ResponseEntity<BaseResponse<?>> failure(final FailMessage failMessage) {
+        return ResponseEntity.status(failMessage.getHttpStatus())
+                .body(BaseResponse.of(failMessage.getCode(), failMessage.getMessage()));
+    }
+
+    public static ResponseEntity<BaseResponse<?>> failure(final FailMessage failMessage, final String customMessage) {
+        return ResponseEntity.status(failMessage.getHttpStatus())
+                .body(BaseResponse.of(failMessage.getCode(), customMessage));
+    }
+}

--- a/src/main/java/com/cocos/cocos/common/response/SuccessResponse.java
+++ b/src/main/java/com/cocos/cocos/common/response/SuccessResponse.java
@@ -1,0 +1,17 @@
+package com.cocos.cocos.common.response;
+
+import com.cocos.cocos.common.response.message.ApiMessage;
+import org.springframework.http.ResponseEntity;
+
+public class SuccessResponse {
+
+    public static <T> ResponseEntity<BaseResponse<T>> success(final ApiMessage apiMessage, final T data) {
+        return ResponseEntity.status(apiMessage.getHttpStatus())
+                .body(BaseResponse.of(apiMessage.getCode(), apiMessage.getMessage(), data));
+    }
+
+    public static ResponseEntity<BaseResponse<?>> success(final ApiMessage apiMessage) {
+        return ResponseEntity.status(apiMessage.getHttpStatus())
+                .body(BaseResponse.of(apiMessage.getCode(), apiMessage.getMessage()));
+    }
+}

--- a/src/main/java/com/cocos/cocos/common/response/message/ApiMessage.java
+++ b/src/main/java/com/cocos/cocos/common/response/message/ApiMessage.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.common.response.message;
+
+import org.springframework.http.HttpStatus;
+
+public interface ApiMessage {
+    HttpStatus getHttpStatus();
+    int getCode();
+    String getMessage();
+}

--- a/src/main/java/com/cocos/cocos/common/response/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/common/response/message/FailMessage.java
@@ -1,0 +1,67 @@
+package com.cocos.cocos.common.response.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FailMessage implements ApiMessage{
+
+    /**
+     * 400
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, 40000, "잘못된 요청입니다. "),
+    BAD_REQUEST_REQUEST_BODY_VALID(HttpStatus.BAD_REQUEST, 40001,"request body 검증 실패입니다. "),
+    BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST,40002, "필수 param이 없습니다. "),
+    BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40003,"메서드 인자타입이 잘못되었습니다. "),
+    BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40004,"json 오류 혹은 reqeust body 필드 오류 입니다. "),
+
+    /**
+     * 401
+     */
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100,"인증이 필요합니다. "),
+
+    /**
+     * 403
+     */
+    FORBIDDEN(HttpStatus.FORBIDDEN, 40300,"권한이 없습니다. "),
+
+    /**
+     * 404
+     */
+    NOT_FOUND(HttpStatus.NOT_FOUND, 40400,"리소스를 찾을 수 없습니다. "),
+    NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, 40401,"대상을 찾을 수 없습니다. "),
+    NOT_FOUND_API(HttpStatus.NOT_FOUND,40402, "잘못된 API입니다. "),
+
+    /**
+     * 405
+     */
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500,"잘못된 HTTP method 요청입니다."),
+
+    /**
+     * 409
+     */
+    CONFLICT(HttpStatus.CONFLICT, 40900,"데이터 충돌이 발생했습니다. "),
+    INTEGRITY_CONFLICT(HttpStatus.CONFLICT, 40901,"데이터 무결성 위반입니다."),
+
+    /**
+     * 422
+     */
+    UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, 42200,"처리할 수 없는 요청입니다."),
+
+    /**
+     * 500
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000,"서버 내부 오류가 발생했습니다. "),
+
+    /**
+     * 503
+     */
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 50300,"현재 서비스를 사용할 수 없습니다. ");
+
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/cocos/cocos/common/response/message/SuccessMessage.java
+++ b/src/main/java/com/cocos/cocos/common/response/message/SuccessMessage.java
@@ -1,0 +1,23 @@
+package com.cocos.cocos.common.response.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage implements ApiMessage {
+    /**
+     * 200
+     */
+    OK(HttpStatus.OK, 20000,"요청에 성공했습니다. "),
+
+    /**
+     * 201
+     */
+    CREATED(HttpStatus.CREATED, 20100,"요청에 성공했습니다 .");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #5 

## 👷 **작업한 내용**
- global exception 추가했습니다.
- 예상되는 에러를 미리 정의했습니다.
- API 공통 응답 형식을 정의했습니다.
- custom 에러 코드를 추가했습니다. 

## 🚨 **참고 사항**
- 성공 시에는 SuccessResponse.success를 사용하여 응답을 보내면 됩니다.
```java
    @GetMapping("/check-param")
    public ResponseEntity<?> testOptionalParam(@RequestParam(value = "param") String param) {
        return SuccessResponse.success(SuccessMessage.OK, param);
    }
```

- runtime에러를 발생시킬 때는 CocosException을 던져주세요.
```java
throw new CocosException(FailMessage.NOT_FOUND);
```

- 에러를 던질 때, 새로운 에러라면 FailMessage 또는 SuccessMessage에 응답 코드와 메시지를 추가하고 에러를 던져주세요.
```java
    BAD_REQUEST(HttpStatus.BAD_REQUEST, 40000, "잘못된 요청입니다. "),
```