### PR TITLE
Fix: 사용자 댓글 조회 시 게시글을 찾을 수 없는 오류 해결

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -157,12 +157,9 @@ public class CommentService {
     }
 
     public MyAllCommentsResponse getMemberComments(final String nickname, final Long memberId) {
-        final Long selectedMemberId = (nickname != null ) ? findMemberByNickname(nickname): memberId;
-        final List<Comment> comments = commentRepository.findByMemberIdOrderByCreatedAtAsc(selectedMemberId);
-        final List<Long> commentIds = comments.stream()
-                .map(Comment::getId)
-                .toList();
-        final List<SubComment> subComments = subCommentRepository.findByCommentIdInOrderByCreatedAtAsc(commentIds);
+        final Long selectedMemberId = findMemberByNickname(nickname, memberId);
+
+        final List<Comment> comments = commentRepository.findAllByMemberIdOrderByCreatedAtDesc(selectedMemberId);
         final List<MyCommentResponse> myComments = comments.stream()
                 .map(comment -> {
                     final String postTitle = postRepository.findById(comment.getPostId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_POST)).getTitle();
@@ -175,12 +172,14 @@ public class CommentService {
                     );
                 }).toList();
 
+        final List<SubComment> subComments = subCommentRepository.findAllByMemberIdOrderByCreatedAtDesc(selectedMemberId);
         final List<MySubCommentResponse> mySubComments = subComments.stream()
                 .map(subComment -> {
                     final Comment comment = commentRepository.findById(subComment.getCommentId()).orElseThrow(
                             () -> new CocosException(FailMessage.NOT_FOUND_COMMENT)
                     );
-                    final Post post = postRepository.findById(comment.getId()).orElseThrow(
+
+                    final Post post = postRepository.findById(comment.getPostId()).orElseThrow(
                             () -> new CocosException(FailMessage.NOT_FOUND_POST)
                     );
 
@@ -196,7 +195,7 @@ public class CommentService {
                             mentionedMember.getNickname()
                     );
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         return MyAllCommentsResponse.of(
                 myComments,
@@ -249,7 +248,7 @@ public class CommentService {
                 .orElseThrow(() -> new CocosException(FailMessage.INTERNAL_SERVER_ERROR_PET_AGE));
     }
 
-    private Long findMemberByNickname(String nickname) {
+    private Long findMemberByNickname(final String nickname, final Long memberId) {
         if (nickname != null) {
             final Member member = memberRepository.findByNickname(nickname);
             if (member == null) {
@@ -257,7 +256,7 @@ public class CommentService {
             }
             return member.getId();
         } else {
-            return null;
+            return memberId;
         }
     }
 }

--- a/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
@@ -18,6 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
 
-    List<Comment> findByMemberIdOrderByCreatedAtAsc(final Long memberId);
+    List<Comment> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
 
 }

--- a/src/main/java/com/cocos/cocos/db/comment/repository/SubCommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/SubCommentRepository.java
@@ -16,5 +16,5 @@ public interface SubCommentRepository extends JpaRepository<SubComment, Long> {
 
     List<SubComment> findByCommentIdInOrderByCreatedAtAsc(@Param("commentId") List<Long> commentId);
 
-    List<SubComment> findByMemberIdOrderByCreatedAtAsc(final Long memberId);
+    List<SubComment> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #105 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 대댓글에서 댓글을 추출하고 댓글의 자체 아이디가 아닌 postId를 넘기도록 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
