### PR TITLE
Feat: 게시글 공감 추가 API 및 게시글 공감 삭제 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
@@ -1,0 +1,34 @@
+package com.cocos.cocos.api.post.controller;
+
+import com.cocos.cocos.api.post.service.PostLikeService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/dev/likes")
+@RequiredArgsConstructor
+public class PostLikeController implements PostLikeControllerSwagger {
+
+    private static final Long MEMBER_ID = 1L;
+    private final PostLikeService postLikeService;
+
+    @PostMapping("/{postId}")
+    public ResponseEntity<BaseResponse<Void>> addPostLike(
+            @PathVariable(name = "postId") final Long postId
+    ) {
+        postLikeService.addPostLike(MEMBER_ID, postId);
+        return SuccessResponse.success(SuccessMessage.NO_CONTENT, null);
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<BaseResponse<Void>> deletePostLike(
+            @PathVariable(name = "postId") final Long postId
+    ) {
+        postLikeService.deletePostLike(MEMBER_ID, postId);
+        return SuccessResponse.success(SuccessMessage.NO_CONTENT, null);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/dev/likes")
+@RequestMapping("${api.prefix}/likes")
 @RequiredArgsConstructor
 public class PostLikeController implements PostLikeControllerSwagger {
 
@@ -21,7 +21,7 @@ public class PostLikeController implements PostLikeControllerSwagger {
             @PathVariable(name = "postId") final Long postId
     ) {
         postLikeService.addPostLike(MEMBER_ID, postId);
-        return SuccessResponse.success(SuccessMessage.NO_CONTENT, null);
+        return SuccessResponse.success(SuccessMessage.OK, null);
     }
 
     @DeleteMapping("/{postId}")
@@ -29,6 +29,6 @@ public class PostLikeController implements PostLikeControllerSwagger {
             @PathVariable(name = "postId") final Long postId
     ) {
         postLikeService.deletePostLike(MEMBER_ID, postId);
-        return SuccessResponse.success(SuccessMessage.NO_CONTENT, null);
+        return SuccessResponse.success(SuccessMessage.OK, null);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeControllerSwagger.java
@@ -1,0 +1,35 @@
+package com.cocos.cocos.api.post.controller;
+
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "PostLike Controller", description = "게시글 공감 관련 API")
+public interface PostLikeControllerSwagger {
+
+    @Operation(summary = "게시글 공감 추가 API", description = "게시글 공감을 추가하는 API입니다.")
+    @ApiResponse(
+            responseCode = "204",
+            description = "게시글 공감 추가 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = BaseResponse.class)))
+    @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    public ResponseEntity<BaseResponse<Void>> addPostLike(
+            final Long postId
+    );
+
+    @Operation(summary = "게시글 공감 삭제 API", description = "게시글 공감을 삭제하는 API입니다.")
+    @ApiResponse(
+            responseCode = "204",
+            description = "게시글 공감 삭제 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = BaseResponse.class)))
+    @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    public ResponseEntity<BaseResponse<Void>> deletePostLike(
+            final Long postId
+    );
+}

--- a/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
@@ -1,0 +1,29 @@
+package com.cocos.cocos.api.post.service;
+
+import com.cocos.cocos.db.post.entity.PostLike;
+import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public void addPostLike(final Long memberId, final Long postId) {
+        postLikeRepository.save(
+                PostLike.builder()
+                        .memberId(memberId)
+                        .postId(postId)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void deletePostLike(final Long memberId, final Long postId) {
+        postLikeRepository.deleteByMemberIdAndPostId(memberId, postId);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
@@ -1,7 +1,9 @@
 package com.cocos.cocos.api.post.service;
 
+import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.post.entity.PostLike;
 import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.enums.message.FailMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,9 @@ public class PostLikeService {
 
     @Transactional
     public void addPostLike(final Long memberId, final Long postId) {
+        if (postLikeRepository.existsByMemberIdAndPostId(memberId, postId)) {
+            throw new CocosException(FailMessage.CONFLICT_POSTLIKE);
+        }
         postLikeRepository.save(
                 PostLike.builder()
                         .memberId(memberId)
@@ -24,6 +29,9 @@ public class PostLikeService {
 
     @Transactional
     public void deletePostLike(final Long memberId, final Long postId) {
+        if (!postLikeRepository.existsByMemberIdAndPostId(memberId, postId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_POSTLIKE);
+        }
         postLikeRepository.deleteByMemberIdAndPostId(memberId, postId);
     }
 }

--- a/src/main/java/com/cocos/cocos/common/response/SuccessResponse.java
+++ b/src/main/java/com/cocos/cocos/common/response/SuccessResponse.java
@@ -5,13 +5,13 @@ import org.springframework.http.ResponseEntity;
 
 public class SuccessResponse {
 
-    public static <T> ResponseEntity<BaseResponse<T>> success(final SuccessMessage apiMessage, final T data) {
-        return ResponseEntity.status(apiMessage.getHttpStatus())
-                .body(BaseResponse.of(apiMessage.getCode(), apiMessage.getMessage(), data));
+    public static <T> ResponseEntity<BaseResponse<T>> success(final SuccessMessage successMessage, final T data) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage.getCode(), successMessage.getMessage(), data));
     }
 
-    public static ResponseEntity<BaseResponse<?>> success(final SuccessMessage apiMessage) {
-        return ResponseEntity.status(apiMessage.getHttpStatus())
-                .body(BaseResponse.of(apiMessage.getCode(), apiMessage.getMessage()));
+    public static ResponseEntity<BaseResponse<?>> success(final SuccessMessage successMessage) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage.getCode(), successMessage.getMessage()));
     }
 }

--- a/src/main/java/com/cocos/cocos/db/post/entity/PostLike.java
+++ b/src/main/java/com/cocos/cocos/db/post/entity/PostLike.java
@@ -2,6 +2,7 @@ package com.cocos.cocos.db.post.entity;
 
 import com.cocos.cocos.db.BaseTime;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,4 +22,10 @@ public class PostLike extends BaseTime {
 
     @Column(name = "post_id", nullable = false)
     private Long postId;
+
+    @Builder
+    public PostLike(Long memberId, Long postId) {
+        this.memberId = memberId;
+        this.postId = postId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    void deleteByMemberIdAndPostId(final Long memberId, final Long postId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     void deleteByMemberIdAndPostId(final Long memberId, final Long postId);
+
+    boolean existsByMemberIdAndPostId(final Long memberId, final Long postId);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -33,6 +33,7 @@ public enum FailMessage {
     NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "리소스를 찾을 수 없습니다. "),
     NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, 40401, "대상을 찾을 수 없습니다. "),
     NOT_FOUND_API(HttpStatus.NOT_FOUND, 40402, "잘못된 API입니다. "),
+    NOT_FOUND_POSTLIKE(HttpStatus.NOT_FOUND, 40403, "게시물 공감을 찾을 수 없습니다."),
 
     /**
      * 405
@@ -44,6 +45,7 @@ public enum FailMessage {
      */
     CONFLICT(HttpStatus.CONFLICT, 40900, "데이터 충돌이 발생했습니다. "),
     INTEGRITY_CONFLICT(HttpStatus.CONFLICT, 40901, "데이터 무결성 위반입니다."),
+    CONFLICT_POSTLIKE(HttpStatus.CONFLICT, 40902, "이미 존재하는 게시글 공감입니다."),
 
     /**
      * 422

--- a/src/main/java/com/cocos/cocos/enums/message/SuccessMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/SuccessMessage.java
@@ -10,12 +10,17 @@ public enum SuccessMessage {
     /**
      * 200
      */
-    OK(HttpStatus.OK, 20000, "요청에 성공했습니다. "),
+    OK(HttpStatus.OK, 20000, "요청에 성공했습니다."),
 
     /**
      * 201
      */
-    CREATED(HttpStatus.CREATED, 20100, "요청에 성공했습니다 .");
+    CREATED(HttpStatus.CREATED, 20100, "요청에 성공했습니다."),
+
+    /**
+     * 204
+     */
+    NO_CONTENT(HttpStatus.NO_CONTENT, 20400, "요청에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/test/java/com/cocos/cocos/post/PostLikeTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostLikeTest.java
@@ -1,0 +1,59 @@
+package com.cocos.cocos.post;
+
+import com.cocos.cocos.api.post.service.PostLikeService;
+import com.cocos.cocos.db.post.entity.PostLike;
+import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("게시글 공감 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PostLikeTest {
+
+    @InjectMocks
+    PostLikeService postLikeService;
+
+    @Mock
+    PostLikeRepository postLikeRepository;
+
+    @Test
+    @DisplayName("게시글에 공감을 추가할 수 있다.")
+    void addPostLike() {
+        //given
+        final Long memberId = 1L;
+        final Long postId = 1L;
+
+        //when
+        postLikeService.addPostLike(memberId, postId);
+
+        //then
+        BDDMockito.verify(postLikeRepository).save(any(PostLike.class));
+    }
+
+    @Test
+    @DisplayName("게시글에 공감을 삭제할 수 있다.")
+    void deletePostLike() {
+        // given
+        final Long memberId = 1L;
+        final Long postId = 1L;
+
+        // when
+        postLikeService.deletePostLike(memberId, postId);
+
+        // then
+        BDDMockito.verify(postLikeRepository, times(1)).deleteByMemberIdAndPostId(memberId, postId);
+    }
+
+
+}

--- a/src/test/java/com/cocos/cocos/post/PostLikeTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostLikeTest.java
@@ -1,8 +1,11 @@
 package com.cocos.cocos.post;
 
 import com.cocos.cocos.api.post.service.PostLikeService;
+import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.post.entity.PostLike;
 import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -33,12 +36,13 @@ public class PostLikeTest {
         //given
         final Long memberId = 1L;
         final Long postId = 1L;
+        BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(false);
 
         //when
         postLikeService.addPostLike(memberId, postId);
 
         //then
-        BDDMockito.verify(postLikeRepository).save(any(PostLike.class));
+        BDDMockito.verify(postLikeRepository, times(1)).save(any(PostLike.class));
     }
 
     @Test
@@ -47,6 +51,7 @@ public class PostLikeTest {
         // given
         final Long memberId = 1L;
         final Long postId = 1L;
+        BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(true);
 
         // when
         postLikeService.deletePostLike(memberId, postId);
@@ -55,5 +60,32 @@ public class PostLikeTest {
         BDDMockito.verify(postLikeRepository, times(1)).deleteByMemberIdAndPostId(memberId, postId);
     }
 
+    @Test
+    @DisplayName("공감 추가 시 해당하는 공감이 있는 경우 예외가 발생한다.")
+    void foundPostLikWhenAdd() throws Exception {
+        // given
+        final Long memberId = 1L;
+        final Long postId = 1L;
+        BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(true);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> postLikeService.addPostLike(memberId, postId))
+                .isInstanceOf(CocosException.class)
+                .hasMessageContaining(FailMessage.CONFLICT_POSTLIKE.getMessage());
+    }
+
+    @Test
+    @DisplayName("공감 삭제 시 해당하는 공감이 없는 경우 예외가 발생한다.")
+    void notFoundPostLikWhenDelete() throws Exception {
+        // given
+        final Long memberId = 1L;
+        final Long postId = 1L;
+        BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(false);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> postLikeService.deletePostLike(memberId, postId))
+                .isInstanceOf(CocosException.class)
+                .hasMessageContaining(FailMessage.NOT_FOUND_POSTLIKE.getMessage());
+    }
 
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolves: #17 
- Resolves: #18 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 게시글 공감 추가 API를 구현했습니다.
* 게시글 공감 삭제 API를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* apiMessage 변수명을 SuccessMessage 변수명으로 변경했습니다.
https://github.com/SOPT-all/35-APPJAM-SERVER-COCOS/blob/8ecd86a77fcf709e56c7789a4992fe7e5d6e9664/src/main/java/com/cocos/cocos/common/response/SuccessResponse.java#L8

* 제네릭 타입의 소거를 방지하고 강력한 컴파일 단계에서의 타입 정의를 위해 Void를 선언했습니다.
https://github.com/SOPT-all/35-APPJAM-SERVER-COCOS/blob/8ecd86a77fcf709e56c7789a4992fe7e5d6e9664/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java#L20

ref)
https://jyami.tistory.com/99