### PR TITLE
Fix: s3에서 이미지 가져올 때 조합하지 않고 가져오도록 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -127,7 +127,7 @@ public class CommentService {
                                     .map(subComment -> SubCommentResponse.of(
                                             subComment.getId(),
                                             getOrDefaultNickname(subComment.getMemberId(), memberMap),
-                                            memberDataS3Client.getPresignedUrl(subComment.getMemberId() + "/" + getOrDefaultProfileImage(subComment.getMemberId(), memberMap)),
+                                            memberDataS3Client.getPresignedUrl(getOrDefaultProfileImage(subComment.getMemberId(), memberMap)),
                                             getOrDefaultBreedName(subComment.getMemberId(), petMap, breedMap),
                                             getOrDefaultPetAge(subComment.getMemberId(), petMap),
                                             subComment.getContent(),
@@ -139,7 +139,7 @@ public class CommentService {
                     return CommentAndSubCommentsResponse.of(
                             comment.getId(),
                             getOrDefaultNickname(comment.getMemberId(), memberMap),
-                            memberDataS3Client.getPresignedUrl(comment.getMemberId() + "/" + getOrDefaultProfileImage(comment.getMemberId(), memberMap)),
+                            memberDataS3Client.getPresignedUrl(getOrDefaultProfileImage(comment.getMemberId(), memberMap)),
                             getOrDefaultBreedName(comment.getMemberId(), petMap, breedMap),
                             getOrDefaultPetAge(comment.getMemberId(), petMap),
                             comment.getContent(),


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #81 

## 👷 **작업한 내용**
- 댓글조회할 때 s3에서 이미지 가져올 때 조합하지 않고 가져오도록 수정

## 🚨 **참고 사항**
- 댓글 조회할 때는 s3에서 조합하도록 되어있어서 조합하지 않는 방식으로 수정했습니다! 
