### PR TITLE
Feat: 닉네임 중복 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -40,6 +40,14 @@ public class MemberController implements MemberControllerSwagger {
         return SuccessResponse.success(SuccessMessage.OK, nicknameExistenceResponse);
     }
 
+    @GetMapping("/check")
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> checkNickname(
+            @RequestParam(name = "nickname") final String nickname
+    ) {
+        final NicknameExistenceResponse nicknameExistenceResponse = memberService.checkNickname(nickname);
+        return SuccessResponse.success(SuccessMessage.OK, nicknameExistenceResponse);
+    }
+
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<LoginResponse>> login(
             @RequestBody final LoginRequest loginRequest

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -46,4 +46,10 @@ public interface MemberControllerSwagger {
             responseCode = "200",
             description = "요청에 성공했습니다. ")
     public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(@RequestParam final String nickname);
+
+    @Operation(summary = "닉네임 중복 조회 API", description = "중복된 닉네임이 있는지 검사합니다. ")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다. ")
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> checkNickname(@RequestParam final String nickname);
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -119,5 +119,14 @@ public class MemberService {
 
         }
     }
+
+    public NicknameExistenceResponse checkNickname(final String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            return NicknameExistenceResponse.of(true);
+        } else {
+            return NicknameExistenceResponse.of(false);
+
+        }
+    }
 }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #59 

## 👷 **작업한 내용**
- 닉네임 중복 조회 API 구현

## 🚨 **참고 사항**
- 이전 API는 그대로 뒀습니다. 
