### PR TITLE
Feat: 로그인, 로그아웃 및 토큰 재발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,14 @@ dependencies {
     implementation("software.amazon.awssdk:bom:2.21.0")
     implementation("software.amazon.awssdk:s3:2.21.0")
 
+    //jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    //spring security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -1,25 +1,44 @@
 package com.cocos.cocos.api.member.controller;
 
+import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
 import com.cocos.cocos.api.member.service.MemberService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.util.PrincipalHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("${api.prefix}/members")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberControllerSwagger{
     private static final Long memberId = 1L;
     private final MemberService memberService;
 
     @GetMapping
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile() {
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(memberId));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<LoginResponse>> login(
+            @RequestBody final LoginRequest loginRequest
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.login(loginRequest.code()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout() {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.logout(PrincipalHandler.getMemberIdFromPrincipal()));
+    }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<BaseResponse<ReissueTokenResponse>> reIssueToken() {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.reIssueToken(PrincipalHandler.getMemberIdFromPrincipal()));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -1,6 +1,9 @@
 package com.cocos.cocos.api.member.controller;
 
+import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,5 +17,25 @@ public interface MemberControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "사용자 조회에 성공했습니다.")
-    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(final Long memberId);
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile();
+
+    @Operation(summary = "로그인 API", description = "로그인 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인에 성공했습니다.")
+    public ResponseEntity<BaseResponse<LoginResponse>> login(final LoginRequest loginRequest);
+
+    @Operation(summary = "로그아웃 API", description = "로그아웃 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃에 성공했습니다.")
+    public ResponseEntity<BaseResponse<Void>> logout();
+
+    @Operation(summary = "토큰 재발급 API", description = "토큰 재발급 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "토큰 재발급에 성공했습니다.")
+    public ResponseEntity<BaseResponse<ReissueTokenResponse>> reIssueToken();
+
+
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.api.member.dto.request;
+
+import com.cocos.cocos.enums.member.Platform;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginRequest(
+        @Schema(description = "소셜 플랫폼", example = "KAKAO")
+        Platform platform,
+        @Schema(description = "코드", example = "egagasdgasdgdagdasgasgasdgdasgasdglkj")
+        String code
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/LoginResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(
+        @Schema(description = "토큰")
+        TokenResponse token,
+        @Schema(description = "기존 멤버 여부", example = "false")
+        boolean isCompletedSignUp
+) {
+    public static LoginResponse of(final TokenResponse token, final boolean isCompletedSignUp) {
+        return new LoginResponse(token, isCompletedSignUp);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberProfileResponse.java
@@ -1,7 +1,11 @@
 package com.cocos.cocos.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MemberProfileResponse(
+        @Schema(description = "닉네임", example = "모모")
         String nickname,
+        @Schema(description = "프로필 이미지", example = "http://~~")
         String profileImage
 ) {
     public static MemberProfileResponse of(final String nickname, final String profileImage) {

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReissueTokenResponse(
+        @Schema(description = "토큰")
+        TokenResponse tokens
+) {
+    public static ReissueTokenResponse of(final TokenResponse tokens) {
+        return new ReissueTokenResponse(tokens);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenResponse(
+        @Schema(description = "어세스 토큰", example = "egwg.adgad.asdgas")
+        String accessToken,
+        @Schema(description = "리프레시 토큰", example = "egwg.adgad.asdgas")
+        String refreshToken
+) {
+    public static TokenResponse of(final String accessToken, final String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -1,10 +1,18 @@
 package com.cocos.cocos.api.member.service;
 
+import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
+import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
+import com.cocos.cocos.api.member.dto.response.TokenResponse;
+import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.member.entity.Member;
+import com.cocos.cocos.db.member.entity.MemberToken;
 import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.db.member.repository.MemberTokenRepository;
+import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.external.KakaoLoginClient;
 import com.cocos.cocos.external.MemberDataS3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +24,9 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberDataS3Client memberDataS3Client;
+    private final KakaoLoginClient kakaoLoginClient;
+    private final JwtProvider jwtProvider;
+    private final MemberTokenRepository memberTokenRepository;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final Long memberId) {
@@ -24,4 +35,62 @@ public class MemberService {
         );
         return MemberProfileResponse.of(member.getNickname(), memberDataS3Client.getPresignedUrl(member.getImage()));
     }
+
+    @Transactional
+    public LoginResponse login(final String code) {
+        final String sub = kakaoLoginClient.login(code);
+        Member member = null;
+        boolean isCompletedSignUp;
+        if (memberRepository.existsBySub(sub)) {
+            member = memberRepository.findBySub(sub);
+
+            if (member.getNickname() == null) {
+                isCompletedSignUp = false;
+            } else {
+                isCompletedSignUp = true;
+            }
+        } else {
+            member = memberRepository.save(Member.builder()
+                    .email("")
+                    .image("")
+                    .isAdmin(false)
+                    .nickname("")
+                    .platform(Platform.KAKAO)
+                    .sub(sub)
+                    .build()
+            );
+            isCompletedSignUp = false;
+        }
+        final String accessToken = jwtProvider.generateAccessToken(member.getId());
+        final String refreshToken = jwtProvider.generateRefreshToken(member.getId());
+        if (memberTokenRepository.existsByMemberId(member.getId())) {
+            final MemberToken memberToken = memberTokenRepository.findByMemberId(member.getId());
+            memberToken.updateRefreshToken(refreshToken);
+        } else {
+            memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
+        }
+        return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
+    }
+
+    @Transactional
+    public Void logout(final Long memberId) {
+        if (memberTokenRepository.existsByMemberId(memberId)) {
+            memberTokenRepository.deleteByMemberId(memberId);
+        }
+        return null;
+    }
+
+    @Transactional
+    public ReissueTokenResponse reIssueToken(final Long memberId) {
+        if (memberTokenRepository.existsByMemberId(memberId)) {
+            final MemberToken memberToken = memberTokenRepository.findByMemberId(memberId);
+            final String accessToken = jwtProvider.generateAccessToken(memberToken.getMemberId());
+            final String refreshToken = jwtProvider.generateRefreshToken(memberToken.getMemberId());
+            memberToken.updateRefreshToken(refreshToken);
+            return ReissueTokenResponse.of(TokenResponse.of(accessToken, refreshToken));
+        }
+        return null;
+    }
+
 }
+

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
@@ -4,6 +4,7 @@ import com.cocos.cocos.api.post.service.PostLikeService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.util.PrincipalHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +21,7 @@ public class PostLikeController implements PostLikeControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> addPostLike(
             @PathVariable(name = "postId") final Long postId
     ) {
-        postLikeService.addPostLike(MEMBER_ID, postId);
+        postLikeService.addPostLike(PrincipalHandler.getMemberIdFromPrincipal(), postId);
         return SuccessResponse.success(SuccessMessage.OK, null);
     }
 

--- a/src/main/java/com/cocos/cocos/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/cocos/cocos/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.cocos.cocos.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/cocos/cocos/auth/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/cocos/cocos/auth/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.cocos.cocos.auth;
+
+import com.cocos.cocos.common.response.FailResponse;
+import com.cocos.cocos.enums.message.FailMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(FailResponse.failure(FailMessage.UNAUTHORIZED)));
+    }
+}

--- a/src/main/java/com/cocos/cocos/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cocos/cocos/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.cocos.cocos.auth;
+
+import com.cocos.cocos.common.exception.CocosException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.cocos.cocos.enums.auth.JwtValidationType.VALID_JWT;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            final String token = getJwtFromRequest(request);
+            if (jwtProvider.validateToken(token) == VALID_JWT) {
+                Long memberId = jwtProvider.getUserFromJwt(token);
+                MemberAuthentication authentication = MemberAuthentication.createMemberAuthentication(memberId);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info(authentication.toString());
+            }
+        } catch (CocosException exception) {
+            log.info(exception.getMessage());
+            // throw new UnAuthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cocos/cocos/auth/JwtProvider.java
+++ b/src/main/java/com/cocos/cocos/auth/JwtProvider.java
@@ -1,0 +1,101 @@
+package com.cocos.cocos.auth;
+
+import com.cocos.cocos.api.member.dto.response.TokenResponse;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.auth.JwtValidationType;
+import com.cocos.cocos.enums.message.FailMessage;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private static final String MEMBER_ID = "memberId";
+
+    //1분
+    //1주일 1000ms = 1초
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7;
+    // 3분
+    // 1주일
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7;
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    public TokenResponse reissueToken(Long memberId) {
+        return TokenResponse.of(
+                generateAccessToken(memberId),
+                generateRefreshToken(memberId)
+        );
+    }
+
+    public String generateAccessToken(Long memberId) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME));      // 만료 시간
+
+        claims.put(MEMBER_ID, memberId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME));      // 만료 시간
+
+        claims.put(MEMBER_ID, memberId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            throw new CocosException(FailMessage.UNAUTHORIZED_EXPIRATION_JWT_EXCEPTION);
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(MEMBER_ID).toString());
+    }
+
+}

--- a/src/main/java/com/cocos/cocos/auth/MemberAuthentication.java
+++ b/src/main/java/com/cocos/cocos/auth/MemberAuthentication.java
@@ -1,0 +1,16 @@
+package com.cocos.cocos.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class MemberAuthentication extends UsernamePasswordAuthenticationToken {
+    public MemberAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static MemberAuthentication createMemberAuthentication(Long memberId) {
+        return new MemberAuthentication(memberId, null, null);
+    }
+}

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -1,0 +1,75 @@
+package com.cocos.cocos.config;
+
+import com.cocos.cocos.auth.CustomAccessDeniedHandler;
+import com.cocos.cocos.auth.CustomJwtAuthenticationEntryPoint;
+import com.cocos.cocos.auth.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+
+    private static final String[] AUTH_WHITE_LIST = {"/api/dev/members/login",
+            "/swagger-ui/**",
+            "/api/dev/members/refresh",
+            "/v3/api-docs/**",
+    };
+
+    @Bean
+    @Profile("dev")
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception ->
+                {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                });
+
+
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    @Profile("local")
+    SecurityFilterChain securityFilterChainLocal(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception ->
+                {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                });
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/cocos/cocos/config/WebConfig.java
+++ b/src/main/java/com/cocos/cocos/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.cocos.cocos.util.PetProblemEnumConverter;
 import com.cocos.cocos.util.SortCriteriaEnumConverter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -13,5 +14,14 @@ public class WebConfig implements WebMvcConfigurer {
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new SortCriteriaEnumConverter());
         registry.addConverter(new PetProblemEnumConverter());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173", "https://www.cocos.r-e.kr/", "https://cocos-pet.kr")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/MemberToken.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/MemberToken.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.member.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,15 @@ public class MemberToken {
 
     @Column(name = "member_id", nullable = false)
     private Long memberId;
+
+    @Builder
+    public MemberToken(String refreshToken, String kakaoRefreshToken, Long memberId) {
+        this.refreshToken = refreshToken;
+        KakaoRefreshToken = kakaoRefreshToken;
+        this.memberId = memberId;
+    }
+
+    public void updateRefreshToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
@@ -7,4 +7,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByNickname(final String nickname);
+
+    boolean existsBySub(final String sub);
+
+    Member findBySub(final String sub);
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberTokenRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberTokenRepository.java
@@ -6,4 +6,14 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberTokenRepository extends JpaRepository<MemberToken, Long> {
+
+    MemberToken findByMemberId(final Long memberId);
+
+    boolean existsByMemberId(final Long memberId);
+
+    void deleteByMemberId(final Long memberId);
+
+    MemberToken findByRefreshToken(final String refreshToken);
+
+    boolean existsByRefreshToken(final String refreshToken);
 }

--- a/src/main/java/com/cocos/cocos/enums/auth/JwtValidationType.java
+++ b/src/main/java/com/cocos/cocos/enums/auth/JwtValidationType.java
@@ -1,0 +1,10 @@
+package com.cocos.cocos.enums.auth;
+
+public enum JwtValidationType {
+    VALID_JWT,
+    INVALID_JWT_SIGNATURE,
+    INVALID_JWT_TOKEN,
+    EXPIRED_JWT_TOKEN,
+    UNSUPPORTED_JWT_TOKEN,
+    EMPTY_JWT
+}

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -21,6 +21,9 @@ public enum FailMessage {
      * 401
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증이 필요합니다. "),
+    UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, 40101, "인증되지 않은 사용자 입니다."),
+    UNAUTHORIZED_EXPIRATION_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, 40102, "기간이 만료된 토큰입니다."),
+
 
     /**
      * 403

--- a/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
+++ b/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
@@ -1,0 +1,54 @@
+package com.cocos.cocos.external;
+
+import com.cocos.cocos.external.login.dto.KakaoAccessTokenResponse;
+import com.cocos.cocos.external.login.dto.KakaoInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j
+@Component
+public class KakaoLoginClient {
+
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+    @Value("${kakao.redirect-url}")
+    private String kakaoRedirectUrl;
+
+    public String login(final String code) {
+
+        RestClient restClient = RestClient.create();
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/token")
+                .queryParam("code", "{code}")
+                .queryParam("client_id", "{client_id}")
+                .queryParam("redirect_uri", "{redirect_uri}")
+                .queryParam("grant_type", "{grant_type}")
+                .encode()
+                .buildAndExpand(code, kakaoClientId, kakaoRedirectUrl, "authorization_code")
+                .toUri();
+
+        KakaoAccessTokenResponse kakaoAccessTokenResponse = restClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .retrieve()
+                .body(KakaoAccessTokenResponse.class);
+
+
+        log.info(kakaoAccessTokenResponse.accessToken());
+
+        KakaoInfoResponse kakaoInfoResponse = restClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .header("Authorization", "Bearer " + kakaoAccessTokenResponse.accessToken())
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .body(KakaoInfoResponse.class);
+
+        return kakaoInfoResponse.id();
+    }
+}

--- a/src/main/java/com/cocos/cocos/external/login/dto/KakaoAccessTokenResponse.java
+++ b/src/main/java/com/cocos/cocos/external/login/dto/KakaoAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.cocos.cocos.external.login.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoAccessTokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/com/cocos/cocos/external/login/dto/KakaoAccount.java
+++ b/src/main/java/com/cocos/cocos/external/login/dto/KakaoAccount.java
@@ -1,0 +1,6 @@
+package com.cocos.cocos.external.login.dto;
+
+public record KakaoAccount(
+        String email
+) {
+}

--- a/src/main/java/com/cocos/cocos/external/login/dto/KakaoInfoResponse.java
+++ b/src/main/java/com/cocos/cocos/external/login/dto/KakaoInfoResponse.java
@@ -1,0 +1,6 @@
+package com.cocos.cocos.external.login.dto;
+
+public record KakaoInfoResponse(
+        String id
+) {
+}

--- a/src/main/java/com/cocos/cocos/test/controller/TestController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestController.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.test.controller;
 
+import com.cocos.cocos.util.PrincipalHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/test")
+@RequestMapping("/api/dev/test")
 public class TestController implements TestControllerSwagger {
 
     @GetMapping("/health-check")
@@ -18,5 +19,10 @@ public class TestController implements TestControllerSwagger {
     @GetMapping("/token-check")
     public ResponseEntity<String> tokenCheck(final HttpServletRequest request) {
         return ResponseEntity.ok("token : " + request.getHeader("Authorization"));
+    }
+
+    @GetMapping("/token-valid")
+    public ResponseEntity<String> tokenValid() {
+        return ResponseEntity.ok(PrincipalHandler.getMemberIdFromPrincipal().toString());
     }
 }

--- a/src/main/java/com/cocos/cocos/util/PrincipalHandler.java
+++ b/src/main/java/com/cocos/cocos/util/PrincipalHandler.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.util;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrincipalHandler {
+
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    public static Long getMemberIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    private static void isPrincipalNull(
+            final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new CocosException(FailMessage.UNAUTHORIZED_MEMBER);
+        }
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #41 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 카카오 로그인 구현했습니다.
* 로그아웃 구현했습니다.
* 토큰 재발급 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->

* yml파일 업데이트 되어서 그거 노션에 업로드 했습니다.