### PR TITLE
Fix: 게시글 작성자와 현재 사용자가 작성한 댓글, 대댓글, 게시글을 구별하는 필드 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/dto/response/CommentAndSubCommentsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/response/CommentAndSubCommentsResponse.java
@@ -22,11 +22,13 @@ public record CommentAndSubCommentsResponse(
         LocalDateTime createdAt,
         @Schema(description = "작성자여부", example = "true")
         boolean isWriter,
+        @Schema(description = "게시글 작성자 여부", example = "false")
+        boolean isPostWriter,
         @Schema(description = "대댓글 리스트")
         List<SubCommentResponse> subComments
 ) {
-    public static CommentAndSubCommentsResponse of(final Long id, final String nickname, final String profileImage, final String breed, final int petAge, final String content, final LocalDateTime createdAt, final boolean isWriter, final List<SubCommentResponse> subComments) {
-        return new CommentAndSubCommentsResponse(id, nickname, profileImage, breed, petAge, content, createdAt, isWriter, List.copyOf(subComments));
+    public static CommentAndSubCommentsResponse of(final Long id, final String nickname, final String profileImage, final String breed, final int petAge, final String content, final LocalDateTime createdAt, final boolean isWriter, final boolean isPostWriter, final List<SubCommentResponse> subComments) {
+        return new CommentAndSubCommentsResponse(id, nickname, profileImage, breed, petAge, content, createdAt, isWriter, isPostWriter, List.copyOf(subComments));
     }
 }
 

--- a/src/main/java/com/cocos/cocos/api/comment/dto/response/SubCommentResponse.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/response/SubCommentResponse.java
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record SubCommentResponse(
-        @Schema(description = "대댓글 아이디",example = "1")
+        @Schema(description = "대댓글 아이디", example = "1")
         Long id,
-        @Schema(description = "대댓글 사용자 닉네임",example = "닉네임2")
+        @Schema(description = "대댓글 사용자 닉네임", example = "닉네임2")
         String nickname,
-        @Schema(description = "대댓글 사용자 프로필 사진",example = "https://")
+        @Schema(description = "대댓글 사용자 프로필 사진", example = "https://")
         String profileImage,
-        @Schema(description = "대댓글 사용자 애완동물 종",example = "포메라니안")
+        @Schema(description = "대댓글 사용자 애완동물 종", example = "포메라니안")
         String breed,
         @Schema(description = "애완동물 나이", example = "12")
         int petAge,
@@ -19,12 +19,14 @@ public record SubCommentResponse(
         String content,
         @Schema(description = "생성일", example = "2025-01-01T00:00:00")
         LocalDateTime createdAt,
-        @Schema(description = "작성자 여부",example = "true")
+        @Schema(description = "작성자 여부", example = "true")
         boolean isWriter,
         @Schema(description = "언급 표시를 위한 사용자 닉네임", example = "빵빵이")
-        String mentionedNickname
+        String mentionedNickname,
+        @Schema(description = "게시글 작성자 여부", example = "false")
+        boolean isPostWriter
 ) {
-    public static SubCommentResponse of(final Long id, final String nickname, final String profileImage, final String breed, final int petAge, final String content, LocalDateTime createdAt, final boolean isWriter, final String mentionedNickname) {
-        return new SubCommentResponse(id, nickname, profileImage, breed, petAge, content, createdAt, isWriter, mentionedNickname);
+    public static SubCommentResponse of(final Long id, final String nickname, final String profileImage, final String breed, final int petAge, final String content, LocalDateTime createdAt, final boolean isWriter, final String mentionedNickname, final boolean isPostWriter) {
+        return new SubCommentResponse(id, nickname, profileImage, breed, petAge, content, createdAt, isWriter, mentionedNickname, isPostWriter);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -93,6 +93,10 @@ public class CommentService {
     public CommentsAndSubCommentsResponse getPostComments(final Long postId, final Long memberId) {
         validatePostExists(postId);
 
+        final Post post = postRepository.findById(postId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_POST)
+        );
+
         final List<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId);
         final List<Long> commentIds = comments.stream()
                 .map(Comment::getId)
@@ -137,7 +141,8 @@ public class CommentService {
                                             subComment.getContent(),
                                             subComment.getCreatedAt(),
                                             subComment.getMemberId().equals(memberId),
-                                            getOrDefaultNickname(subComment.getMentionedMemberId(), memberMap)
+                                            getOrDefaultNickname(subComment.getMentionedMemberId(), memberMap),
+                                            subComment.getMemberId().equals(post.getMemberId())
                                     )).toList();
 
                     return CommentAndSubCommentsResponse.of(
@@ -149,6 +154,7 @@ public class CommentService {
                             comment.getContent(),
                             comment.getCreatedAt(),
                             comment.getMemberId().equals(memberId),
+                            comment.getMemberId().equals(post.getMemberId()),
                             subCommentDtos
                     );
                 }).toList();


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #127 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 게시글 작성자와 현재 사용자가 작성한 댓글, 대댓글, 게시글을 구별하는 필드 추가

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
