### PR TITLE
Feat: 게시글 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
@@ -5,10 +5,12 @@ import com.cocos.cocos.api.body.service.BodyService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.enums.pet.PetProblem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,7 +21,9 @@ public class BodyController implements BodyControllerSwagger {
     private final BodyService bodyService;
 
     @GetMapping
-    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies() {
-        return SuccessResponse.success(SuccessMessage.OK, bodyService.getBodies());
+    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies(
+            @RequestParam final PetProblem petProblem
+            ) {
+        return SuccessResponse.success(SuccessMessage.OK, bodyService.getBodies(petProblem));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
@@ -2,7 +2,11 @@ package com.cocos.cocos.api.body.controller;
 
 import com.cocos.cocos.api.body.dto.response.BodiesResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.enums.pet.PetProblem;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -14,5 +18,6 @@ public interface BodyControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "신체 부위 조회 성공")
-    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies();
+    @Parameter(name = "petProblem", description = "반려동물 문제", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+    public ResponseEntity<BaseResponse<BodiesResponse>> getBodies(final PetProblem petProblem);
 }

--- a/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
+++ b/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
@@ -4,6 +4,11 @@ import com.cocos.cocos.api.body.dto.response.BodiesResponse;
 import com.cocos.cocos.api.body.dto.response.BodyResponse;
 import com.cocos.cocos.db.body.entity.Body;
 import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.disease.entity.Disease;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.db.symptom.entity.Symptom;
+import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import com.cocos.cocos.enums.pet.PetProblem;
 import com.cocos.cocos.external.AppDataS3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,15 +21,30 @@ import java.util.List;
 public class BodyService {
 
     private final BodyRepository bodyRepository;
+    private final DiseaseRepository diseaseRepository;
+    private final SymptomRepository symptomRepository;
     private final AppDataS3Client appDataS3Client;
 
     @Transactional(readOnly = true)
-    public BodiesResponse getBodies() {
-        final List<Body> bodies = bodyRepository.findAll();
+    public BodiesResponse getBodies(final PetProblem petProblem) {
+        final List<Long> bodyIds = fetchBodyIdsByPetProblem(petProblem);
+        final List<Body> bodies = bodyRepository.findAllById(bodyIds);
         return BodiesResponse.of(
                 bodies.stream()
                         .map(body -> BodyResponse.of(body.getId(), body.getName(), appDataS3Client.getPresignedUrl(body.getImage())))
                         .toList()
         );
+    }
+
+    private List<Long> fetchBodyIdsByPetProblem(final PetProblem petProblem) {
+        if (petProblem.equals(PetProblem.DISEASE)) {
+            return diseaseRepository.findAll().stream()
+                    .map(Disease::getBodyId)
+                    .toList();
+        } else {
+            return symptomRepository.findAll().stream()
+                    .map(Symptom::getBodyId)
+                    .toList();
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -59,7 +59,7 @@ public class PostController implements PostControllerSwagger {
     public ResponseEntity<BaseResponse<PostListResponse>> getPosts(
             @RequestBody final PostListRequest postListRequest
     ) {
-        return SuccessResponse.success(SuccessMessage.OK, postService.getPosts(postListRequest.keyword(),
+        return SuccessResponse.success(SuccessMessage.OK, postService.getPosts(MEMBER_ID, postListRequest.keyword(),
                 postListRequest.animalIds(), postListRequest.symptomIds(), postListRequest.diseaseIds(),
                 postListRequest.sortBy(), postListRequest.cursorId(), postListRequest.categoryId(),
                 postListRequest.likeCount(), postListRequest.createAt()));

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -1,10 +1,8 @@
 package com.cocos.cocos.api.post.controller;
 
+import com.cocos.cocos.api.post.dto.request.PostListRequest;
 import com.cocos.cocos.api.post.dto.request.PostRequest;
-import com.cocos.cocos.api.post.dto.response.PopularPostsResponse;
-import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
-import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
-import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
+import com.cocos.cocos.api.post.dto.response.*;
 import com.cocos.cocos.api.post.service.PostService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
@@ -55,5 +53,15 @@ public class PostController implements PostControllerSwagger {
     @GetMapping("/popular")
     public ResponseEntity<BaseResponse<PopularPostsResponse>> getPopularPosts() {
         return SuccessResponse.success(SuccessMessage.OK, postService.getPopularPosts(MEMBER_ID));
+    }
+
+    @PostMapping("/filters")
+    public ResponseEntity<BaseResponse<PostListResponse>> getPosts(
+            @RequestBody final PostListRequest postListRequest
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, postService.getPosts(postListRequest.keyword(),
+                postListRequest.animalIds(), postListRequest.symptomIds(), postListRequest.diseaseIds(),
+                postListRequest.sortBy(), postListRequest.cursorId(), postListRequest.categoryId(),
+                postListRequest.likeCount(), postListRequest.createAt()));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
@@ -1,0 +1,19 @@
+package com.cocos.cocos.api.post.dto.request;
+
+import com.cocos.cocos.enums.post.SortCriteria;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostListRequest(
+        String keyword,
+        List<Long> animalIds,
+        List<Long> symptomIds,
+        List<Long> diseaseIds,
+        SortCriteria sortBy,
+        Long cursorId,
+        Long categoryId,
+        Long likeCount,
+        LocalDateTime createAt
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
@@ -1,19 +1,29 @@
 package com.cocos.cocos.api.post.dto.request;
 
 import com.cocos.cocos.enums.post.SortCriteria;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record PostListRequest(
+        @Schema(description = "검색 키워드", example = "포메 or null")
         String keyword,
+        @Schema(description = "동물 아이디 리스트", example = "[1, 2] or null")
         List<Long> animalIds,
+        @Schema(description = "증상 아이디 리스트", example = "[1, 2] or null")
         List<Long> symptomIds,
+        @Schema(description = "질병 아이디 리스트", example = "[1, 2] or null")
         List<Long> diseaseIds,
+        @Schema(description = "정렬 기준", example = "RECENT or POPULAR")
         SortCriteria sortBy,
+        @Schema(description = "마지막 게시글 아이디", example = "1 or null")
         Long cursorId,
+        @Schema(description = "마지막 게시글 카테고리 아이디", example = "1 or null")
         Long categoryId,
+        @Schema(description = "마지막 게시글 좋아요 수 아이디", example = "1 or null")
         Long likeCount,
+        @Schema(description = "마지막 게시글 생성일", example = "YYYY-MM-DD~ or null")
         LocalDateTime createAt
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PostListResponse.java
@@ -1,9 +1,13 @@
 package com.cocos.cocos.api.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record PostListResponse(
+        @Schema(description = "마지막 게시글 아이디", example = "1 or null")
         Long cursorId,
+        @Schema(description = "게시글 리스트")
         List<PostResponse> posts
 ) {
     public static PostListResponse of(final Long cursorId, final List<PostResponse> posts) {

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PostListResponse.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import java.util.List;
+
+public record PostListResponse(
+        Long cursorId,
+        List<PostResponse> posts
+) {
+    public static PostListResponse of(final Long cursorId, final List<PostResponse> posts) {
+        return new PostListResponse(cursorId, posts);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PostResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PostResponse.java
@@ -1,0 +1,21 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PostResponse(
+        Long id,
+        String breed,
+        int petAge,
+        String title,
+        String content,
+        int likeCount,
+        int commentCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String image,
+        String category
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/PostResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/PostResponse.java
@@ -1,21 +1,33 @@
 package com.cocos.cocos.api.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder
 public record PostResponse(
+        @Schema(description = "게시글 아이디", example = "1")
         Long id,
+        @Schema(description = "반려동물 품종", example = "포메라니안")
         String breed,
+        @Schema(description = "반려동물 나이", example = "14")
         int petAge,
+        @Schema(description = "게시글 제목", example = "title")
         String title,
+        @Schema(description = "게시글 내용", example = "content")
         String content,
+        @Schema(description = "게시글 좋아요 개수", example = "1")
         int likeCount,
+        @Schema(description = "게시글 댓글 개수", example = "1")
         int commentCount,
+        @Schema(description = "게시글 생성일", example = "1")
         LocalDateTime createdAt,
+        @Schema(description = "게시글 수정일", example = "1")
         LocalDateTime updatedAt,
+        @Schema(description = "게시글 이미지", example = "1")
         String image,
+        @Schema(description = "게시글 카테고리", example = "1")
         String category
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -27,20 +27,27 @@ import com.cocos.cocos.db.post.repository.*;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.enums.post.SortCriteria;
 import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.AppDataS3Client;
 import com.cocos.cocos.external.MemberDataS3Client;
+import com.cocos.cocos.util.PostSpecification;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostService {
 
     private final PostRepository postRepository;
@@ -239,5 +246,117 @@ public class PostService {
         return postRepository.findTop5ByLikeCountDesc();
     }
 
+    @Transactional(readOnly = true)
+    public PostListResponse getPosts(final String keyword, final List<Long> animalIds, final List<Long> symptomIds,
+                                     final List<Long> diseaseIds, final SortCriteria sortBy, final Long cursorId,
+                                     final Long categoryId, final Long likeCount, final LocalDateTime createAt) {
+        Specification<Post> spec = (root, query, criteriaBuilder) -> null;
+        if (keyword != null) {
+            spec = spec.and(PostSpecification.hasKeyword(keyword));
+        }
+        if (animalIds != null) {
+            final List<PostTag> postTags = postTagRepository.findAllByTagIdAndTagType(animalIds, TagType.ANIMAL);
+            final List<Long> postIds = postTags.stream()
+                    .map(PostTag::getPostId)
+                    .toList();
+            spec = spec.and(PostSpecification.inPostIds(postIds));
+        }
+        if (symptomIds != null) {
+            final List<PostTag> postTags = postTagRepository.findAllByTagIdAndTagType(symptomIds, TagType.SYMPTOM);
+            final List<Long> postIds = postTags.stream()
+                    .map(PostTag::getPostId)
+                    .toList();
+            spec = spec.and(PostSpecification.inPostIds(postIds));
+        }
+        if (diseaseIds != null) {
+            final List<PostTag> postTags = postTagRepository.findAllByTagIdAndTagType(diseaseIds, TagType.DISEASE);
+            final List<Long> postIds = postTags.stream()
+                    .map(PostTag::getPostId)
+                    .toList();
+            spec = spec.and(PostSpecification.inPostIds(postIds));
+        }
+        if (categoryId != null) {
+            spec = spec.and(PostSpecification.equalCategory(categoryId));
+        }
+
+        if (cursorId != null) {
+            if (sortBy.equals(SortCriteria.RECENT)) {
+                spec = spec.and(PostSpecification.lessThanByRecentCursorId(createAt, cursorId));
+                log.info("최신 순일 때 커서 이후");
+            } else if (sortBy.equals(SortCriteria.POPULAR)) {
+                spec = spec.and(PostSpecification.lessThanByPostLikeCursorId(likeCount, createAt, cursorId));
+                log.info("인기 순일 때 커서 이후");
+            }
+        }
+        // 정렬 및 페이징
+        Sort sort;
+        if (sortBy.equals(SortCriteria.POPULAR)) {
+            sort = Sort.by(
+                    Sort.Order.desc("likeCount"),
+                    Sort.Order.desc("createdAt"),
+                    Sort.Order.desc("id")
+            );
+            log.info("인기 순일 때 기준");
+        } else if (sortBy.equals(SortCriteria.RECENT)) {
+            sort = Sort.by(
+                    Sort.Order.desc("createdAt"),
+                    Sort.Order.desc("id")
+            );
+            log.info("최신 순일 때 기준");
+        } else {
+            throw new IllegalArgumentException("Invalid sort type");
+        }
+
+        Pageable pageable = PageRequest.of(0, 2, sort);
+        final List<Post> posts = postRepository.findAll(spec, pageable).getContent();
+
+        Long nextCursorId = null;
+        if (!posts.isEmpty()) {
+            Post lastPost = posts.get(posts.size() - 1); // 마지막 Post 가져오기
+            nextCursorId = lastPost.getId(); // 정렬 기준에 따라 커서 생성
+        }
+
+        return PostListResponse.of(nextCursorId,
+                posts.stream()
+                        .map(post -> {
+                            final Member member = memberRepository.findById(post.getMemberId()).orElseThrow(
+                                    () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+                            );
+                            final Pet pet = petRepository.findByMemberId(member.getId());
+                            final Breed breed = breedRepository.findById(pet.getBreedId()).orElseThrow(
+                                    () -> new CocosException(FailMessage.NOT_FOUND_BREED)
+                            );
+                            final int commentCounts = commentRepository.countByPostId(post.getId());
+                            final int subCommentCounts = commentRepository.findAllByPostId(post.getId()).stream()
+                                    .mapToInt(comment -> subCommentRepository.countByCommentId(comment.getId()))
+                                    .sum();
+                            final List<PostImage> postImages = postImageRepository.findAllByPostId(post.getId());
+                            final String image = getImageUrl(postImages);
+                            return PostResponse.builder()
+                                    .id(post.getId())
+                                    .breed(breed.getName())
+                                    .petAge(pet.getAge())
+                                    .title(post.getTitle())
+                                    .content(post.getContent())
+                                    .likeCount(post.getLikeCount())
+                                    .commentCount(commentCounts + subCommentCounts)
+                                    .createdAt(post.getCreatedAt())
+                                    .updatedAt(post.getUpdatedAt())
+                                    .image(image)
+                                    .category(postCategoryRepository.findById(post.getCategoryId()).orElseThrow(
+                                            () -> new CocosException(FailMessage.NOT_FOUND_CATEGORY)
+                                    ).getName())
+                                    .build();
+                        })
+                        .toList()
+        );
+    }
+
+    private String getImageUrl(final List<PostImage> postImages) {
+        if (!postImages.isEmpty()) {
+            return memberDataS3Client.getPresignedUrl(postImages.getFirst().getImage());
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -24,7 +24,6 @@ import com.cocos.cocos.db.post.entity.PostCategory;
 import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.post.entity.PostTag;
 import com.cocos.cocos.db.post.repository.*;
-import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
@@ -256,10 +255,6 @@ public class PostService {
         Specification<Post> spec = (root, query, criteriaBuilder) -> null;
         if (keyword != null) {
             spec = spec.and(PostSpecification.hasKeyword(keyword));
-            searchRepository.save(Search.builder()
-                    .keyword(keyword)
-                    .memberId(memberId)
-                    .build());
         }
         if (animalIds != null) {
             final List<PostTag> postTags = postTagRepository.findAllByTagIdAndTagType(animalIds, TagType.ANIMAL);
@@ -314,14 +309,15 @@ public class PostService {
             throw new IllegalArgumentException("Invalid sort type");
         }
 
-        Pageable pageable = PageRequest.of(0, 2, sort);
-        final List<Post> posts = postRepository.findAll(spec, pageable).getContent();
+        //Pageable pageable = PageRequest.of(0, 2, sort); //무한 스크롤 용
+        final List<Post> posts = postRepository.findAll(spec, sort);
 
+        //무한 스크롤 용
         Long nextCursorId = null;
-        if (!posts.isEmpty()) {
+        /*if (!posts.isEmpty()) {
             Post lastPost = posts.get(posts.size() - 1); // 마지막 Post 가져오기
             nextCursorId = lastPost.getId(); // 정렬 기준에 따라 커서 생성
-        }
+        }*/
 
         return PostListResponse.of(nextCursorId,
                 posts.stream()

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -24,6 +24,8 @@ import com.cocos.cocos.db.post.entity.PostCategory;
 import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.post.entity.PostTag;
 import com.cocos.cocos.db.post.repository.*;
+import com.cocos.cocos.db.search.entity.Search;
+import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
@@ -65,6 +67,7 @@ public class PostService {
     private final SymptomRepository symptomRepository;
     private final PetDiseaseRepository petDiseaseRepository;
     private final PetSymptomRepository petSymptomRepository;
+    private final SearchRepository searchRepository;
     private final AppDataS3Client appDataS3Client;
     private final MemberDataS3Client memberDataS3Client;
 
@@ -247,12 +250,16 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostListResponse getPosts(final String keyword, final List<Long> animalIds, final List<Long> symptomIds,
+    public PostListResponse getPosts(final Long memberId, final String keyword, final List<Long> animalIds, final List<Long> symptomIds,
                                      final List<Long> diseaseIds, final SortCriteria sortBy, final Long cursorId,
                                      final Long categoryId, final Long likeCount, final LocalDateTime createAt) {
         Specification<Post> spec = (root, query, criteriaBuilder) -> null;
         if (keyword != null) {
             spec = spec.and(PostSpecification.hasKeyword(keyword));
+            searchRepository.save(Search.builder()
+                    .keyword(keyword)
+                    .memberId(memberId)
+                    .build());
         }
         if (animalIds != null) {
             final List<PostTag> postTags = postTagRepository.findAllByTagIdAndTagType(animalIds, TagType.ANIMAL);

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
@@ -7,9 +7,7 @@ import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("${api.prefix}/search")
@@ -22,5 +20,12 @@ public class SearchController implements SearchControllerSwagger {
     @GetMapping
     public ResponseEntity<BaseResponse<SearchResponse>> getSearch() {
         return SuccessResponse.success(SuccessMessage.OK, searchService.getSearch(MEMBER_ID));
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> addSearch(
+            @RequestParam final String keyword
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(MEMBER_ID, keyword));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
@@ -3,6 +3,9 @@ package com.cocos.cocos.api.search.controller;
 import com.cocos.cocos.api.search.dto.response.SearchResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -15,4 +18,11 @@ public interface SearchControllerSwagger {
             responseCode = "200",
             description = "최근 검색어 조회 성공")
     public ResponseEntity<BaseResponse<SearchResponse>> getSearch();
+
+    @Operation(summary = "최근 검색어 저장 API", description = "최근 검색어를 저장하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "최근 검색어 저장 성공")
+    @Parameter(name = "keyword", description = "검색어", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+    public ResponseEntity<BaseResponse<Void>> addSearch(final String keyword);
 }

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -18,11 +18,22 @@ public class SearchService {
 
     @Transactional(readOnly = true)
     public SearchResponse getSearch(final Long memberId) {
-        final List<Search> searchList = searchRepository.findTop5ByMemberIdOrderByCreatedAtDesc(memberId);
+        final List<Search> searchList = searchRepository.findTop5ByMemberIdOrderByUpdatedAtDesc(memberId);
         return SearchResponse.of(
                 searchList.stream()
                         .map(search -> KeywordResponse.of(search.getId(), search.getKeyword()))
                         .toList()
         );
+    }
+
+    @Transactional
+    public Void addSearch(final Long memberId, final String keyword) {
+        if (searchRepository.existsByMemberIdAndKeyword(memberId, keyword)) {
+            final Search search = searchRepository.findByMemberIdAndKeyword(memberId, keyword);
+            search.updateTime();
+        } else {
+            searchRepository.save(Search.builder().memberId(memberId).keyword(keyword).build());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/cocos/cocos/config/WebConfig.java
+++ b/src/main/java/com/cocos/cocos/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.config;
 
+import com.cocos.cocos.util.PetProblemEnumConverter;
 import com.cocos.cocos.util.SortCriteriaEnumConverter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
@@ -11,5 +12,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new SortCriteriaEnumConverter());
+        registry.addConverter(new PetProblemEnumConverter());
     }
 }

--- a/src/main/java/com/cocos/cocos/config/WebConfig.java
+++ b/src/main/java/com/cocos/cocos/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.cocos.cocos.config;
+
+import com.cocos.cocos.util.SortCriteriaEnumConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new SortCriteriaEnumConverter());
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/BaseTime.java
+++ b/src/main/java/com/cocos/cocos/db/BaseTime.java
@@ -22,4 +22,8 @@ public abstract class BaseTime {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public void updateTime() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.db.post.repository;
 import com.cocos.cocos.db.post.entity.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 
     @Query("SELECT p FROM Post p ORDER BY p.likeCount DESC")
     List<Post> findTop5ByLikeCountDesc();

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -9,5 +9,9 @@ import java.util.List;
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
-    List<Search> findTop5ByMemberIdOrderByCreatedAtDesc(final Long memberId);
+    List<Search> findTop5ByMemberIdOrderByUpdatedAtDesc(final Long memberId);
+
+    boolean existsByMemberIdAndKeyword(final Long memberId, final String keyword);
+
+    Search findByMemberIdAndKeyword(final Long memberId, final String keyword);
 }

--- a/src/main/java/com/cocos/cocos/enums/pet/PetProblem.java
+++ b/src/main/java/com/cocos/cocos/enums/pet/PetProblem.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.enums.pet;
+
+import com.cocos.cocos.enums.post.SortCriteria;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PetProblem {
+
+    DISEASE("질병"),
+    SYMPTOM("증상");
+
+    private final String problem;
+
+    public static PetProblem create(String requestCategory) {
+        for (PetProblem value : PetProblem.values()) {
+            if (value.toString().equals(requestCategory)) {
+                return value;
+            }
+        }
+        throw new IllegalStateException("일치하는 카테고리가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/cocos/cocos/enums/post/SortCriteria.java
+++ b/src/main/java/com/cocos/cocos/enums/post/SortCriteria.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.enums.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SortCriteria {
+
+    RECENT("최신순", "createdAt"),
+    POPULAR("인기순", "likeCount");
+
+    private final String sortBy;
+    private final String fieldName;
+
+    public static SortCriteria create(String requestCategory) {
+        for (SortCriteria value : SortCriteria.values()) {
+            if (value.toString().equals(requestCategory)) {
+                return value;
+            }
+        }
+        throw new IllegalStateException("일치하는 카테고리가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/cocos/cocos/util/PetProblemEnumConverter.java
+++ b/src/main/java/com/cocos/cocos/util/PetProblemEnumConverter.java
@@ -1,0 +1,13 @@
+package com.cocos.cocos.util;
+
+
+import com.cocos.cocos.enums.pet.PetProblem;
+import org.springframework.core.convert.converter.Converter;
+
+public class PetProblemEnumConverter implements Converter<String, PetProblem> {
+
+    @Override
+    public PetProblem convert(String requestCategory) {
+        return PetProblem.create(requestCategory.toUpperCase());
+    }
+}

--- a/src/main/java/com/cocos/cocos/util/PostSpecification.java
+++ b/src/main/java/com/cocos/cocos/util/PostSpecification.java
@@ -1,0 +1,61 @@
+package com.cocos.cocos.util;
+
+import com.cocos.cocos.db.post.entity.Post;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PostSpecification {
+
+    public static Specification<Post> hasKeyword(String keyword) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + keyword + "%");
+    }
+
+    public static Specification<Post> inPostIds(List<Long> postIds) {
+        return ((root, query, criteriaBuilder) -> root.get("id").in(postIds));
+    }
+
+    public static Specification<Post> equalCategory(Long categoryId) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("categoryId"), categoryId);
+    }
+
+    public static Specification<Post> lessThanByRecentCursorId(LocalDateTime cursorCreatedAt, Long cursorId) {
+        return (root, query, criteriaBuilder) -> {
+            if (cursorCreatedAt != null && cursorId != null) {
+                return criteriaBuilder.or(
+                        criteriaBuilder.lessThan(root.get("createdAt"), cursorCreatedAt),
+                        criteriaBuilder.and(
+                                criteriaBuilder.equal(root.get("createdAt"), cursorCreatedAt),
+                                criteriaBuilder.lessThan(root.get("id"), cursorId)
+                        )
+                );
+            }
+            return criteriaBuilder.conjunction(); // 항상 참인 조건 반환
+        };
+    }
+
+    public static Specification<Post> lessThanByPostLikeCursorId(Long cursorLikeCount, LocalDateTime cursorCreatedAt, Long cursorId) {
+        return (root, query, criteriaBuilder) -> {
+            if (cursorLikeCount != null && cursorCreatedAt != null && cursorId != null) {
+                return criteriaBuilder.or(
+                        criteriaBuilder.lessThan(root.get("likeCount"), cursorLikeCount),
+                        criteriaBuilder.and(
+                                criteriaBuilder.equal(root.get("likeCount"), cursorLikeCount),
+                                criteriaBuilder.or(
+                                        criteriaBuilder.lessThan(root.get("createdAt"), cursorCreatedAt),
+                                        criteriaBuilder.and(
+                                                criteriaBuilder.equal(root.get("createdAt"), cursorCreatedAt),
+                                                criteriaBuilder.lessThan(root.get("id"), cursorId)
+                                        )
+                                )
+                        )
+                );
+            }
+            return criteriaBuilder.conjunction();
+        };
+    }
+
+
+}

--- a/src/main/java/com/cocos/cocos/util/SortCriteriaEnumConverter.java
+++ b/src/main/java/com/cocos/cocos/util/SortCriteriaEnumConverter.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.util;
+
+import com.cocos.cocos.enums.post.SortCriteria;
+import org.springframework.core.convert.converter.Converter;
+
+public class SortCriteriaEnumConverter implements Converter<String, SortCriteria> {
+    @Override
+    public SortCriteria convert(String requestCategory) {
+        return SortCriteria.create(requestCategory.toUpperCase());
+    }
+
+}

--- a/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
+++ b/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
@@ -5,6 +5,9 @@ import com.cocos.cocos.api.body.dto.response.BodyResponse;
 import com.cocos.cocos.api.body.service.BodyService;
 import com.cocos.cocos.db.body.entity.Body;
 import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.db.disease.entity.Disease;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.enums.pet.PetProblem;
 import com.cocos.cocos.external.AppDataS3Client;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +37,9 @@ public class BodyServiceTest {
     private BodyRepository bodyRepository;
 
     @Mock
+    private DiseaseRepository diseaseRepository;
+
+    @Mock
     private AppDataS3Client appDataS3Client;
 
     @Test
@@ -48,17 +54,28 @@ public class BodyServiceTest {
                 .name("이름2")
                 .image("이미지2")
                 .build();
+        final Disease disease1 = Disease.builder()
+                .bodyId(1L)
+                .name("질병1")
+                .build();
+        final Disease disease2 = Disease.builder()
+                .bodyId(2L)
+                .name("질병2")
+                .build();
+        final List<Disease> diseases = new ArrayList<>(List.of(disease1, disease2));
         final List<Body> bodies = new ArrayList<Body>(List.of(body1, body2));
         final BodiesResponse expected = BodiesResponse.of(
                 bodies.stream()
                         .map(body -> BodyResponse.of(body.getId(), body.getName(), "image"))
                         .toList()
         );
-        BDDMockito.given(bodyRepository.findAll()).willReturn(bodies);
+
+        BDDMockito.given(diseaseRepository.findAll()).willReturn(diseases);
+        BDDMockito.given(bodyRepository.findAllById(any())).willReturn(bodies);
         BDDMockito.given(appDataS3Client.getPresignedUrl(any())).willReturn("image");
 
         //when
-        final BodiesResponse actual = bodyService.getBodies();
+        final BodiesResponse actual = bodyService.getBodies(PetProblem.DISEASE);
 
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -46,7 +46,7 @@ public class SearchServiceTest {
                 .keyword("keyword1")
                 .build();
         final List<Search> searchList = new ArrayList<>(List.of(search1, search2));
-        BDDMockito.given(searchRepository.findTop5ByMemberIdOrderByCreatedAtDesc(any())).willReturn(searchList);
+        BDDMockito.given(searchRepository.findTop5ByMemberIdOrderByUpdatedAtDesc(any())).willReturn(searchList);
 
         final SearchResponse expected = SearchResponse.of(
                 searchList.stream()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #34 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 필터에 따라 게시글을 조회하는 API를 구현했습니다.
* Jpa Specification을 이용했습니다.
* 커서 기반 페이지네이션으로 구현을 하였습니다.
* 검색어가 있는 경우 검색어가 있는 게시물을 필터링 했습니다.
* 동물, 질병, 증상을 필터링 한 경우 그 태그를 가진 게시물들을 가져올 수 있도록 구현했습니다.
* 인기순, 최신순으로 정렬할 때 고유값이 아닌 중복될 수 있는값이기 때문에 여러개의 값을 기준으로 정렬할 수 있게 했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 리팩 무 조 건 필수
* indexing에 대해서 더 찾아보고 좋은 방안이라면 적용이 필요할 거 같습니다.
