### PR TITLE
Feat: 사용자 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -1,15 +1,14 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
 import com.cocos.cocos.api.member.service.MemberService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("${api.prefix}/members")
@@ -21,5 +20,13 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile() {
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(memberId));
+    }
+
+    @PatchMapping
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(
+            @RequestParam(name = "nickname") final String nickname
+    ) {
+        final NicknameExistenceResponse nicknameExistenceResponse = memberService.updateMemberProfile(nickname, memberId);
+        return SuccessResponse.success(SuccessMessage.OK, nicknameExistenceResponse);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -1,11 +1,13 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member Controller", description = "사용자 관련 API")
 public interface MemberControllerSwagger {
@@ -13,6 +15,12 @@ public interface MemberControllerSwagger {
     @Operation(summary = "사용자 조회 API", description = "사용자를 조회하는 API 입니다.")
     @ApiResponse(
             responseCode = "200",
-            description = "사용자 조회에 성공했습니다.")
+            description = "요청에 성공했습니다. ")
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(final Long memberId);
+
+    @Operation(summary = "사용자 정보 업데이트 API", description = "사용자를 정보 업데이트 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다. ")
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(@RequestParam final String nickname);
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/NicknameExistenceResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/NicknameExistenceResponse.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.api.member.dto.response;
+
+public record NicknameExistenceResponse(
+        boolean isExistNickname
+) {
+    public static NicknameExistenceResponse of(final boolean isExistNickname) {
+        return new NicknameExistenceResponse(isExistNickname);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.member.service;
 
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
@@ -23,5 +24,18 @@ public class MemberService {
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
         );
         return MemberProfileResponse.of(member.getNickname(), memberDataS3Client.getPresignedUrl(member.getImage()));
+    }
+
+    @Transactional
+    public NicknameExistenceResponse updateMemberProfile(final String nickname, final Long memberId) {
+        if (memberRepository.existsByNickname(nickname)) {
+            return NicknameExistenceResponse.of(true);
+        } else {
+            final Member member = memberRepository.findById(memberId).orElseThrow(
+                    ()-> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+            );
+            member.updateFields(nickname);
+            return NicknameExistenceResponse.of(false);
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -46,4 +46,8 @@ public class Member extends BaseTime {
         this.sub = sub;
         this.isAdmin = isAdmin;
     }
+
+    public void updateFields(final String nickname) {
+        if (nickname != null ) this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByNickname(final String nickname);
+    boolean existsByNickname(final String nickname);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #45 

## 👷 **작업한 내용**
- 사용자 정보 수정 API 구현

## 🚨 **참고 사항**
- nickname으로 조회했을 때 있으면 수정 요청을 반영하지 않습니다.
- 조회했을 때 없으면 수정 요청을 반영하고, 응답합니다. 