### PR TITLE
Feat: 품종 조회, 신체 부위 조회, 질병 조회, 증상 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.api.body.controller;
+
+import com.cocos.cocos.api.body.dto.response.BodiesResponse;
+import com.cocos.cocos.api.body.service.BodyService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${api.prefix}/bodies")
+@RequiredArgsConstructor
+public class BodyController implements BodyControllerSwagger {
+
+    private final BodyService bodyService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies() {
+        return SuccessResponse.success(SuccessMessage.OK, bodyService.getBodies());
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.api.body.controller;
+
+import com.cocos.cocos.api.body.dto.response.BodiesResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Body Controller", description = "신체 부위 관련 API")
+public interface BodyControllerSwagger {
+
+    @Operation(summary = "신체 부위 조회 API", description = "신체 부위를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "신체 부위 조회 성공")
+    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies();
+}

--- a/src/main/java/com/cocos/cocos/api/body/dto/response/BodiesResponse.java
+++ b/src/main/java/com/cocos/cocos/api/body/dto/response/BodiesResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.body.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record BodiesResponse(
+        @Schema(description = "신체 부위 리스트")
+        List<BodyResponse> bodies
+) {
+    public static BodiesResponse of(final List<BodyResponse> bodies) {
+        return new BodiesResponse(bodies);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/body/dto/response/BodyResponse.java
+++ b/src/main/java/com/cocos/cocos/api/body/dto/response/BodyResponse.java
@@ -1,0 +1,16 @@
+package com.cocos.cocos.api.body.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BodyResponse(
+        @Schema(description = "신체 부위 아이디", example = "1")
+        Long id,
+        @Schema(description = "신체 부위 이름", example = "손")
+        String name,
+        @Schema(description = "신체 부위 이미지", example = "http://~")
+        String image
+) {
+    public static BodyResponse of(final Long id, final String name, final String image) {
+        return new BodyResponse(id, name, image);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
+++ b/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.api.body.service;
+
+import com.cocos.cocos.api.body.dto.response.BodiesResponse;
+import com.cocos.cocos.api.body.dto.response.BodyResponse;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.external.AppDataS3Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BodyService {
+
+    private final BodyRepository bodyRepository;
+    private final AppDataS3Client appDataS3Client;
+
+    @Transactional(readOnly = true)
+    public BodiesResponse getBodies() {
+        final List<Body> bodies = bodyRepository.findAll();
+        return BodiesResponse.of(
+                bodies.stream()
+                        .map(body -> BodyResponse.of(body.getId(), body.getName(), appDataS3Client.getPresignedUrl(body.getImage())))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/breed/controller/BreedController.java
+++ b/src/main/java/com/cocos/cocos/api/breed/controller/BreedController.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.api.breed.controller;
+
+import com.cocos.cocos.api.breed.dto.response.BreedsResponse;
+import com.cocos.cocos.api.breed.service.BreedService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("${api.prefix}/breeds")
+@RequiredArgsConstructor
+public class BreedController implements BreedControllerSwagger {
+
+    private final BreedService breedService;
+
+    @GetMapping("/{animalId}")
+    public ResponseEntity<BaseResponse<BreedsResponse>> getBreeds(
+            @RequestParam(name = "breedName") final String breedName,
+            @PathVariable(name = "animalId") final Long animalId
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, breedService.getBreeds(breedName, animalId));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/breed/controller/BreedControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/breed/controller/BreedControllerSwagger.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.api.breed.controller;
+
+import com.cocos.cocos.api.breed.dto.response.BreedsResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Breed Controller", description = "품종 관련 API")
+public interface BreedControllerSwagger {
+
+    @Operation(summary = "품종 리스트 조회 API", description = "품종 리스트를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "품종 리스트 조회 성공")
+    @Parameter(name = "breedName", description = "품종 이름", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+    @Parameter(name = "animalId", description = "동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    public ResponseEntity<BaseResponse<BreedsResponse>> getBreeds(
+            final String breedName,
+            final Long animalId
+    );
+}

--- a/src/main/java/com/cocos/cocos/api/breed/dto/response/BreedResponse.java
+++ b/src/main/java/com/cocos/cocos/api/breed/dto/response/BreedResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.breed.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BreedResponse(
+        @Schema(description = "품종 아이디", example = "1")
+        Long id,
+        @Schema(description = "품종 이름", example = "포메라니안")
+        String name
+) {
+    public static BreedResponse of(final Long id, final String name) {
+        return new BreedResponse(id, name);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/breed/dto/response/BreedsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/breed/dto/response/BreedsResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.breed.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record BreedsResponse(
+        @Schema(description = "품종 리스트")
+        List<BreedResponse> breeds
+) {
+    public static BreedsResponse of(final List<BreedResponse> breeds) {
+        return new BreedsResponse(breeds);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
+++ b/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.api.breed.service;
+
+import com.cocos.cocos.api.breed.dto.response.BreedResponse;
+import com.cocos.cocos.api.breed.dto.response.BreedsResponse;
+import com.cocos.cocos.db.breed.entity.Breed;
+import com.cocos.cocos.db.breed.repository.BreedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BreedService {
+
+    private final BreedRepository breedRepository;
+
+    @Transactional(readOnly = true)
+    public BreedsResponse getBreeds(final String breedName, final Long animalId) {
+        final List<Breed> breeds = breedRepository.findAllByNameContainingAndAnimalId(breedName, animalId);
+        return BreedsResponse.of(breeds.stream()
+                .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.api.disease.controller;
+
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodiesResponse;
+import com.cocos.cocos.api.disease.service.DiseaseService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api.prefix}/diseases")
+@RequiredArgsConstructor
+public class DiseaseController implements DiseaseControllerSwagger{
+
+    private final DiseaseService diseaseService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(
+            @RequestParam(name = "bodyIds") final List<Long> bodyIds
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, diseaseService.getDiseases(bodyIds));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.api.disease.controller;
+
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodiesResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Disease Controller", description = "질병 관련 API")
+public interface DiseaseControllerSwagger {
+
+    @Operation(summary = "질병 리스트 조회 API", description = "질병 리스트를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "질병 리스트 조회 성공")
+    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
+    public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(final List<Long> bodyIds);
+}

--- a/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseaseResponse.java
+++ b/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseaseResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.disease.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DiseaseResponse(
+        @Schema(description = "질병 아이디", example = "1")
+        Long id,
+        @Schema(description = "질병 이름", example = "심장병")
+        String name
+) {
+    public static DiseaseResponse of(final Long id, final String name) {
+        return new DiseaseResponse(id, name);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseasesOfBodiesResponse.java
+++ b/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseasesOfBodiesResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.disease.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record DiseasesOfBodiesResponse(
+        @Schema(description = "신체 부위 당 질병 리스트")
+        List<DiseasesOfBodyResponse> bodies
+) {
+    public static DiseasesOfBodiesResponse of(final List<DiseasesOfBodyResponse> bodies) {
+        return new DiseasesOfBodiesResponse(bodies);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseasesOfBodyResponse.java
+++ b/src/main/java/com/cocos/cocos/api/disease/dto/response/DiseasesOfBodyResponse.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.api.disease.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record DiseasesOfBodyResponse(
+        @Schema(description = "신체 부위 아이디", example = "1")
+        Long id,
+        @Schema(description = "신체 부위 이름", example = "심장")
+        String name,
+        @Schema(description = "질병 리스트")
+        List<DiseaseResponse> diseases
+) {
+    public static DiseasesOfBodyResponse of(final Long id, final String name, final List<DiseaseResponse> diseases) {
+        return new DiseasesOfBodyResponse(id, name, diseases);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/disease/service/DiseaseService.java
+++ b/src/main/java/com/cocos/cocos/api/disease/service/DiseaseService.java
@@ -1,0 +1,43 @@
+package com.cocos.cocos.api.disease.service;
+
+import com.cocos.cocos.api.disease.dto.response.DiseaseResponse;
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodiesResponse;
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodyResponse;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.disease.entity.Disease;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DiseaseService {
+
+    private final DiseaseRepository diseaseRepository;
+    private final BodyRepository bodyRepository;
+
+    @Transactional(readOnly = true)
+    public DiseasesOfBodiesResponse getDiseases(final List<Long> bodyIds) {
+        return DiseasesOfBodiesResponse.of(
+                bodyIds.stream()
+                        .map(bodyId -> {
+                            final Body body = bodyRepository.findById(bodyId).orElseThrow(
+                                    () -> new CocosException(FailMessage.NOT_FOUND_BODY)
+                            );
+                            final List<Disease> diseases = diseaseRepository.findAllByBodyId(bodyId);
+                            return DiseasesOfBodyResponse.of(bodyId, body.getName(),
+                                    diseases.stream()
+                                            .map(disease -> DiseaseResponse.of(disease.getId(), disease.getName()))
+                                            .toList()
+                            );
+                        })
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.api.symptom.controller;
+
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodiesResponse;
+import com.cocos.cocos.api.symptom.service.SymptomService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api.prefix}/symptoms")
+@RequiredArgsConstructor
+public class SymptomController implements SymptomControllerSwagger {
+
+    private final SymptomService symptomService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(
+            @RequestParam(name = "bodyIds") final List<Long> bodyIds
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, symptomService.getSymptoms(bodyIds));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.api.symptom.controller;
+
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodiesResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Symptom Controller", description = "증상 관련 API")
+public interface SymptomControllerSwagger {
+
+    @Operation(summary = "증상 리스트 조회 API", description = "증상 리스트를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "증상 리스트 조회 성공")
+    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
+    public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(final List<Long> bodyIds);
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomResponse.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.symptom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SymptomResponse(
+        @Schema(description = "증상 아이디", example = "1")
+        Long id,
+        @Schema(description = "증상 이름", example = "머리가 아픔")
+        String name
+) {
+    public static SymptomResponse of(final Long id, final String name) {
+        return new SymptomResponse(id, name);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomsOfBodiesResponse.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomsOfBodiesResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.symptom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SymptomsOfBodiesResponse(
+        @Schema(description = "신체 부위 당 증상 리스트")
+        List<SymptomsOfBodyResponse> bodies
+) {
+    public static SymptomsOfBodiesResponse of(final List<SymptomsOfBodyResponse> bodies) {
+        return new SymptomsOfBodiesResponse(bodies);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomsOfBodyResponse.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/dto/response/SymptomsOfBodyResponse.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.api.symptom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SymptomsOfBodyResponse(
+        @Schema(description = "신체 부위 아이디", example = "1")
+        Long id,
+        @Schema(description = "신체 부위 이름", example = "머리")
+        String name,
+        @Schema(description = "증상 리스트")
+        List<SymptomResponse> symptoms
+) {
+    public static SymptomsOfBodyResponse of(final Long id, final String name, final List<SymptomResponse> symptoms) {
+        return new SymptomsOfBodyResponse(id, name, symptoms);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/symptom/service/SymptomService.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/service/SymptomService.java
@@ -1,0 +1,43 @@
+package com.cocos.cocos.api.symptom.service;
+
+import com.cocos.cocos.api.symptom.dto.response.SymptomResponse;
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodiesResponse;
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodyResponse;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.symptom.entity.Symptom;
+import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SymptomService {
+
+    private final SymptomRepository symptomRepository;
+    private final BodyRepository bodyRepository;
+
+    @Transactional(readOnly = true)
+    public SymptomsOfBodiesResponse getSymptoms(final List<Long> bodyIds) {
+        return SymptomsOfBodiesResponse.of(
+                bodyIds.stream()
+                        .map(bodyId -> {
+                            final Body body = bodyRepository.findById(bodyId).orElseThrow(
+                                    () -> new CocosException(FailMessage.NOT_FOUND_BODY)
+                            );
+                            final List<Symptom> symptoms = symptomRepository.findAllByBodyId(bodyId);
+                            return SymptomsOfBodyResponse.of(bodyId, body.getName(),
+                                    symptoms.stream()
+                                            .map(symptom -> SymptomResponse.of(symptom.getId(), symptom.getName()))
+                                            .toList()
+                            );
+                        })
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/body/entity/Body.java
+++ b/src/main/java/com/cocos/cocos/db/body/entity/Body.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.body.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class Body {
 
     @Column(name = "image", nullable = false)
     private String image;
+
+    @Builder
+    public Body(String name, String image) {
+        this.name = name;
+        this.image = image;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/breed/entity/Breed.java
+++ b/src/main/java/com/cocos/cocos/db/breed/entity/Breed.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.breed.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class Breed {
 
     @Column(name = "animal_id", nullable = false)
     private Long animalId;
+
+    @Builder
+    public Breed(String name, Long animalId) {
+        this.name = name;
+        this.animalId = animalId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/breed/repository/BreedRepository.java
+++ b/src/main/java/com/cocos/cocos/db/breed/repository/BreedRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.breed.entity.Breed;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface BreedRepository extends JpaRepository<Breed, Long> {
+
+    List<Breed> findAllByNameContainingAndAnimalId(final String Name, final Long animalId);
 }

--- a/src/main/java/com/cocos/cocos/db/disease/entity/Disease.java
+++ b/src/main/java/com/cocos/cocos/db/disease/entity/Disease.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.disease.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,11 @@ public class Disease {
 
     @Column(name = "body_id", nullable = false)
     private Long bodyId;
+
+    @Builder
+
+    public Disease(String name, Long bodyId) {
+        this.name = name;
+        this.bodyId = bodyId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/disease/repository/DiseaseRepository.java
+++ b/src/main/java/com/cocos/cocos/db/disease/repository/DiseaseRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.disease.entity.Disease;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DiseaseRepository extends JpaRepository<Disease, Long> {
+
+    List<Disease> findAllByBodyId(final Long bodyId);
 }

--- a/src/main/java/com/cocos/cocos/db/symptom/entity/Symptom.java
+++ b/src/main/java/com/cocos/cocos/db/symptom/entity/Symptom.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.symptom.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class Symptom {
 
     @Column(name = "body_id", nullable = false)
     private Long bodyId;
+
+    @Builder
+    public Symptom(String name, Long bodyId) {
+        this.name = name;
+        this.bodyId = bodyId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.symptom.entity.Symptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SymptomRepository extends JpaRepository<Symptom, Long> {
+
+    List<Symptom> findAllByBodyId(final Long BodyId);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -34,6 +34,7 @@ public enum FailMessage {
     NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, 40401, "대상을 찾을 수 없습니다. "),
     NOT_FOUND_API(HttpStatus.NOT_FOUND, 40402, "잘못된 API입니다. "),
     NOT_FOUND_POSTLIKE(HttpStatus.NOT_FOUND, 40403, "게시물 공감을 찾을 수 없습니다."),
+    NOT_FOUND_BODY(HttpStatus.NOT_FOUND, 40404, "신체 부위를 찾을 수 없습니다."),
 
     /**
      * 405

--- a/src/test/java/com/cocos/cocos/animal/AnimalServiceTest.java
+++ b/src/test/java/com/cocos/cocos/animal/AnimalServiceTest.java
@@ -1,0 +1,66 @@
+package com.cocos.cocos.animal;
+
+import com.cocos.cocos.api.animal.dto.response.AnimalResponse;
+import com.cocos.cocos.api.animal.dto.response.AnimalsResponse;
+import com.cocos.cocos.api.animal.service.AnimalService;
+import com.cocos.cocos.db.animal.entity.Animal;
+import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.external.AppDataS3Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("동물 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class AnimalServiceTest {
+
+    @InjectMocks
+    private AnimalService animalService;
+
+    @Mock
+    private AnimalRepository animalRepository;
+
+    @Mock
+    private AppDataS3Client appDataS3Client;
+
+    @Test
+    @DisplayName("동물 리스트를 조회할 수 있다.")
+    void addPostLike() {
+        //given
+        final Animal animal1 = Animal.builder()
+                .name("이름1")
+                .image("image1")
+                .build();
+        final Animal animal2 = Animal.builder()
+                .name("이름2")
+                .image("image2")
+                .build();
+        final List<Animal> animals = new ArrayList<Animal>(List.of(animal1, animal2));
+        final AnimalsResponse expected = AnimalsResponse.of(
+                animals.stream()
+                        .map(animal -> AnimalResponse.of(animal.getId(), animal.getName(), "image"))
+                        .toList()
+        );
+        BDDMockito.given(animalRepository.findAll()).willReturn(animals);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(any())).willReturn("image");
+
+        //when
+        final AnimalsResponse actual = animalService.getAnimals();
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
+++ b/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
@@ -1,10 +1,10 @@
-package com.cocos.cocos.animal;
+package com.cocos.cocos.body;
 
-import com.cocos.cocos.api.animal.dto.response.AnimalResponse;
-import com.cocos.cocos.api.animal.dto.response.AnimalsResponse;
-import com.cocos.cocos.api.animal.service.AnimalService;
-import com.cocos.cocos.db.animal.entity.Animal;
-import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.api.body.dto.response.BodiesResponse;
+import com.cocos.cocos.api.body.dto.response.BodyResponse;
+import com.cocos.cocos.api.body.service.BodyService;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
 import com.cocos.cocos.external.AppDataS3Client;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -23,42 +23,42 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("동물 테스트")
+@DisplayName("신체 부위 서비스 테스트")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class AnimalTest {
+public class BodyServiceTest {
 
     @InjectMocks
-    private AnimalService animalService;
+    private BodyService bodyService;
 
     @Mock
-    private AnimalRepository animalRepository;
+    private BodyRepository bodyRepository;
 
     @Mock
     private AppDataS3Client appDataS3Client;
 
     @Test
-    @DisplayName("동물을 조회할 수 있다.")
-    void addPostLike() {
+    @DisplayName("신체 부위 리스트를 조회할 수 있다.")
+    void getBodies() {
         //given
-        final Animal animal1 = Animal.builder()
+        final Body body1 = Body.builder()
                 .name("이름1")
-                .image("image1")
+                .image("이미지1")
                 .build();
-        final Animal animal2 = Animal.builder()
+        final Body body2 = Body.builder()
                 .name("이름2")
-                .image("image2")
+                .image("이미지2")
                 .build();
-        final List<Animal> animals = new ArrayList<Animal>(List.of(animal1, animal2));
-        final AnimalsResponse expected = AnimalsResponse.of(
-                animals.stream()
-                        .map(animal -> AnimalResponse.of(animal.getId(), animal.getName(), "image"))
+        final List<Body> bodies = new ArrayList<Body>(List.of(body1, body2));
+        final BodiesResponse expected = BodiesResponse.of(
+                bodies.stream()
+                        .map(body -> BodyResponse.of(body.getId(), body.getName(), "image"))
                         .toList()
         );
-        BDDMockito.given(animalRepository.findAll()).willReturn(animals);
+        BDDMockito.given(bodyRepository.findAll()).willReturn(bodies);
         BDDMockito.given(appDataS3Client.getPresignedUrl(any())).willReturn("image");
 
         //when
-        final AnimalsResponse actual = animalService.getAnimals();
+        final BodiesResponse actual = bodyService.getBodies();
 
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);

--- a/src/test/java/com/cocos/cocos/breed/BreedRepositoryTest.java
+++ b/src/test/java/com/cocos/cocos/breed/BreedRepositoryTest.java
@@ -1,0 +1,88 @@
+package com.cocos.cocos.breed;
+
+import com.cocos.cocos.db.breed.entity.Breed;
+import com.cocos.cocos.db.breed.repository.BreedRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("품종 레포지토리 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BreedRepositoryTest {
+
+    @Autowired
+    private BreedRepository breedRepository;
+
+    @BeforeEach
+    void setUp() {
+        breedRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("이름이 포함된 품종 리스트를 가져올 수 있다.")
+    void getBreedsContainingName() {
+        //given
+        final Breed breed1 = Breed.builder()
+                .name("포")
+                .animalId(1L)
+                .build();
+        final Breed breed2 = Breed.builder()
+                .name("포메")
+                .animalId(1L)
+                .build();
+        final Breed breed3 = Breed.builder()
+                .name("포메라")
+                .animalId(1L)
+                .build();
+        final Breed breed4 = Breed.builder()
+                .name("포메라니")
+                .animalId(1L)
+                .build();
+        final Breed breed5 = Breed.builder()
+                .name("포메라니안")
+                .animalId(1L)
+                .build();
+        final Breed breed6 = Breed.builder()
+                .name("나는 고양이")
+                .animalId(2L)
+                .build();
+        breedRepository.save(breed1);
+        breedRepository.save(breed2);
+        breedRepository.save(breed3);
+        breedRepository.save(breed4);
+        breedRepository.save(breed5);
+        breedRepository.save(breed6);
+
+
+        final String BREED_NAME1 = "라니";
+        final String BREED_NAME2 = "라";
+        final List<Breed> expected1 = new ArrayList<>(List.of(breed4, breed5));
+        final List<Breed> expected2 = new ArrayList<>(List.of(breed3, breed4, breed5));
+
+        //when
+        final List<Breed> actual1 = breedRepository.findAllByNameContainingAndAnimalId(BREED_NAME1, 1L);
+        final List<Breed> actual2 = breedRepository.findAllByNameContainingAndAnimalId(BREED_NAME2, 1L);
+
+        //then
+        Assertions.assertThat(actual1)
+                .extracting(Breed::getName)
+                .isEqualTo(expected1.stream()
+                        .map(Breed::getName)
+                        .toList());
+
+        Assertions.assertThat(actual2)
+                .extracting(Breed::getName)
+                .isEqualTo(expected2.stream()
+                        .map(Breed::getName)
+                        .toList());
+
+    }
+
+}

--- a/src/test/java/com/cocos/cocos/breed/BreedServiceTest.java
+++ b/src/test/java/com/cocos/cocos/breed/BreedServiceTest.java
@@ -1,0 +1,70 @@
+package com.cocos.cocos.breed;
+
+import com.cocos.cocos.api.breed.dto.response.BreedResponse;
+import com.cocos.cocos.api.breed.dto.response.BreedsResponse;
+import com.cocos.cocos.api.breed.service.BreedService;
+import com.cocos.cocos.db.breed.entity.Breed;
+import com.cocos.cocos.db.breed.repository.BreedRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("품종 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BreedServiceTest {
+
+    @InjectMocks
+    private BreedService breedService;
+
+    @Mock
+    private BreedRepository breedRepository;
+
+    @Test
+    @DisplayName("품종 리스트를 조회할 수 있다.")
+    void getBodies() {
+        //given
+        final String breedName = "라";
+        final Long animalId = 1L;
+        final Breed breed1 = Breed.builder()
+                .name("포메라")
+                .animalId(1L)
+                .build();
+        final Breed breed2 = Breed.builder()
+                .name("포메라니")
+                .animalId(1L)
+                .build();
+        final Breed breed3 = Breed.builder()
+                .name("포메라니안")
+                .animalId(1L)
+                .build();
+
+        final List<Breed> breeds = new ArrayList<>(List.of(breed1, breed2, breed3));
+        BDDMockito.given(breedRepository.findAllByNameContainingAndAnimalId(any(), any())).willReturn(breeds);
+
+        final BreedsResponse expected = BreedsResponse.of(
+                breeds.stream()
+                        .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
+                        .toList()
+        );
+
+        //when
+        final BreedsResponse actual = breedService.getBreeds(breedName, animalId);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/cocos/cocos/diseases/DiseaseServiceTest.java
+++ b/src/test/java/com/cocos/cocos/diseases/DiseaseServiceTest.java
@@ -1,0 +1,96 @@
+package com.cocos.cocos.diseases;
+
+import com.cocos.cocos.api.disease.dto.response.DiseaseResponse;
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodiesResponse;
+import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodyResponse;
+import com.cocos.cocos.api.disease.service.DiseaseService;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.disease.entity.Disease;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("질병 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class DiseaseServiceTest {
+
+    @InjectMocks
+    private DiseaseService diseaseService;
+
+    @Mock
+    private DiseaseRepository diseaseRepository;
+
+    @Mock
+    private BodyRepository bodyRepository;
+
+    @Test
+    @DisplayName("신체 부위 아이디에 해당하는 질병 리스트를 조회할 수 있다.")
+    void getDiseases() {
+        //given
+        final Body body1 = Body.builder()
+                .name("신체1")
+                .image("이미지1")
+                .build();
+        final Body body2 = Body.builder()
+                .name("신체1")
+                .image("이미지1")
+                .build();
+        final List<Long> bodyIds = new ArrayList<>(List.of(1L, 2L));
+
+        final Disease disease1 = Disease.builder()
+                .name("질병1")
+                .bodyId(1L)
+                .build();
+        final Disease disease2 = Disease.builder()
+                .name("질병2")
+                .bodyId(2L)
+                .build();
+        final List<Disease> diseases1 = new ArrayList<>(List.of(disease1));
+        final List<Disease> diseases2 = new ArrayList<>(List.of(disease2));
+
+        BDDMockito.given(bodyRepository.findById(1L)).willReturn(Optional.ofNullable(body1));
+        BDDMockito.given(bodyRepository.findById(2L)).willReturn(Optional.ofNullable(body2));
+        BDDMockito.given(diseaseRepository.findAllByBodyId(1L)).willReturn(diseases1);
+        BDDMockito.given(diseaseRepository.findAllByBodyId(2L)).willReturn(diseases2);
+
+        final DiseasesOfBodiesResponse expected = DiseasesOfBodiesResponse.of(
+                bodyIds.stream()
+                        .map(bodyId -> {
+                            if (bodyId == 1L) {
+                                return DiseasesOfBodyResponse.of(bodyId, body1.getName(),
+                                        diseases1.stream()
+                                                .map(disease -> DiseaseResponse.of(disease.getId(), disease.getName()))
+                                                .toList()
+                                );
+                            } else {
+                                return DiseasesOfBodyResponse.of(bodyId, body2.getName(),
+                                        diseases2.stream()
+                                                .map(disease -> DiseaseResponse.of(disease.getId(), disease.getName()))
+                                                .toList()
+                                );
+                            }
+                        })
+                        .toList()
+        );
+
+        //when
+        final DiseasesOfBodiesResponse actual = diseaseService.getDiseases(bodyIds);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
@@ -20,9 +20,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("게시글 공감 테스트")
+@DisplayName("게시글 공감 서비스 테스트")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class PostLikeTest {
+public class PostLikeServiceTest {
 
     @InjectMocks
     PostLikeService postLikeService;

--- a/src/test/java/com/cocos/cocos/symptom/SymptomServiceTest.java
+++ b/src/test/java/com/cocos/cocos/symptom/SymptomServiceTest.java
@@ -1,0 +1,96 @@
+package com.cocos.cocos.symptom;
+
+import com.cocos.cocos.api.symptom.dto.response.SymptomResponse;
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodiesResponse;
+import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodyResponse;
+import com.cocos.cocos.api.symptom.service.SymptomService;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.symptom.entity.Symptom;
+import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("증상 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class SymptomServiceTest {
+
+    @InjectMocks
+    private SymptomService symptomService;
+
+    @Mock
+    private SymptomRepository symptomRepository;
+
+    @Mock
+    private BodyRepository bodyRepository;
+
+    @Test
+    @DisplayName("신체 부위 아이디에 해당하는 증상 리스트를 조회할 수 있다.")
+    void getDiseases() {
+        //given
+        final Body body1 = Body.builder()
+                .name("신체1")
+                .image("이미지1")
+                .build();
+        final Body body2 = Body.builder()
+                .name("신체1")
+                .image("이미지1")
+                .build();
+        final List<Long> bodyIds = new ArrayList<>(List.of(1L, 2L));
+
+        final Symptom symptom1 = Symptom.builder()
+                .name("증상1")
+                .bodyId(1L)
+                .build();
+        final Symptom symptom2 = Symptom.builder()
+                .name("증상2")
+                .bodyId(2L)
+                .build();
+        final List<Symptom> symptoms1 = new ArrayList<>(List.of(symptom1));
+        final List<Symptom> sypmtoms2 = new ArrayList<>(List.of(symptom2));
+
+        BDDMockito.given(bodyRepository.findById(1L)).willReturn(Optional.ofNullable(body1));
+        BDDMockito.given(bodyRepository.findById(2L)).willReturn(Optional.ofNullable(body2));
+        BDDMockito.given(symptomRepository.findAllByBodyId(1L)).willReturn(symptoms1);
+        BDDMockito.given(symptomRepository.findAllByBodyId(2L)).willReturn(sypmtoms2);
+
+        final SymptomsOfBodiesResponse expected = SymptomsOfBodiesResponse.of(
+                bodyIds.stream()
+                        .map(bodyId -> {
+                            if (bodyId == 1L) {
+                                return SymptomsOfBodyResponse.of(bodyId, body1.getName(),
+                                        symptoms1.stream()
+                                                .map(symptom -> SymptomResponse.of(symptom.getId(), symptom.getName()))
+                                                .toList()
+                                );
+                            } else {
+                                return SymptomsOfBodyResponse.of(bodyId, body2.getName(),
+                                        sypmtoms2.stream()
+                                                .map(symptom -> SymptomResponse.of(symptom.getId(), symptom.getName()))
+                                                .toList()
+                                );
+                            }
+                        })
+                        .toList()
+        );
+
+        //when
+        final SymptomsOfBodiesResponse actual = symptomService.getSymptoms(bodyIds);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #23 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 품종 조회 API를 구현했습니다.
* 신체 부위 조회 API를 구현했습니다.
* 질병 조회 API를 구현했습니다.
* 증상 조회 API를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 질병 조회, 증상 조회 API 명세서가 처음에는 RequestBody를 통해 정보를 받는 것으로 되어있었는데, Get메소드인 것을 확인하고 QueryParameter로 받을 수 있도록 설계했습니다.
* 품종을 조회하는 API에서 Containing 키워드를 이용하여 '%keyword%'를 사용하여 해당 단어가 포함되고, 해당 동물 아이디에 해당하는 Entity를 모두 들고 오도록 설정했습니다.
https://github.com/SOPT-all/35-APPJAM-SERVER-COCOS/blob/a75c5020dded9d780d33741a04c19e8c237e15cf/src/main/java/com/cocos/cocos/db/breed/repository/BreedRepository.java#L12
* [ ] 동물아이디에 해당하는 동물이 없을 경우 예외처리를 해야할 거 같습니다.
