### PR TITLE
Feat: 인기글 조회, 게시글 작성 API 구현 

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -1,7 +1,9 @@
 package com.cocos.cocos.api.post.controller;
 
+import com.cocos.cocos.api.post.dto.request.PostRequest;
 import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
 import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
 import com.cocos.cocos.api.post.service.PostService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class PostController implements PostControllerSwagger {
 
+    private static final Long MEMBER_ID = 1L;
     private final PostService postService;
 
     @GetMapping("/{postId}")
@@ -35,5 +38,16 @@ public class PostController implements PostControllerSwagger {
     @GetMapping("/categories")
     public ResponseEntity<BaseResponse<PostCategoriesResponse>> getPostCategories() {
         return SuccessResponse.success(SuccessMessage.OK, postService.getCategories());
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(
+            @RequestBody final PostRequest postRequest
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, postService.addPost(
+                MEMBER_ID, postRequest.categoryId(), postRequest.title(),
+                postRequest.content(), postRequest.images(), postRequest.animalId(),
+                postRequest.symptomIds(), postRequest.diseaseIds()
+        ));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.post.controller;
 
 import com.cocos.cocos.api.post.dto.request.PostRequest;
+import com.cocos.cocos.api.post.dto.response.PopularPostsResponse;
 import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
 import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
 import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
@@ -49,5 +50,10 @@ public class PostController implements PostControllerSwagger {
                 postRequest.content(), postRequest.images(), postRequest.animalId(),
                 postRequest.symptomIds(), postRequest.diseaseIds()
         ));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<BaseResponse<PopularPostsResponse>> getPopularPosts() {
+        return SuccessResponse.success(SuccessMessage.OK, postService.getPopularPosts(MEMBER_ID));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
@@ -1,7 +1,9 @@
 package com.cocos.cocos.api.post.controller;
 
+import com.cocos.cocos.api.post.dto.request.PostRequest;
 import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
 import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,4 +35,10 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "게시글 카테고리 리스트 조회 성공")
     public ResponseEntity<BaseResponse<PostCategoriesResponse>> getPostCategories();
+
+    @Operation(summary = "게시글 추가 API", description = "게시글을 추가하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "게시글 추가 성공")
+    public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(final PostRequest postRequest);
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.post.controller;
 
 import com.cocos.cocos.api.post.dto.request.PostRequest;
+import com.cocos.cocos.api.post.dto.response.PopularPostsResponse;
 import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
 import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
 import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
@@ -41,4 +42,10 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "게시글 추가 성공")
     public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(final PostRequest postRequest);
+
+    @Operation(summary = "인기 게시글 조회 API", description = "인기 게시글을 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "인기 게시글 조회 성공")
+    public ResponseEntity<BaseResponse<PopularPostsResponse>> getPopularPosts();
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
@@ -1,0 +1,23 @@
+package com.cocos.cocos.api.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record PostRequest(
+        @Schema(description = "게시글 카테고리 아이디", example = "1")
+        Long categoryId,
+        @Schema(description = "게시글 제목", example = "제목")
+        String title,
+        @Schema(description = "게시글 내용", example = "내용")
+        String content,
+        @Schema(description = "게시글 이미지 리스트", example = "[image1.png, image2.jpg]")
+        List<String> images,
+        @Schema(description = "게시글 카테고리 아이디", example = "1")
+        Long animalId,
+        @Schema(description = "게시글 카테고리 아이디", example = "[1, 2]")
+        List<Long> symptomIds,
+        @Schema(description = "게시글 카테고리 아이디", example = "[2, 4]")
+        List<Long> diseaseIds
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostResponse.java
@@ -1,0 +1,10 @@
+package com.cocos.cocos.api.post.dto.response;
+
+public record PopularPostResponse(
+        Long id,
+        String title
+) {
+    public static PopularPostResponse of(final Long id, final String title) {
+        return new PopularPostResponse(id, title);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostResponse.java
@@ -1,7 +1,11 @@
 package com.cocos.cocos.api.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record PopularPostResponse(
+        @Schema(description = "게시글 아이디", example = "1")
         Long id,
+        @Schema(description = "게시글 제목", example = "인기 게시글")
         String title
 ) {
     public static PopularPostResponse of(final Long id, final String title) {

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostsResponse.java
@@ -1,0 +1,11 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import java.util.List;
+
+public record PopularPostsResponse(
+        List<PopularPostResponse> posts
+) {
+    public static PopularPostsResponse of(final List<PopularPostResponse> posts) {
+        return new PopularPostsResponse(posts);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PopularPostsResponse.java
@@ -1,8 +1,11 @@
 package com.cocos.cocos.api.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record PopularPostsResponse(
+        @Schema(description = "인기 게시글 리스트")
         List<PopularPostResponse> posts
 ) {
     public static PopularPostsResponse of(final List<PopularPostResponse> posts) {

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PostImagesResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PostImagesResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record PostImagesResponse(
+        @Schema(description = "게시글 이미지 presigned url", example = "[1, 2]")
+        List<String> images
+) {
+    public static PostImagesResponse of(final List<String> images) {
+        return new PostImagesResponse(images);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
@@ -1,8 +1,10 @@
 package com.cocos.cocos.api.post.service;
 
 import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostLike;
 import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
 import com.cocos.cocos.enums.message.FailMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostLikeService {
 
     private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
 
     @Transactional
     public void addPostLike(final Long memberId, final Long postId) {
@@ -25,6 +28,10 @@ public class PostLikeService {
                         .postId(postId)
                         .build()
         );
+        final Post post = postRepository.findById(postId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_POST)
+        );
+        post.addLike();
     }
 
     @Transactional
@@ -33,5 +40,9 @@ public class PostLikeService {
             throw new CocosException(FailMessage.NOT_FOUND_POSTLIKE);
         }
         postLikeRepository.deleteByMemberIdAndPostId(memberId, postId);
+        final Post post = postRepository.findById(postId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_POST)
+        );
+        post.deleteLike();
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -14,6 +14,8 @@ import com.cocos.cocos.db.disease.repository.DiseaseRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.pet.entity.Pet;
+import com.cocos.cocos.db.pet.entity.PetDisease;
+import com.cocos.cocos.db.pet.entity.PetSymptom;
 import com.cocos.cocos.db.pet.repository.PetDiseaseRepository;
 import com.cocos.cocos.db.pet.repository.PetRepository;
 import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
@@ -29,6 +31,8 @@ import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.AppDataS3Client;
 import com.cocos.cocos.external.MemberDataS3Client;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -199,9 +203,40 @@ public class PostService {
         return PostImagesResponse.of(null);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PopularPostsResponse getPopularPosts(final Long memberId) {
-        return null;
+        final List<Post> popularPosts = fetchPopularPosts(memberId);
+        return PopularPostsResponse.of(
+                popularPosts.stream()
+                        .map(popularPost -> PopularPostResponse.of(popularPost.getId(), popularPost.getTitle()))
+                        .toList()
+        );
+    }
+
+    private List<Post> fetchPopularPosts(final Long memberId) {
+        if (petRepository.existsByMemberId(memberId)) {
+            final Pet pet = petRepository.findByMemberId(memberId);
+            if (petDiseaseRepository.existsByPetId(pet.getId())) {
+                final List<Long> diseaseIds = petDiseaseRepository.findAllByPetId(pet.getId()).stream()
+                        .map(PetDisease::getDiseaseId)
+                        .toList();
+                final List<Long> postIds = postTagRepository.findAllByTagIdAndTagType(diseaseIds, TagType.DISEASE).stream()
+                        .map(PostTag::getPostId)
+                        .toList();
+                Pageable pageable = PageRequest.of(0, 5);
+                return postRepository.findTopPostsByPostIds(postIds, pageable);
+            } else if (petSymptomRepository.existsByPetId(pet.getId())) {
+                final List<Long> symptomIds = petSymptomRepository.findAllByPetId(pet.getId()).stream()
+                        .map(PetSymptom::getSymptomId)
+                        .toList();
+                final List<Long> postIds = postTagRepository.findAllByTagIdAndTagType(symptomIds, TagType.SYMPTOM).stream()
+                        .map(PostTag::getPostId)
+                        .toList();
+                Pageable pageable = PageRequest.of(0, 5);
+                return postRepository.findTopPostsByPostIds(postIds, pageable);
+            }
+        }
+        return postRepository.findTop5ByLikeCountDesc();
     }
 
 

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -1,8 +1,6 @@
 package com.cocos.cocos.api.post.service;
 
-import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
-import com.cocos.cocos.api.post.dto.response.PostCategoryResponse;
-import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.*;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.animal.entity.Animal;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
@@ -16,20 +14,26 @@ import com.cocos.cocos.db.disease.repository.DiseaseRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.pet.entity.Pet;
+import com.cocos.cocos.db.pet.repository.PetDiseaseRepository;
 import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
 import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostCategory;
+import com.cocos.cocos.db.post.entity.PostImage;
+import com.cocos.cocos.db.post.entity.PostTag;
 import com.cocos.cocos.db.post.repository.*;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.AppDataS3Client;
+import com.cocos.cocos.external.MemberDataS3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -48,7 +52,10 @@ public class PostService {
     private final AnimalRepository animalRepository;
     private final DiseaseRepository diseaseRepository;
     private final SymptomRepository symptomRepository;
+    private final PetDiseaseRepository petDiseaseRepository;
+    private final PetSymptomRepository petSymptomRepository;
     private final AppDataS3Client appDataS3Client;
+    private final MemberDataS3Client memberDataS3Client;
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostDetail(final Long postId) {
@@ -135,5 +142,67 @@ public class PostService {
                 .map(postCategory -> PostCategoryResponse.of(postCategory.getId(), postCategory.getName(), appDataS3Client.getPresignedUrl(postCategory.getImage())))
                 .toList());
     }
+
+    @Transactional
+    public PostImagesResponse addPost(final Long memberId, final Long categoryId, final String title,
+                                      final String content, final List<String> images, final Long animalId,
+                                      final List<Long> symptomIds, final List<Long> diseaseIds) {
+        final Post post = postRepository.save(Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build());
+        if (animalId != null) {
+            postTagRepository.save(
+                    PostTag.builder()
+                            .postId(post.getId())
+                            .tagId(animalId)
+                            .tagType(TagType.ANIMAL)
+                            .build()
+            );
+        }
+        if (symptomIds != null) {
+            symptomIds.forEach(symptomId -> postTagRepository.save(
+                    PostTag.builder()
+                            .postId(post.getId())
+                            .tagId(symptomId)
+                            .tagType(TagType.SYMPTOM)
+                            .build()
+            ));
+        }
+        if (diseaseIds != null) {
+            diseaseIds.forEach(diseaseId -> postTagRepository.save(
+                    PostTag.builder()
+                            .postId(post.getId())
+                            .tagId(diseaseId)
+                            .tagType(TagType.DISEASE)
+                            .build()
+            ));
+        }
+        if (images != null) {
+            return PostImagesResponse.of(
+                    images.stream()
+                            .map(image -> {
+                                final String fileName = String.format("%s/%s/%s", memberId, "post", UUID.randomUUID() + image);
+                                postImageRepository.save(
+                                        PostImage.builder()
+                                                .postId(post.getId())
+                                                .image(fileName)
+                                                .build()
+                                );
+                                return memberDataS3Client.putPresignedUrl(fileName);
+                            })
+                            .toList()
+            );
+        }
+        return PostImagesResponse.of(null);
+    }
+
+    @Transactional
+    public PopularPostsResponse getPopularPosts(final Long memberId) {
+        return null;
+    }
+
 
 }

--- a/src/main/java/com/cocos/cocos/config/SwaggerConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SwaggerConfig.java
@@ -38,9 +38,9 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("Offroad API Swagger")
+                .title("COCOS API Swagger")
                 .description(SWAGGER_DESCRIPTION)
-                .version("v1");
+                .version("dev");
     }
 
 

--- a/src/main/java/com/cocos/cocos/db/pet/entity/PetDisease.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/PetDisease.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.pet.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class PetDisease {
 
     @Column(name = "disease_id", nullable = false)
     private Long diseaseId;
+
+    @Builder
+    public PetDisease(Long petId, Long diseaseId) {
+        this.petId = petId;
+        this.diseaseId = diseaseId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/pet/entity/PetSymptom.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/PetSymptom.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.pet.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class PetSymptom {
 
     @Column(name = "symptom_id", nullable = false)
     private Long symptomId;
+
+    @Builder
+    public PetSymptom(Long petId, Long symptomId) {
+        this.petId = petId;
+        this.symptomId = symptomId;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/pet/repository/PetDiseaseRepository.java
+++ b/src/main/java/com/cocos/cocos/db/pet/repository/PetDiseaseRepository.java
@@ -4,6 +4,12 @@ import com.cocos.cocos.db.pet.entity.PetDisease;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PetDiseaseRepository extends JpaRepository<PetDisease, Long> {
+
+    boolean existsByPetId(final Long petId);
+
+    List<PetDisease> findAllByPetId(final Long petId);
 }

--- a/src/main/java/com/cocos/cocos/db/pet/repository/PetRepository.java
+++ b/src/main/java/com/cocos/cocos/db/pet/repository/PetRepository.java
@@ -14,4 +14,6 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
 
     List<Pet> findAllByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 
+    boolean existsByMemberId(final Long memberId);
+
 }

--- a/src/main/java/com/cocos/cocos/db/pet/repository/PetSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/pet/repository/PetSymptomRepository.java
@@ -4,6 +4,12 @@ import com.cocos.cocos.db.pet.entity.PetSymptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PetSymptomRepository extends JpaRepository<PetSymptom, Long> {
+
+    boolean existsByPetId(final Long petId);
+
+    List<PetSymptom> findAllByPetId(final Long petId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/entity/Post.java
+++ b/src/main/java/com/cocos/cocos/db/post/entity/Post.java
@@ -29,11 +29,22 @@ public class Post extends BaseTime {
     @Column(name = "category_id", nullable = false)
     private Long categoryId;
 
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
     @Builder
     public Post(String title, String content, Long memberId, Long categoryId) {
         this.title = title;
         this.content = content;
         this.memberId = memberId;
         this.categoryId = categoryId;
+    }
+
+    public void addLike() {
+        this.likeCount++;
+    }
+
+    public void deleteLike() {
+        this.likeCount--;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
@@ -1,9 +1,20 @@
 package com.cocos.cocos.db.post.repository;
 
 import com.cocos.cocos.db.post.entity.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("SELECT p FROM Post p ORDER BY p.likeCount DESC")
+    List<Post> findTop5ByLikeCountDesc();
+
+    @Query("SELECT p FROM Post p WHERE p.id IN :postIds ORDER BY p.likeCount DESC")
+    List<Post> findTopPostsByPostIds(@Param("postIds") List<Long> postIds, Pageable pageable);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostTagRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostTagRepository.java
@@ -1,7 +1,10 @@
 package com.cocos.cocos.db.post.repository;
 
 import com.cocos.cocos.db.post.entity.PostTag;
+import com.cocos.cocos.enums.tag.TagType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +15,7 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     List<PostTag> findAllByPostId(final Long postId);
 
     void deleteAllByPostId(final Long postId);
+
+    @Query("SELECT pt FROM PostTag pt WHERE pt.tagId IN :tagIds AND pt.tagType = :tagType")
+    List<PostTag> findAllByTagIdAndTagType(@Param("tagIds") List<Long> tagIds, @Param("tagType") TagType tagType);
 }

--- a/src/main/java/com/cocos/cocos/external/MemberDataS3Client.java
+++ b/src/main/java/com/cocos/cocos/external/MemberDataS3Client.java
@@ -4,9 +4,12 @@ import com.cocos.cocos.config.AwsConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.Duration;
 
@@ -15,20 +18,17 @@ public class MemberDataS3Client {
 
     private final S3Presigner s3Presigner;
     private final String bucketName;
+    private final String POST = "post";
 
     public MemberDataS3Client(@Value("${aws.member-data-s3-bucket-name}") final String bucketName, final AwsConfig awsConfig) {
         this.bucketName = bucketName;
         this.s3Presigner = awsConfig.getPresigner();
     }
 
-    public String getPresignedUrl(final String filename) {
-        if (filename == null || filename.equals("")) {
-            return null;
-        }
-
+    public String getPresignedUrl(final String fileName) {
         final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
-                .key(filename)
+                .key(fileName)
                 .build();
 
         final GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
@@ -39,6 +39,25 @@ public class MemberDataS3Client {
         final PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner
                 .presignGetObject(getObjectPresignRequest);
         final String url = presignedGetObjectRequest.url().toString();
+
+        s3Presigner.close();
+        return url;
+    }
+
+    public String putPresignedUrl(final String fileName) {
+        final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        final PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        final PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner
+                .presignPutObject(putObjectPresignRequest);
+        final String url = presignedPutObjectRequest.url().toString();
 
         s3Presigner.close();
         return url;

--- a/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
@@ -2,8 +2,10 @@ package com.cocos.cocos.post;
 
 import com.cocos.cocos.api.post.service.PostLikeService;
 import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostLike;
 import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
 import com.cocos.cocos.enums.message.FailMessage;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,8 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -30,19 +34,32 @@ public class PostLikeServiceTest {
     @Mock
     PostLikeRepository postLikeRepository;
 
+    @Mock
+    PostRepository postRepository;
+
     @Test
     @DisplayName("게시글에 공감을 추가할 수 있다.")
     void addPostLike() {
         //given
         final Long memberId = 1L;
         final Long postId = 1L;
+        final Long categoryId = 1L;
+        final Post post = Post.builder()
+                .title("title")
+                .content("content")
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
         BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(false);
+        BDDMockito.given(postRepository.findById(any())).willReturn(Optional.ofNullable(post));
 
         //when
         postLikeService.addPostLike(memberId, postId);
 
         //then
         BDDMockito.verify(postLikeRepository, times(1)).save(any(PostLike.class));
+        Assertions.assertThat(post.getLikeCount()).isEqualTo(1);
     }
 
     @Test
@@ -51,7 +68,15 @@ public class PostLikeServiceTest {
         // given
         final Long memberId = 1L;
         final Long postId = 1L;
+        final Long categoryId = 1L;
+        final Post post = Post.builder()
+                .title("title")
+                .content("content")
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
         BDDMockito.given(postLikeRepository.existsByMemberIdAndPostId(any(), any())).willReturn(true);
+        BDDMockito.given(postRepository.findById(any())).willReturn(Optional.ofNullable(post));
 
         // when
         postLikeService.deletePostLike(memberId, postId);

--- a/src/test/java/com/cocos/cocos/post/PostRepositoryTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.cocos.cocos.post;
+
+import com.cocos.cocos.config.JpaAuditingConfig;
+import com.cocos.cocos.db.post.entity.Post;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("게시글 레포지토리 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Import(JpaAuditingConfig.class)
+public class PostRepositoryTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @BeforeEach
+    void setUp() {
+        postRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("저장 후 반환하는 엔티티에는 아이디가 있다.")
+    void hasIdAfterSave() {
+        //given, when
+        final Post actual = postRepository.save(Post.builder()
+                .title("title")
+                .content("content")
+                .memberId(1L)
+                .categoryId(1L)
+                .build());
+
+        //then
+        Assertions.assertNotNull(actual.getId());
+    }
+
+}

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.post;
 import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
 import com.cocos.cocos.api.post.dto.response.PostCategoryResponse;
 import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
 import com.cocos.cocos.api.post.service.PostService;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
 import com.cocos.cocos.db.breed.entity.Breed;
@@ -25,6 +26,7 @@ import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.AppDataS3Client;
+import com.cocos.cocos.external.MemberDataS3Client;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -79,6 +81,8 @@ public class PostServiceTest {
     private SymptomRepository symptomRepository;
     @Mock
     private AppDataS3Client appDataS3Client;
+    @Mock
+    private MemberDataS3Client memberDataS3Client;
 
     @Test
     @DisplayName("게시글 세부사항을 조회할 수 있다.")
@@ -250,5 +254,154 @@ public class PostServiceTest {
 
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("이미지, 증상태그, 질병태그, 동물태그가 포함된 게시글을 조회할 수 있다.")
+    void addPost() {
+        //given
+        final Long memberId = 1L;
+        final Long categoryId = 1L;
+        final String title = "제목";
+        final String content = "내용";
+        final List<String> images = new ArrayList<>(List.of("image1.png", "image2.jpg"));
+        final Long animalId = 1L;
+        final List<Long> symptomIds = new ArrayList<>(List.of(2L));
+        final List<Long> diseaseIds = new ArrayList<>(List.of(2L, 3L));
+
+        final Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
+        BDDMockito.given(postRepository.save(any())).willReturn(post);
+
+        //when
+        postService.addPost(memberId, categoryId, title, content, images, animalId, symptomIds, diseaseIds);
+
+        //then
+        BDDMockito.verify(postRepository, times(1)).save(any());
+        BDDMockito.verify(postTagRepository, times(4)).save(any());
+        BDDMockito.verify(postImageRepository, times(2)).save(any());
+
+    }
+
+    @Test
+    @DisplayName("증상태그, 질병태그, 동물태그가 포함된 게시글을 조회할 수 있다.")
+    void addPostWithoutImage() {
+        //given
+        final Long memberId = 1L;
+        final Long categoryId = 1L;
+        final String title = "제목";
+        final String content = "내용";
+        final Long animalId = 1L;
+        final List<Long> symptomIds = new ArrayList<>(List.of(2L));
+        final List<Long> diseaseIds = new ArrayList<>(List.of(2L, 3L));
+
+        final Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
+        BDDMockito.given(postRepository.save(any())).willReturn(post);
+
+        //when
+        postService.addPost(memberId, categoryId, title, content, null, animalId, symptomIds, diseaseIds);
+
+        //then
+        BDDMockito.verify(postRepository, times(1)).save(any());
+        BDDMockito.verify(postTagRepository, times(4)).save(any());
+        BDDMockito.verify(postImageRepository, times(0)).save(any());
+
+    }
+
+    @Test
+    @DisplayName("증상태그, 질병태그가 포함된 게시글을 조회할 수 있다.")
+    void addPostWithoutImageAndAnimal() {
+        //given
+        final Long memberId = 1L;
+        final Long categoryId = 1L;
+        final String title = "제목";
+        final String content = "내용";
+        final List<Long> symptomIds = new ArrayList<>(List.of(2L));
+        final List<Long> diseaseIds = new ArrayList<>(List.of(2L, 3L));
+
+        final Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
+        BDDMockito.given(postRepository.save(any())).willReturn(post);
+
+        //when
+        postService.addPost(memberId, categoryId, title, content, null, null, symptomIds, diseaseIds);
+
+        //then
+        BDDMockito.verify(postRepository, times(1)).save(any());
+        BDDMockito.verify(postTagRepository, times(3)).save(any());
+        BDDMockito.verify(postImageRepository, times(0)).save(any());
+
+    }
+
+    @Test
+    @DisplayName("이미지, 증상태그, 동물태그가 포함된 게시글을 조회할 수 있다.")
+    void addPostWithoutImageAndDisease() {
+        //given
+        final Long memberId = 1L;
+        final Long categoryId = 1L;
+        final String title = "제목";
+        final String content = "내용";
+        final Long animalId = 1L;
+        final List<String> images = new ArrayList<>(List.of("image1.png", "image2.jpg"));
+        final List<Long> symptomIds = new ArrayList<>(List.of(2L));
+
+        final Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
+        BDDMockito.given(postRepository.save(any())).willReturn(post);
+
+        //when
+        postService.addPost(memberId, categoryId, title, content, images, animalId, symptomIds, null);
+
+        //then
+        BDDMockito.verify(postRepository, times(1)).save(any());
+        BDDMockito.verify(postTagRepository, times(2)).save(any());
+        BDDMockito.verify(postImageRepository, times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("이미지의 개수만큼 Presigned Url을 생성할 수 있다.")
+    void createPostImagePresignedUrl() {
+        //given
+        final Long memberId = 1L;
+        final Long categoryId = 1L;
+        final String title = "제목";
+        final String content = "내용";
+        final List<String> images = new ArrayList<>(List.of("image1.png", "image2.jpg"));
+
+        final Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .memberId(memberId)
+                .categoryId(categoryId)
+                .build();
+
+        BDDMockito.given(postRepository.save(any())).willReturn(post);
+
+        //when
+        final PostImagesResponse actual = postService.addPost(memberId, categoryId, title, content, images, null, null, null);
+
+        //then
+        Assertions.assertThat(actual.images().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -1,9 +1,6 @@
 package com.cocos.cocos.post;
 
-import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
-import com.cocos.cocos.api.post.dto.response.PostCategoryResponse;
-import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
-import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
+import com.cocos.cocos.api.post.dto.response.*;
 import com.cocos.cocos.api.post.service.PostService;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
 import com.cocos.cocos.db.breed.entity.Breed;
@@ -16,7 +13,11 @@ import com.cocos.cocos.db.disease.repository.DiseaseRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.pet.entity.Pet;
+import com.cocos.cocos.db.pet.entity.PetDisease;
+import com.cocos.cocos.db.pet.entity.PetSymptom;
+import com.cocos.cocos.db.pet.repository.PetDiseaseRepository;
 import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
 import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostCategory;
 import com.cocos.cocos.db.post.entity.PostImage;
@@ -79,6 +80,10 @@ public class PostServiceTest {
     private DiseaseRepository diseaseRepository;
     @Mock
     private SymptomRepository symptomRepository;
+    @Mock
+    private PetDiseaseRepository petDiseaseRepository;
+    @Mock
+    private PetSymptomRepository petSymptomRepository;
     @Mock
     private AppDataS3Client appDataS3Client;
     @Mock
@@ -403,5 +408,100 @@ public class PostServiceTest {
 
         //then
         Assertions.assertThat(actual.images().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("펫이 존재하고 질병이 있는 경우의 인기글 조회를 할 수 있다.")
+    void getPopularPostsWithDisease() {
+        //given
+        final Long memberId = 1L;
+        final Long breedId = 1L;
+        final String name = "이름";
+        final Gender gender = Gender.MALE;
+        final int age = 15;
+
+        final Pet pet = Pet.builder()
+                .name(name)
+                .gender(gender)
+                .memberId(memberId)
+                .breedId(breedId)
+                .age(age)
+                .build();
+
+        final PetDisease petDisease1 = PetDisease.builder()
+                .petId(1L)
+                .diseaseId(1L)
+                .build();
+        final PetDisease petDisease2 = PetDisease.builder()
+                .petId(1L)
+                .diseaseId(2L)
+                .build();
+        final List<PetDisease> petDiseases = new ArrayList<>(List.of(petDisease1, petDisease2));
+
+        final PetSymptom petSymptom1 = PetSymptom.builder()
+                .petId(1L)
+                .symptomId(2L)
+                .build();
+        final PetSymptom petSymptom2 = PetSymptom.builder()
+                .petId(1L)
+                .symptomId(3L)
+                .build();
+        final List<PetSymptom> petSymptoms = new ArrayList<>(List.of(petSymptom1, petSymptom2));
+
+
+        final PostTag postTag1 = PostTag.builder()
+                .tagId(1L)
+                .postId(1L)
+                .tagType(TagType.DISEASE)
+                .build();
+        final PostTag postTag2 = PostTag.builder()
+                .tagId(2L)
+                .postId(1L)
+                .tagType(TagType.DISEASE)
+                .build();
+        final PostTag postTag3 = PostTag.builder()
+                .tagId(2L)
+                .postId(1L)
+                .tagType(TagType.SYMPTOM)
+                .build();
+        final PostTag postTag4 = PostTag.builder()
+                .tagId(3L)
+                .postId(1L)
+                .tagType(TagType.SYMPTOM)
+                .build();
+        final List<PostTag> postTags = new ArrayList<>(List.of(postTag1, postTag2, postTag3, postTag4));
+
+        final Post post1 = Post.builder()
+                .title("title")
+                .content("content")
+                .memberId(1L)
+                .categoryId(1L)
+                .build();
+        final Post post2 = Post.builder()
+                .title("title1")
+                .content("content1")
+                .memberId(1L)
+                .categoryId(2L)
+                .build();
+        final List<Post> posts = new ArrayList<>(List.of(post1, post2));
+
+        BDDMockito.given(petRepository.existsByMemberId(any())).willReturn(true);
+        BDDMockito.given(petRepository.findByMemberId(any())).willReturn(pet);
+        BDDMockito.given(petDiseaseRepository.existsByPetId(any())).willReturn(true);
+        BDDMockito.given(petDiseaseRepository.findAllByPetId(any())).willReturn(petDiseases);
+        BDDMockito.given(postTagRepository.findAllByTagIdAndTagType(any(), any())).willReturn(postTags);
+        BDDMockito.given(postRepository.findTopPostsByPostIds(any(), any())).willReturn(posts);
+
+        final PopularPostsResponse expected = PopularPostsResponse.of(
+                posts.stream()
+                        .map(post -> PopularPostResponse.of(post.getId(), post.getTitle()))
+                        .toList()
+        );
+        //when
+        final PopularPostsResponse actual = postService.getPopularPosts(memberId);
+
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #28 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 인기글 조회 API 구현
* 게시글 작성 API 구현

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* Post필드에 likeCount필드가 추가되었습니다.
* 게시글 공감 추가, 삭제 API에서 Post의 likeCount 필드의 상태를 업데이트 할 수 있도록 설정했습니다.
