### PR TITLE
Fix: 대댓글 추가 시 언급된 사용자가 유효한지 확인하는 로직 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -62,6 +62,9 @@ public class CommentService {
     @Transactional
     public void addPostSubComment(final Long commentId, final Long mentionedMemberId, final String content, final Long memberId) {
         validateCommentExists(commentId);
+        if (!memberRepository.existsById(mentionedMemberId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_MENTIONED_MEMBER);
+        }
         subCommentRepository.save(
                 SubComment.builder()
                         .commentId(commentId)

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -50,6 +50,7 @@ public enum FailMessage {
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, 40413, "댓글을 찾을 수 없습니다."),
     NOT_FOUND_SUB_COMMENT(HttpStatus.NOT_FOUND, 40414, "대댓글을 찾을 수 없습니다."),
     NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "애완동물을 찾을 없습니다. "),
+    NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
     /**
      * 405
      */


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #66 

## 👷 **작업한 내용**
- 대댓글 추가 시 언급된 사용자가 유효한지 확인하는 로직 추가

## 🚨 **참고 사항**
