### PR TITLE
feat: 지역 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/location/controller/LocationController.java
+++ b/src/main/java/com/cocos/cocos/api/location/controller/LocationController.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.api.location.controller;
+
+import com.cocos.cocos.api.location.dto.response.LocationResponse;
+import com.cocos.cocos.api.location.service.LocationService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${api.prefix}/locations")
+@RequiredArgsConstructor
+public class LocationController implements LocationControllerSwagger {
+
+    private final LocationService locationService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<LocationResponse>> getLocations() {
+        return SuccessResponse.success(SuccessMessage.OK, locationService.getLocations());
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/location/controller/LocationControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/location/controller/LocationControllerSwagger.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.api.location.controller;
+
+import com.cocos.cocos.api.location.dto.response.LocationResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Location Controller", description = "지역 관련 API")
+public interface LocationControllerSwagger {
+
+    @Operation(summary = "지역 조회 API", description = "전체 지역을 조회하는 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다.")
+    public ResponseEntity<BaseResponse<LocationResponse>> getLocations();
+}

--- a/src/main/java/com/cocos/cocos/api/location/dto/response/CityResponse.java
+++ b/src/main/java/com/cocos/cocos/api/location/dto/response/CityResponse.java
@@ -1,0 +1,13 @@
+package com.cocos.cocos.api.location.dto.response;
+
+import java.util.List;
+
+public record CityResponse(
+        Long id,
+        String name,
+        List<DistrictResponse> districts
+) {
+    public static CityResponse of(final Long id, final String name, final List<DistrictResponse> districts) {
+        return new CityResponse(id, name, districts);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
+++ b/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
@@ -1,0 +1,10 @@
+package com.cocos.cocos.api.location.dto.response;
+
+public record DistrictResponse(
+        Long id,
+        String name
+) {
+    public static DistrictResponse of(final Long id, final String name) {
+        return new DistrictResponse(id, name);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/location/dto/response/LocationResponse.java
+++ b/src/main/java/com/cocos/cocos/api/location/dto/response/LocationResponse.java
@@ -1,0 +1,11 @@
+package com.cocos.cocos.api.location.dto.response;
+
+import java.util.List;
+
+public record LocationResponse(
+        List<CityResponse> cities
+) {
+    public static LocationResponse of(final List<CityResponse> cities) {
+        return new LocationResponse(cities);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
+++ b/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
@@ -1,0 +1,41 @@
+package com.cocos.cocos.api.location.service;
+
+import com.cocos.cocos.api.location.dto.response.CityResponse;
+import com.cocos.cocos.api.location.dto.response.DistrictResponse;
+import com.cocos.cocos.api.location.dto.response.LocationResponse;
+import com.cocos.cocos.db.city.entity.City;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.entity.District;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final DistrictRepository districtRepository;
+    private final CityRepository cityRepository;
+
+    @Transactional(readOnly = true)
+    public LocationResponse getLocations() {
+        final List<City> cities = cityRepository.findAll();
+        return LocationResponse.of(
+                cities.stream()
+                        .map(city -> {
+                            final List<District> districts = districtRepository.findByCityId(city.getId());
+                            return CityResponse.of(
+                                    city.getId(),
+                                    city.getName(),
+                                    districts.stream()
+                                            .map(district -> DistrictResponse.of(district.getId(), district.getName()))
+                                            .toList());
+
+                        })
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
             "/api/dev/members/refresh",
             "/v3/api-docs/**",
             "/api/dev/test/**",
+            "/api/dev/locations",
+            "/api/local/**"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/db/city/entity/City.java
+++ b/src/main/java/com/cocos/cocos/db/city/entity/City.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.db.city.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "city")
+public class City {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Builder
+    public City(final String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
+++ b/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.city.repository;
+
+import com.cocos.cocos.db.city.entity.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CityRepository extends JpaRepository<City, Long> {
+}

--- a/src/main/java/com/cocos/cocos/db/district/entity/District.java
+++ b/src/main/java/com/cocos/cocos/db/district/entity/District.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.db.district.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "district")
+public class District {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "city_id", nullable = false)
+    private Long cityId;
+
+    @Builder
+    public District(final String name, final Long cityId) {
+        this.name = name;
+        this.cityId = cityId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
+++ b/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
@@ -1,0 +1,13 @@
+package com.cocos.cocos.db.district.repository;
+
+import com.cocos.cocos.db.district.entity.District;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DistrictRepository extends JpaRepository<District, Long> {
+
+    List<District> findByCityId(final Long cityId);
+}

--- a/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
+++ b/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
@@ -1,0 +1,77 @@
+package com.cocos.cocos.location;
+
+import com.cocos.cocos.api.location.dto.response.CityResponse;
+import com.cocos.cocos.api.location.dto.response.DistrictResponse;
+import com.cocos.cocos.api.location.dto.response.LocationResponse;
+import com.cocos.cocos.api.location.service.LocationService;
+import com.cocos.cocos.db.city.entity.City;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.entity.District;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("지역 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class LocationServiceTest {
+
+    @InjectMocks
+    LocationService locationService;
+    @Mock
+    CityRepository cityRepository;
+    @Mock
+    DistrictRepository districtRepository;
+
+
+    @Test
+    @DisplayName("지역을 모두 조회할 수 있다.")
+    void addPostComment() {
+        // given
+        final Long cityId = 1L;
+        final City city = City.builder()
+                .name("시/도")
+                .build();
+
+        final District district1 = District.builder()
+                .name("시/군/구1")
+                .cityId(cityId)
+                .build();
+
+        final District district2 = District.builder()
+                .name("시/군/구2")
+                .cityId(cityId)
+                .build();
+
+        final List<City> cities = new ArrayList<>(List.of(city));
+        final List<District> districts = new ArrayList<>(List.of(district1, district2));
+
+        BDDMockito.given(cityRepository.findAll()).willReturn(cities);
+        BDDMockito.given(districtRepository.findByCityId(any())).willReturn(districts);
+
+        final DistrictResponse districtResponse1 = DistrictResponse.of(district1.getId(), district1.getName());
+        final DistrictResponse districtResponse2 = DistrictResponse.of(district2.getId(), district2.getName());
+        final CityResponse cityResponse = CityResponse.of(city.getId(), city.getName(), List.of(districtResponse1, districtResponse2));
+        final LocationResponse expected = LocationResponse.of(List.of(cityResponse));
+
+        // when
+        final LocationResponse actual = locationService.getLocations();
+
+        // then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        Assertions.assertThat(actual.cities().getFirst().name()).isEqualTo("시/도");
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #144 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 시/도, 시/군/구 엔티티와 레포지토리를 생성했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* local에서 api요청을 확인할 수 있도록 filter white list에 local용 api prefix를 추가했습니다.
* 지역 선택은 비로그인 사용자도 볼 수 있는 API라 생각해서 white list에 추가했습니다.
* 이후 로그인 & 비로그인 화면이 나오면 local, dev, prod에 따라 white list를 각각 설정하고 이를 yml에 옮기는 작업도 필요해 보입니다.
