### PR TITLE
Feat: 사용자 게시글 조회 API 및 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.api.member.controller;
+
+import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.service.MemberService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${api.prefix}/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private static final Long memberId = 1L;
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile() {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(memberId));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.api.member.controller;
+
+import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Member Controller", description = "사용자 관련 API")
+public interface MemberControllerSwagger {
+
+    @Operation(summary = "사용자 조회 API", description = "사용자를 조회하는 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 조회에 성공했습니다.")
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(final Long memberId);
+}

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,10 @@
+package com.cocos.cocos.api.member.dto.response;
+
+public record MemberProfileResponse(
+        String nickname,
+        String profileImage
+) {
+    public static MemberProfileResponse of(final String nickname, final String profileImage) {
+        return new MemberProfileResponse(nickname, profileImage);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.api.member.service;
+
+import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.member.entity.Member;
+import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.external.MemberDataS3Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberDataS3Client memberDataS3Client;
+
+    @Transactional(readOnly = true)
+    public MemberProfileResponse getMemberProfile(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+        return MemberProfileResponse.of(member.getNickname(), memberDataS3Client.getPresignedUrl(member.getImage()));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -64,4 +64,11 @@ public class PostController implements PostControllerSwagger {
                 postListRequest.sortBy(), postListRequest.cursorId(), postListRequest.categoryId(),
                 postListRequest.likeCount(), postListRequest.createAt()));
     }
+
+    @GetMapping("/members")
+    public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(
+            @RequestParam(name = "nickname", required = false) final String nickname
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, postService.getMemberPosts(MEMBER_ID, nickname));
+    }
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -65,7 +65,7 @@ public class PostController implements PostControllerSwagger {
                 postListRequest.likeCount(), postListRequest.createAt()));
     }
 
-    @GetMapping("/members")
+    @GetMapping("/my")
     public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(
             @RequestParam(name = "nickname", required = false) final String nickname
     ) {

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
@@ -1,10 +1,7 @@
 package com.cocos.cocos.api.post.controller;
 
 import com.cocos.cocos.api.post.dto.request.PostRequest;
-import com.cocos.cocos.api.post.dto.response.PopularPostsResponse;
-import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
-import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
-import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
+import com.cocos.cocos.api.post.dto.response.*;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,6 +21,7 @@ public interface PostControllerSwagger {
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<PostDetailResponse>> getPostDetail(final Long postId);
 
+    @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제하는 API입니다.")
     @ApiResponse(
             responseCode = "200",
             description = "게시글 삭제 성공")
@@ -47,4 +45,11 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "인기 게시글 조회 성공")
     public ResponseEntity<BaseResponse<PopularPostsResponse>> getPopularPosts();
+
+    @Operation(summary = "사용자 게시글 조회 API", description = "사용자 게시글을 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 게시글 조회 성공")
+    @Parameter(name = "nickname", description = "모모", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "String"))
+    public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(final String nickname);
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/MemberPostDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/MemberPostDetailResponse.java
@@ -1,0 +1,34 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record MemberPostDetailResponse(
+        @Schema(description = "게시글 아이디", example = "1")
+        Long id,
+        String nickname,
+        @Schema(description = "게시글 제목", example = "title")
+        String title,
+        @Schema(description = "게시글 내용", example = "content")
+        String content,
+        @Schema(description = "게시글 좋아요 개수", example = "1")
+        int likeCount,
+        @Schema(description = "게시글 댓글 개수", example = "1")
+        int commentCount,
+        @Schema(description = "게시글 생성일", example = "1")
+        LocalDateTime createdAt,
+        @Schema(description = "게시글 수정일", example = "1")
+        LocalDateTime updatedAt,
+        @Schema(description = "게시글 이미지", example = "1")
+        String image,
+        @Schema(description = "게시글 카테고리", example = "1")
+        String category,
+        @Schema(description = "반려동물 품종", example = "포메라니안")
+        String breed,
+        @Schema(description = "반려동물 나이", example = "14")
+        int age
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/post/dto/response/MemberPostsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/response/MemberPostsResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MemberPostsResponse(
+        @Schema(description = "사용자 게시글 리스트")
+        List<MemberPostDetailResponse> posts
+) {
+    public static MemberPostsResponse of(final List<MemberPostDetailResponse> posts) {
+        return new MemberPostsResponse(posts);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -362,4 +362,53 @@ public class PostService {
         return null;
     }
 
+    @Transactional(readOnly = true)
+    public MemberPostsResponse getMemberPosts(final Long memberId, final String nickname) {
+        final Member member = findMember(memberId, nickname);
+        log.info(member.getId().toString());
+        final List<Post> posts = postRepository.findAllByMemberId(member.getId());
+        final Pet pet = petRepository.findByMemberId(member.getId());
+        final Breed breed = breedRepository.findById(pet.getBreedId()).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_BREED)
+        );
+        return MemberPostsResponse.of(
+                posts.stream()
+                        .map(post -> {
+                            final int commentCounts = commentRepository.countByPostId(post.getId());
+                            final int subCommentCounts = commentRepository.findAllByPostId(post.getId()).stream()
+                                    .mapToInt(comment -> subCommentRepository.countByCommentId(comment.getId()))
+                                    .sum();
+
+                            final List<PostImage> postImages = postImageRepository.findAllByPostId(post.getId());
+                            final String image = getImageUrl(postImages);
+
+                            return MemberPostDetailResponse.builder()
+                                    .id(post.getId())
+                                    .nickname(member.getNickname())
+                                    .title(post.getTitle())
+                                    .content(post.getContent())
+                                    .likeCount(post.getLikeCount())
+                                    .commentCount(commentCounts + subCommentCounts)
+                                    .createdAt(post.getCreatedAt())
+                                    .updatedAt(post.getUpdatedAt())
+                                    .image(image)
+                                    .category(postCategoryRepository.findById(post.getCategoryId()).orElseThrow(
+                                            () -> new CocosException(FailMessage.NOT_FOUND_CATEGORY)
+                                    ).getName())
+                                    .breed(breed.getName())
+                                    .age(pet.getAge())
+                                    .build();
+                        }).toList()
+        );
+    }
+
+    private Member findMember(final Long memberId, final String nickname) {
+        if (nickname != null) {
+            return memberRepository.findByNickname(nickname);
+        }
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+    }
+
 }

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -334,7 +334,7 @@ public class PostService {
                                     .mapToInt(comment -> subCommentRepository.countByCommentId(comment.getId()))
                                     .sum();
                             final List<PostImage> postImages = postImageRepository.findAllByPostId(post.getId());
-                            final String image = getImageUrl(postImages);
+                            final String image = getFirstImage(postImages);
                             return PostResponse.builder()
                                     .id(post.getId())
                                     .breed(breed.getName())
@@ -355,7 +355,7 @@ public class PostService {
         );
     }
 
-    private String getImageUrl(final List<PostImage> postImages) {
+    private String getFirstImage(final List<PostImage> postImages) {
         if (!postImages.isEmpty()) {
             return memberDataS3Client.getPresignedUrl(postImages.getFirst().getImage());
         }
@@ -380,7 +380,7 @@ public class PostService {
                                     .sum();
 
                             final List<PostImage> postImages = postImageRepository.findAllByPostId(post.getId());
-                            final String image = getImageUrl(postImages);
+                            final String image = getFirstImage(postImages);
 
                             return MemberPostDetailResponse.builder()
                                     .id(post.getId())

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
@@ -18,4 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
 
     @Query("SELECT p FROM Post p WHERE p.id IN :postIds ORDER BY p.likeCount DESC")
     List<Post> findTopPostsByPostIds(@Param("postIds") List<Long> postIds, Pageable pageable);
+
+    List<Post> findAllByMemberId(final Long memberId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #42 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 사용자가 작성한 게시글을 조회하는 API를 구현했습니다.
* 사용자의 정보를 조회하는 API를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
