### PR TITLE
Fix: 닉네임으로 회원 페이지 정보 조회할 수 있도록 변경

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -62,7 +62,9 @@ public class CommentController implements CommentControllerSwagger {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<BaseResponse<MyAllCommentsResponse>> getMyComments() {
-        return SuccessResponse.success(SuccessMessage.OK, commentService.getMyComments(memberId));
+    public ResponseEntity<BaseResponse<MyAllCommentsResponse>> getMyComments(
+            @RequestParam(name = "nickname", required = false) final String nickname
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, commentService.getMyComments(nickname, memberId));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Comment Controller", description = "댓글 관련 API")
 public interface CommentControllerSwagger {
@@ -64,5 +65,7 @@ public interface CommentControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "요청에 성공했습니다.")
-    public ResponseEntity<BaseResponse<MyAllCommentsResponse>> getMyComments ();
+    public ResponseEntity<BaseResponse<MyAllCommentsResponse>> getMyComments (
+            @RequestParam final String nickname
+    );
 }

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -149,9 +149,9 @@ public class CommentService {
         return CommentsAndSubCommentsResponse.of(commentDtos);
     }
 
-    public MyAllCommentsResponse getMyComments(final Long memberId) {
-
-        final List<Comment> comments = commentRepository.findByMemberIdOrderByCreatedAtAsc(memberId);
+    public MyAllCommentsResponse getMyComments(final String nickname, final Long memberId) {
+        final Long selectedMemberId = (nickname != null ) ? findMemberByNickname(nickname): memberId;
+        final List<Comment> comments = commentRepository.findByMemberIdOrderByCreatedAtAsc(selectedMemberId);
         final List<Long> commentIds = comments.stream()
                 .map(Comment::getId)
                 .toList();
@@ -234,5 +234,17 @@ public class CommentService {
                 .findFirst()
                 .map(Pet::getAge)
                 .orElseThrow(() -> new CocosException(FailMessage.INTERNAL_SERVER_ERROR_PET_AGE));
+    }
+
+    private Long findMemberByNickname(String nickname) {
+        if (nickname != null) {
+            final Member member = memberRepository.findByNickname(nickname);
+            if (member == null) {
+                throw new CocosException((FailMessage.NOT_FOUND_MEMBER));
+            }
+            return member.getId();
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -9,17 +9,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("${api.prefix}/members")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberControllerSwagger {
     private static final Long memberId = 1L;
     private final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile() {
-        return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(memberId));
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
+            @RequestParam(name = "nickname", required = false) final String nickname
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(nickname, memberId));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member Controller", description = "사용자 관련 API")
 public interface MemberControllerSwagger {
@@ -14,5 +15,7 @@ public interface MemberControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "사용자 조회에 성공했습니다.")
-    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(final Long memberId);
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
+            @RequestParam(name = "nickname", required = false) final String nickname
+    );
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -18,10 +18,23 @@ public class MemberService {
     private final MemberDataS3Client memberDataS3Client;
 
     @Transactional(readOnly = true)
-    public MemberProfileResponse getMemberProfile(final Long memberId) {
-        final Member member = memberRepository.findById(memberId).orElseThrow(
+    public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
+        final Long selectedMemberId = (nickname != null ) ? findMemberByNickname(nickname): memberId;
+        final Member member = memberRepository.findById(selectedMemberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
         );
         return MemberProfileResponse.of(member.getNickname(), memberDataS3Client.getPresignedUrl(member.getImage()));
+    }
+
+    private Long findMemberByNickname(String nickname) {
+        if (nickname != null) {
+            final Member member = memberRepository.findByNickname(nickname);
+            if (member == null) {
+                throw new CocosException((FailMessage.NOT_FOUND_MEMBER));
+            }
+            return member.getId();
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -365,7 +365,6 @@ public class PostService {
     @Transactional(readOnly = true)
     public MemberPostsResponse getMemberPosts(final Long memberId, final String nickname) {
         final Member member = findMember(memberId, nickname);
-        log.info(member.getId().toString());
         final List<Post> posts = postRepository.findAllByMemberId(member.getId());
         final Pet pet = petRepository.findByMemberId(member.getId());
         final Breed breed = breedRepository.findById(pet.getBreedId()).orElseThrow(
@@ -404,7 +403,12 @@ public class PostService {
 
     private Member findMember(final Long memberId, final String nickname) {
         if (nickname != null) {
-            return memberRepository.findByNickname(nickname);
+            final Member member =  memberRepository.findByNickname(nickname);
+            if (member == null) {
+                throw new CocosException(FailMessage.NOT_FOUND_MEMBER);
+            } else {
+                return member;
+            }
         }
         return memberRepository.findById(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #47 

## 👷 **작업한 내용**
- 멤버 조회 API에 nickname parameter 추가
- 나의 댓글 조회 API에 nickname parameter 추가
- 나의 게시글 조회 API에 nickname parameter 추가

## 🚨 **참고 사항**
- Member Controller 스웨거 누락되어있어서 추가했습니다. 
