### PR TITLE
Fix: 사용자 맞춤 인기글이 5개 미만일 경우 전체 중 인기글 5개 반환하도록 수정(데모데이용)

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -218,7 +218,11 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PopularPostsResponse getPopularPosts(final Long memberId) {
-        final List<Post> popularPosts = fetchPopularPosts(memberId);
+        List<Post> popularPosts = fetchPopularPosts(memberId);
+        //ToDo: 데모데이 이후 final List<Post> popularPosts로 수정 후 아래 if 문 삭제 필요
+        if (popularPosts.size() < 5) {
+            popularPosts = postRepository.findTop5ByLikeCountDesc();
+        }
         return PopularPostsResponse.of(
                 popularPosts.stream()
                         .map(popularPost -> PopularPostResponse.of(popularPost.getId(), popularPost.getTitle()))


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #122 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 사용자 맞춤 인기글이 5개 미만일 경우 전체 . 중인기글 5개 반환하도록 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
