### PR TITLE
Refactor: 댓글 조회 API를 제외한 품종 및 댓글 관련 코드 리팩토링

### DIFF
--- a/src/main/java/com/cocos/cocos/api/breed/controller/BreedController.java
+++ b/src/main/java/com/cocos/cocos/api/breed/controller/BreedController.java
@@ -18,7 +18,6 @@ public class BreedController implements BreedControllerSwagger {
 
     @GetMapping("/{animalId}")
     public ResponseEntity<BaseResponse<BreedsResponse>> getBreeds(
-            //ToDo: breedName을 굳이 넘겨받아야 하나 고민 중, 개발 중 우리는 단순히 전체 종 리스트만 넘겨주면 종을 찾는 건 클쌤들 측에서 처리를 하는 것도 좋아보임
             @RequestParam(name = "breedName", required = false) final String breedName,
             @PathVariable(name = "animalId") final Long animalId
     ) {

--- a/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
+++ b/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
@@ -23,12 +23,12 @@ public class BreedService {
             return BreedsResponse.of(allBreeds.stream()
                     .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
                     .toList());
+        } else {
+            final List<Breed> breeds = breedRepository.findAllByNameContainingAndAnimalId(breedName, animalId);
+            return BreedsResponse.of(breeds.stream()
+                    .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
+                    .toList()
+            );
         }
-        //ToDo: 의미 분명하게 하기 위해 else문 사용도 좋아보임
-        final List<Breed> breeds = breedRepository.findAllByNameContainingAndAnimalId(breedName, animalId);
-        return BreedsResponse.of(breeds.stream()
-                .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
-                .toList()
-        );
     }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.util.validation.EntityExistsValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,14 +20,16 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController implements CommentControllerSwagger {
 
     private final CommentService commentService;
+    private final EntityExistsValidator entityExistsValidator;
 
     @PostMapping("/{postId}")
     public ResponseEntity<BaseResponse<Void>> addPostComment(
             @PathVariable(name = "postId") final Long postId,
-            //ToDo: body보다 정확한 이름을 명시해주는 것이 좋아 보임. (ex: commentContentRequest)
-            @RequestBody final CommentContentRequest body
+            @RequestBody final CommentContentRequest commentContentRequest
     ) {
-        commentService.addPostComment(postId, body.content(), PrincipalHandler.getMemberIdFromPrincipal());
+        entityExistsValidator.validatePostByPostId(postId);
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
+        commentService.addPostComment(postId, commentContentRequest.content(), PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, null);
     }
 
@@ -34,6 +37,7 @@ public class CommentController implements CommentControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> deletePostComment(
             @PathVariable(name = "commentId") final Long commentId
     ) {
+        entityExistsValidator.validateCommentByCommentId(commentId);
         commentService.deletePostComment(commentId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }
@@ -41,10 +45,12 @@ public class CommentController implements CommentControllerSwagger {
     @PostMapping("/sub/{commentId}")
     public ResponseEntity<BaseResponse<Void>> addPostSubComment(
             @PathVariable(name = "commentId") final Long commentId,
-            //ToDo: body보다 정확한 이름을 명시해주는 것이 좋아 보임.
-            @RequestBody final SubCommentContentRequest body
+            @RequestBody final SubCommentContentRequest subCommentContentRequest
     ) {
-        commentService.addPostSubComment(commentId, body.nickname(), body.content(), PrincipalHandler.getMemberIdFromPrincipal());
+        entityExistsValidator.validateCommentByCommentId(commentId);
+        entityExistsValidator.validateMemberByNickname(subCommentContentRequest.nickname());
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
+        commentService.addPostSubComment(commentId, subCommentContentRequest.nickname(), subCommentContentRequest.content(), PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, null);
     }
 
@@ -52,6 +58,7 @@ public class CommentController implements CommentControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> deletePostSubComment(
             @PathVariable(name = "subCommentId") final Long subCommentId
     ) {
+        entityExistsValidator.validateSubCommentBySubCommentId(subCommentId);
         commentService.deletePostSubComment(subCommentId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }
@@ -60,8 +67,7 @@ public class CommentController implements CommentControllerSwagger {
     public ResponseEntity<BaseResponse<CommentsAndSubCommentsResponse>> getPostComments(
             @PathVariable(name = "postId") final Long postId
     ) {
-        final CommentsAndSubCommentsResponse postComments = commentService.getPostComments(postId, PrincipalHandler.getMemberIdFromPrincipal());
-        return SuccessResponse.success(SuccessMessage.OK, postComments);
+        return SuccessResponse.success(SuccessMessage.OK, commentService.getPostComments(postId, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
     @GetMapping("/members")

--- a/src/main/java/com/cocos/cocos/api/comment/dto/request/CommentContentRequest.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/request/CommentContentRequest.java
@@ -6,8 +6,4 @@ public record CommentContentRequest(
         @Schema(description = "댓글 내용", example = "댓글의 내용입니다. ")
         String content
 ) {
-    //ToDo: 이 부분은 없어도 될 것 같음. request를 직접 만드는 경우가 없음
-    public static CommentContentRequest of(final String content) {
-        return new CommentContentRequest(content);
-    }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
@@ -8,8 +8,4 @@ public record SubCommentContentRequest(
         @Schema(description = "댓글 내용", example = "댓글의 내용입니다. ")
         String content
 ) {
-    //ToDo: 이 부분은 없어도 될 것 같음. request를 직접 만드는 경우가 없음
-    public static SubCommentContentRequest of(final String nickname, final String content) {
-        return new SubCommentContentRequest(nickname, content);
-    }
 }

--- a/src/main/java/com/cocos/cocos/api/comment/dto/response/MyCommentResponse.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/response/MyCommentResponse.java
@@ -16,7 +16,6 @@ public record MyCommentResponse(
         @Schema(description = "댓글 생성일", example = "2025-01-01T00:00:00")
         LocalDateTime createdAt
 ) {
-    //ToDo: cmd + option + L로 항상 정렬 필요
     public static MyCommentResponse of(final Long id, final String content, final Long postId, final String postTitle, final LocalDateTime createdAt) {
         return new MyCommentResponse(id, content, postId, postTitle, createdAt);
     }

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -16,9 +16,9 @@ import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.repository.PostRepository;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.MemberDataS3Client;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -39,10 +39,6 @@ public class CommentService {
 
     @Transactional
     public void addPostComment(final Long postId, final String content, final Long memberId) {
-        //ToDo: 네이밍 통일이 필요해 보임
-        validatePostExists(postId);
-        validatePet(memberId);
-
         commentRepository.save(
                 Comment.builder()
                         .content(content)
@@ -54,25 +50,19 @@ public class CommentService {
 
     @Transactional
     public void deletePostComment(final Long commentId, final Long memberId) {
-        //ToDo: validateCommentExists라는 네이밍과는 역할이 조금 다른 것 같음. 댓글을 찾는 것과 유효성을 검사하는 작업은 분리가 되는 것이 더 적합해 보임(유효성을 검사하는 클래스를 따로 빼도 좋을 것 같음)
-        final Comment comment = validateCommentExists(commentId);
+        final Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_COMMENT)
+        );
+
         if (!comment.getMemberId().equals(memberId)) {
             throw new CocosException(FailMessage.FORBIDDEN_COMMENT_DELETE);
         }
         commentRepository.deleteById(commentId);
-        //ToDo: 대댓글도 다 삭제 되는 거 보다 에브리타임처럼 댓글만 삭제되고 "삭제된 댓글입니다" 표시만 나오는 거로 해야하는지
         subCommentRepository.deleteAllByCommentId(comment.getId());
     }
 
     @Transactional
     public void addPostSubComment(final Long commentId, final String nickname, final String content, final Long memberId) {
-        validateCommentExists(commentId);
-        //Todo: 유효성 검사를 하는 메소드를 따로 빼는 것을 통일시키는 것도 좋아보임
-        if (!memberRepository.existsByNickname(nickname)) {
-            throw new CocosException(FailMessage.NOT_FOUND_MENTIONED_MEMBER);
-        }
-
-        validatePet(memberId);
         subCommentRepository.save(
                 SubComment.builder()
                         .commentId(commentId)
@@ -93,11 +83,9 @@ public class CommentService {
         }
         subCommentRepository.deleteById(subComment.getId());
     }
-    //ToDo: @Transactional(readOnly = true) 필요. -> 혹여나 이 메소드 안에서 DB 변화가 일어나는 것을 막아줌
-    public CommentsAndSubCommentsResponse getPostComments(final Long postId, final Long memberId) {
-        //ToDo : validatePostExists와 아래 findById는 역할이 비슷해 보임 여기서는 validatePostExists가 없어도 좋아보임
-        validatePostExists(postId);
 
+    @Transactional(readOnly = true)
+    public CommentsAndSubCommentsResponse getPostComments(final Long postId, final Long memberId) {
         final Post post = postRepository.findById(postId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_POST)
         );
@@ -168,7 +156,7 @@ public class CommentService {
         return CommentsAndSubCommentsResponse.of(commentDtos);
     }
 
-    //ToDo: @Transactional(readOnly = true) 필요. -> 혹여나 이 메소드 안에서 DB 변화가 일어나는 것을 막아줌
+    @Transactional(readOnly = true)
     public MyAllCommentsResponse getMemberComments(final String nickname, final Long memberId) {
         final Long selectedMemberId = findMemberByNickname(nickname, memberId);
 
@@ -214,24 +202,6 @@ public class CommentService {
                 myComments,
                 mySubComments
         );
-    }
-
-    private void validatePet(Long memberId) {
-        if (!petRepository.existsByMemberId(memberId)) {
-            throw new CocosException(FailMessage.NOT_FOUND_PET);
-        }
-    }
-
-    private Comment validateCommentExists(Long commentId) {
-        return commentRepository.findById(commentId).orElseThrow(
-                () -> new CocosException(FailMessage.NOT_FOUND_COMMENT)
-        );
-    }
-
-    private void validatePostExists(Long postId) {
-        if (!postRepository.existsById(postId)) {
-            throw new CocosException(FailMessage.NOT_FOUND_POST);
-        }
     }
 
     private String getOrDefaultNickname(Long memberId, Map<Long, Member> memberMap) {

--- a/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
@@ -19,5 +19,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
 
     List<Comment> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
-
 }

--- a/src/main/java/com/cocos/cocos/util/annotations/Validator.java
+++ b/src/main/java/com/cocos/cocos/util/annotations/Validator.java
@@ -1,7 +1,0 @@
-package com.cocos.cocos.util.annotations;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public @interface Validator {
-}

--- a/src/main/java/com/cocos/cocos/util/annotations/Validator.java
+++ b/src/main/java/com/cocos/cocos/util/annotations/Validator.java
@@ -1,0 +1,7 @@
+package com.cocos.cocos.util.annotations;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public @interface Validator {
+}

--- a/src/main/java/com/cocos/cocos/util/validation/EntityExistsValidator.java
+++ b/src/main/java/com/cocos/cocos/util/validation/EntityExistsValidator.java
@@ -8,10 +8,10 @@ import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.pet.repository.PetRepository;
 import com.cocos.cocos.db.post.repository.PostRepository;
 import com.cocos.cocos.enums.message.FailMessage;
-import com.cocos.cocos.util.annotations.Validator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-@Validator
+@Component
 @RequiredArgsConstructor
 public class EntityExistsValidator {
 

--- a/src/main/java/com/cocos/cocos/util/validation/EntityExistsValidator.java
+++ b/src/main/java/com/cocos/cocos/util/validation/EntityExistsValidator.java
@@ -1,0 +1,54 @@
+package com.cocos.cocos.util.validation;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.breed.repository.BreedRepository;
+import com.cocos.cocos.db.comment.repository.CommentRepository;
+import com.cocos.cocos.db.comment.repository.SubCommentRepository;
+import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.util.annotations.Validator;
+import lombok.RequiredArgsConstructor;
+
+@Validator
+@RequiredArgsConstructor
+public class EntityExistsValidator {
+
+    private final CommentRepository commentRepository;
+    private final SubCommentRepository subCommentRepository;
+    private final MemberRepository memberRepository;
+    private final PetRepository petRepository;
+    private final BreedRepository breedRepository;
+    private final PostRepository postRepository;
+
+    public void validatePostByPostId(final Long postId) {
+        if (!postRepository.existsById(postId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_POST);
+        }
+    }
+
+    public void validatePetByMemberId(final Long memberId) {
+        if (!petRepository.existsByMemberId(memberId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_PET);
+        }
+    }
+
+    public void validateCommentByCommentId(final Long commentId) {
+        if (!commentRepository.existsById(commentId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_COMMENT);
+        }
+    }
+
+    public void validateMemberByNickname(final String nickname) {
+        if (!memberRepository.existsByNickname(nickname)) {
+            throw new CocosException(FailMessage.NOT_FOUND_MENTIONED_MEMBER);
+        }
+    }
+
+    public void validateSubCommentBySubCommentId(final Long subCommentId) {
+        if (!subCommentRepository.existsById(subCommentId)) {
+            throw new CocosException(FailMessage.NOT_FOUND_SUB_COMMENT);
+        }
+    }
+}

--- a/src/test/java/com/cocos/cocos/comment/CommentServiceTest.java
+++ b/src/test/java/com/cocos/cocos/comment/CommentServiceTest.java
@@ -109,7 +109,7 @@ class CommentServiceTest {
         final Long memberId = 1L;
         final String content = "댓글 내용";
         final Long commentId = 1L;
-        final Long mentionedMemberId = 2L;
+        final String nickname = "닉네임";
 
         Comment comment = Comment.builder()
                 .content("댓글 내용")
@@ -121,7 +121,7 @@ class CommentServiceTest {
         BDDMockito.given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
 
         // when
-        commentService.addPostSubComment(commentId, mentionedMemberId, content, memberId);
+        commentService.addPostSubComment(commentId, nickname, content, memberId);
 
         // then
         BDDMockito.verify(subCommentRepository, times(1)).save(any(SubComment.class));


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #137 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 댓글을 조회하는 API를 제외한 품종 및 댓글 관련 코드를 리팩토링 했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 엔티티가 존재하는지 유효성을 검사하는 Validator를 들었습니다.
* validator를 통해 controller에서 검사를 진행하는데 findById에서 Optional이 필요한지 의문입니다. 예를 들어서 Controller단계에서 이미 postId를 통해 게시글이 존재하는지 한 번 판단을 하는데, service에서 findById(postId).orElseThrow()를 통해 한 번 더 확인하는 작업이 불필요한 작업인지, 아니면 중복으로 확인하는 작업인지에 대한 의견이 궁금합니다..!!