### PR TITLE
Fix: 게시글 대댓글 추가 API에서 nickname을 넘겨받도록 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -42,7 +42,7 @@ public class CommentController implements CommentControllerSwagger {
             @PathVariable(name = "commentId") final Long commentId,
             @RequestBody final SubCommentContentRequest body
     ) {
-        commentService.addPostSubComment(commentId, body.mentionedMemberId(), body.content(), PrincipalHandler.getMemberIdFromPrincipal());
+        commentService.addPostSubComment(commentId, body.nickname(), body.content(), PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, null);
     }
 

--- a/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
@@ -3,12 +3,12 @@ package com.cocos.cocos.api.comment.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SubCommentContentRequest(
-        @Schema(description = "언급된 멤버의 아이디 정보입니다. ", example = "1")
-        Long mentionedMemberId,
+        @Schema(description = "언급된 멤버의 닉네임 정보입니다. ", example = "nickname")
+        String nickname,
         @Schema(description = "댓글 내용", example = "댓글의 내용입니다. ")
         String content
 ) {
-    public static SubCommentContentRequest of(final Long mentionedMemberId, final String content) {
-        return new SubCommentContentRequest(mentionedMemberId, content);
+    public static SubCommentContentRequest of(final String nickname, final String content) {
+        return new SubCommentContentRequest(nickname, content);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -62,9 +62,9 @@ public class CommentService {
     }
 
     @Transactional
-    public void addPostSubComment(final Long commentId, final Long mentionedMemberId, final String content, final Long memberId) {
+    public void addPostSubComment(final Long commentId, final String nickname, final String content, final Long memberId) {
         validateCommentExists(commentId);
-        if (!memberRepository.existsById(mentionedMemberId)) {
+        if (!memberRepository.existsByNickname(nickname)) {
             throw new CocosException(FailMessage.NOT_FOUND_MENTIONED_MEMBER);
         }
 
@@ -72,7 +72,7 @@ public class CommentService {
         subCommentRepository.save(
                 SubComment.builder()
                         .commentId(commentId)
-                        .mentionedMemberId(mentionedMemberId)
+                        .mentionedMemberId(memberRepository.findByNickname(nickname).getId())
                         .content(content)
                         .memberId(memberId)
                         .build()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #107 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 클쌤요청에 따라 게시글 대댓글 추가 API에서 언급된 멤버 아이디 대신 nickname을 넘겨 받도록 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
