### PR TITLE
Fix: 댓글 삭제 파라미터 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -28,11 +28,11 @@ public class CommentController implements CommentControllerSwagger {
         return SuccessResponse.success(SuccessMessage.CREATED, null);
     }
 
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/{commentId}")
     public ResponseEntity<BaseResponse<Void>> deletePostComment(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "commentId") final Long commentId
     ) {
-        commentService.deletePostComment(postId, memberId);
+        commentService.deletePostComment(commentId, memberId);
         return SuccessResponse.success(SuccessMessage.OK,null);
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #64 

## 👷 **작업한 내용**
- 댓글 삭제 파라미터가 postId로 잘못들어가있어서 commentId로 수정했습니다. 

## 🚨 **참고 사항**
