### PR TITLE
Fix: 대댓글 테스트 ID 오류 수정

### DIFF
--- a/src/test/java/com/cocos/cocos/comment/CommentServiceTest.java
+++ b/src/test/java/com/cocos/cocos/comment/CommentServiceTest.java
@@ -148,7 +148,7 @@ class CommentServiceTest {
         commentService.deletePostSubComment(subCommentId, memberId);
 
         // then
-        BDDMockito.verify(subCommentRepository, times(1)).deleteById(commentId);
+        BDDMockito.verify(subCommentRepository, times(1)).deleteById(subCommentId);
     }
 
     @Test


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #90 

## 👷 **작업한 내용**
- 테스트 파일에 subCommentId가 commentId로 잘못들어가있어 테스트 오류나는 것을 수정했습니다. 

## 🚨 **참고 사항**
