### PR TITLE
Feat: 병원 최근 검색어 조회, 추가 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     //sentry
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.5.0'
 
+    //H2 Database - testOnly
+    testImplementation 'com.h2database:h2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cocos/cocos/CocosApplication.java
+++ b/src/main/java/com/cocos/cocos/CocosApplication.java
@@ -2,7 +2,9 @@ package com.cocos.cocos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CocosApplication {
 

--- a/src/main/java/com/cocos/cocos/CocosApplication.java
+++ b/src/main/java/com/cocos/cocos/CocosApplication.java
@@ -2,9 +2,7 @@ package com.cocos.cocos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class CocosApplication {
 

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
@@ -28,7 +28,7 @@ public class SearchController implements SearchControllerSwagger {
             @RequestParam(name = "keyword") final String keyword
     ) {
         searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.COMMUNITY);
-        return SuccessResponse.success(SuccessMessage.OK, null );
+        return SuccessResponse.success(SuccessMessage.OK, null);
     }
 
     @GetMapping("/hospital")

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
@@ -27,11 +27,18 @@ public class SearchController implements SearchControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> addSearch(
             @RequestParam(name = "keyword") final String keyword
     ) {
-        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword));
+        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.COMMUNITY));
     }
 
     @GetMapping("/hospital")
     public ResponseEntity<BaseResponse<SearchResponse>> getHospitalSearch() {
         return SuccessResponse.success(SuccessMessage.OK, searchService.getSearchByType(PrincipalHandler.getMemberIdFromPrincipal(), SearchType.HOSPITAL));
+    }
+
+    @PostMapping("/hospital")
+    public ResponseEntity<BaseResponse<Void>> addHospitalSearch(
+            @RequestParam(name = "keyword") final String keyword
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.HOSPITAL));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
@@ -27,7 +27,8 @@ public class SearchController implements SearchControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> addSearch(
             @RequestParam(name = "keyword") final String keyword
     ) {
-        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.COMMUNITY));
+        searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.COMMUNITY);
+        return SuccessResponse.success(SuccessMessage.OK, null );
     }
 
     @GetMapping("/hospital")
@@ -39,6 +40,7 @@ public class SearchController implements SearchControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> addHospitalSearch(
             @RequestParam(name = "keyword") final String keyword
     ) {
-        return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.HOSPITAL));
+        searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword, SearchType.HOSPITAL);
+        return SuccessResponse.success(SuccessMessage.OK, null);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.search.service.SearchService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.enums.search.SearchType;
 import com.cocos.cocos.util.PrincipalHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class SearchController implements SearchControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<SearchResponse>> getSearch() {
-        return SuccessResponse.success(SuccessMessage.OK, searchService.getSearch(PrincipalHandler.getMemberIdFromPrincipal()));
+        return SuccessResponse.success(SuccessMessage.OK, searchService.getSearchByType(PrincipalHandler.getMemberIdFromPrincipal(), SearchType.COMMUNITY));
     }
 
     @PostMapping
@@ -27,5 +28,10 @@ public class SearchController implements SearchControllerSwagger {
             @RequestParam(name = "keyword") final String keyword
     ) {
         return SuccessResponse.success(SuccessMessage.OK, searchService.addSearch(PrincipalHandler.getMemberIdFromPrincipal(), keyword));
+    }
+
+    @GetMapping("/hospital")
+    public ResponseEntity<BaseResponse<SearchResponse>> getHospitalSearch() {
+        return SuccessResponse.success(SuccessMessage.OK, searchService.getSearchByType(PrincipalHandler.getMemberIdFromPrincipal(), SearchType.HOSPITAL));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
@@ -32,4 +32,11 @@ public interface SearchControllerSwagger {
             description = "최근 병원 검색어 조회 성공")
     public ResponseEntity<BaseResponse<SearchResponse>> getHospitalSearch();
 
+    @Operation(summary = "최근 병원 검색어 저장 API", description = "최근 병원 검색어를 저장하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "최근 병원 검색어 저장 성공")
+    @Parameter(name = "keyword", description = "검색어", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+    public ResponseEntity<BaseResponse<Void>> addHospitalSearch(final String keyword);
+
 }

--- a/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/search/controller/SearchControllerSwagger.java
@@ -13,16 +13,23 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Search Controller", description = "최근 검색어 관련 API")
 public interface SearchControllerSwagger {
 
-    @Operation(summary = "최근 검색어 조회 API", description = "최근 검색어를 조회하는 API입니다.")
+    @Operation(summary = "최근 커뮤니티 검색어 조회 API", description = "최근 커뮤니티 검색어를 조회하는 API입니다.")
     @ApiResponse(
             responseCode = "200",
-            description = "최근 검색어 조회 성공")
+            description = "최근 커뮤니티 검색어 조회 성공")
     public ResponseEntity<BaseResponse<SearchResponse>> getSearch();
 
-    @Operation(summary = "최근 검색어 저장 API", description = "최근 검색어를 저장하는 API입니다.")
+    @Operation(summary = "최근 커뮤니티 검색어 저장 API", description = "최근 커뮤니티 검색어를 저장하는 API입니다.")
     @ApiResponse(
             responseCode = "200",
-            description = "최근 검색어 저장 성공")
+            description = "최근 커뮤니티 검색어 저장 성공")
     @Parameter(name = "keyword", description = "검색어", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
     public ResponseEntity<BaseResponse<Void>> addSearch(final String keyword);
+
+    @Operation(summary = "최근 병원 검색어 조회 API", description = "최근 병원 검색어를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "최근 병원 검색어 조회 성공")
+    public ResponseEntity<BaseResponse<SearchResponse>> getHospitalSearch();
+
 }

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -7,7 +7,6 @@ import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.search.SearchType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -18,10 +17,11 @@ public class SearchService {
 
     private final SearchRepository searchRepository;
 
-    @Transactional(isolation = Isolation.SERIALIZABLE)
-    public Void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
-        if (searchRepository.existsByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType)) {
-            final Search search = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+    @Transactional
+    public void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
+        final Search search = searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+
+        if (search != null) {
             search.updateTime();
         } else {
             searchRepository.save(Search.builder()
@@ -30,7 +30,6 @@ public class SearchService {
                     .searchType(searchType)
                     .build());
         }
-        return null;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -19,15 +19,15 @@ public class SearchService {
     private final SearchRepository searchRepository;
 
     @Transactional(isolation = Isolation.SERIALIZABLE)
-    public Void addSearch(final Long memberId, final String keyword) {
-        if (searchRepository.existsByMemberIdAndKeyword(memberId, keyword)) {
-            final Search search = searchRepository.findByMemberIdAndKeyword(memberId, keyword);
+    public Void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
+        if (searchRepository.existsByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType)) {
+            final Search search = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
             search.updateTime();
         } else {
             searchRepository.save(Search.builder()
                     .memberId(memberId)
                     .keyword(keyword)
-                    .searchType(SearchType.COMMUNITY)
+                    .searchType(searchType)
                     .build());
         }
         return null;

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -4,6 +4,7 @@ import com.cocos.cocos.api.search.dto.response.KeywordResponse;
 import com.cocos.cocos.api.search.dto.response.SearchResponse;
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
+import com.cocos.cocos.enums.search.SearchType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
@@ -17,17 +18,6 @@ public class SearchService {
 
     private final SearchRepository searchRepository;
 
-    @Transactional(readOnly = true)
-    public SearchResponse getSearch(final Long memberId) {
-        //ToDo: 검색어도 함께
-        final List<Search> searchList = searchRepository.findTop5ByMemberIdOrderByUpdatedAtDesc(memberId);
-        return SearchResponse.of(
-                searchList.stream()
-                        .map(search -> KeywordResponse.of(search.getId(), search.getKeyword()))
-                        .toList()
-        );
-    }
-
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public Void addSearch(final Long memberId, final String keyword) {
         if (searchRepository.existsByMemberIdAndKeyword(memberId, keyword)) {
@@ -37,8 +27,19 @@ public class SearchService {
             searchRepository.save(Search.builder()
                     .memberId(memberId)
                     .keyword(keyword)
+                    .searchType(SearchType.COMMUNITY)
                     .build());
         }
         return null;
+    }
+
+    @Transactional(readOnly = true)
+    public SearchResponse getSearchByType(final Long memberId, final SearchType searchType) {
+        final List<Search> searchList = searchRepository.findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(memberId, searchType);
+        return SearchResponse.of(
+                searchList.stream()
+                        .map(search -> KeywordResponse.of(search.getId(), search.getKeyword()))
+                        .toList()
+        );
     }
 }

--- a/src/main/java/com/cocos/cocos/db/BaseTime.java
+++ b/src/main/java/com/cocos/cocos/db/BaseTime.java
@@ -1,8 +1,6 @@
 package com.cocos.cocos.db;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -22,6 +20,17 @@ public abstract class BaseTime {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
     public void updateTime() {
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/cocos/cocos/db/BaseTime.java
+++ b/src/main/java/com/cocos/cocos/db/BaseTime.java
@@ -21,17 +21,6 @@ public abstract class BaseTime {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
     public void updateTime() {
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/cocos/cocos/db/BaseTime.java
+++ b/src/main/java/com/cocos/cocos/db/BaseTime.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db;
-
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/src/main/java/com/cocos/cocos/db/search/entity/Search.java
+++ b/src/main/java/com/cocos/cocos/db/search/entity/Search.java
@@ -24,6 +24,7 @@ public class Search extends BaseTime {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "search_type", nullable = false)
     private SearchType searchType;
 

--- a/src/main/java/com/cocos/cocos/db/search/entity/Search.java
+++ b/src/main/java/com/cocos/cocos/db/search/entity/Search.java
@@ -10,7 +10,12 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "search")
+@Table(
+        name = "search",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "keyword", "search_type"})
+        }
+)
 public class Search extends BaseTime {
 
     @Id

--- a/src/main/java/com/cocos/cocos/db/search/entity/Search.java
+++ b/src/main/java/com/cocos/cocos/db/search/entity/Search.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.search.entity;
 
 import com.cocos.cocos.db.BaseTime;
+import com.cocos.cocos.enums.search.SearchType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,9 +24,13 @@ public class Search extends BaseTime {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Column(name = "search_type", nullable = false)
+    private SearchType searchType;
+
     @Builder
-    public Search(String keyword, Long memberId) {
+    public Search(String keyword, Long memberId, SearchType searchType) {
         this.keyword = keyword;
         this.memberId = memberId;
+        this.searchType = searchType;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -2,7 +2,9 @@ package com.cocos.cocos.db.search.repository;
 
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.enums.search.SearchType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,9 +12,10 @@ import java.util.List;
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
-    boolean existsByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
-
-    Search findByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Search findWithLockByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 
     List<Search> findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(final Long memberId, final SearchType searchType);
+
+    List<Search> findAllByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 }

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
+    //TODO: 안정적인 상황 확인 후 동시성 제어 제거
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Search findWithLockByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -10,11 +10,9 @@ import java.util.List;
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
-    List<Search> findTop5ByMemberIdOrderByUpdatedAtDesc(final Long memberId);
+    boolean existsByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 
-    boolean existsByMemberIdAndKeyword(final Long memberId, final String keyword);
-
-    Search findByMemberIdAndKeyword(final Long memberId, final String keyword);
+    Search findByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 
     List<Search> findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(final Long memberId, final SearchType searchType);
 }

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.search.repository;
 
 import com.cocos.cocos.db.search.entity.Search;
+import com.cocos.cocos.enums.search.SearchType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +15,6 @@ public interface SearchRepository extends JpaRepository<Search, Long> {
     boolean existsByMemberIdAndKeyword(final Long memberId, final String keyword);
 
     Search findByMemberIdAndKeyword(final Long memberId, final String keyword);
+
+    List<Search> findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(final Long memberId, final SearchType searchType);
 }

--- a/src/main/java/com/cocos/cocos/enums/search/SearchType.java
+++ b/src/main/java/com/cocos/cocos/enums/search/SearchType.java
@@ -1,0 +1,6 @@
+package com.cocos.cocos.enums.search;
+
+public enum SearchType {
+    HOSPITAL,
+    COMMUNITY
+}

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.search;
 
 import com.cocos.cocos.api.search.service.SearchService;
+import com.cocos.cocos.config.JpaAuditingConfig;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.search.repository.SearchRepository;
@@ -22,7 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @DataJpaTest
-@Import(SearchService.class)
+@Import({SearchService.class,JpaAuditingConfig.class })
 @ActiveProfiles("test")
 class SearchConcurrencyTest {
 

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -2,14 +2,11 @@ package com.cocos.cocos.search;
 
 import com.cocos.cocos.api.search.service.SearchService;
 import com.cocos.cocos.config.JpaAuditingConfig;
-import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.search.repository.SearchRepository;
-import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.search.SearchType;
 import com.cocos.cocos.db.search.entity.Search;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,33 +33,17 @@ class SearchConcurrencyTest {
     @Autowired
     private SearchRepository searchRepository;
 
-    private Long memberId;
-
-    @BeforeEach
-    void setUp() {
-        Member member = Member.builder()
-                .nickname("테스트유저")
-                .email("test@cocos.com")
-                .image("")
-                .platform(Platform.KAKAO)
-                .sub("")
-                .isAdmin(false)
-                .build();
-
-        member = memberRepository.save(member);
-        memberId = member.getId();
-    }
-
     @Test
     @DisplayName("동시에 검색어 저장 요청이 와도 insert는 한 번만 발생한다")
     void addSearchConcurrency() throws InterruptedException {
         // given
-        int threadCount = 10;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch latch = new CountDownLatch(threadCount);
+        final int threadCount = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final Long memberId = 1L;
 
-        String keyword = "피부과";
-        SearchType type = SearchType.HOSPITAL;
+        final String keyword = "피부과";
+        final SearchType type = SearchType.HOSPITAL;
 
         // when: 동시에 10개 요청
         for (int i = 0; i < threadCount; i++) {
@@ -82,7 +63,7 @@ class SearchConcurrencyTest {
         }
 
         // then
-        List<Search> results = searchRepository.findAllByMemberIdAndKeywordAndSearchType(memberId, keyword, type);
+        final List<Search> results = searchRepository.findAllByMemberIdAndKeywordAndSearchType(memberId, keyword, type);
         Assertions.assertThat(results).hasSize(1);
     }
 }

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -1,0 +1,87 @@
+package com.cocos.cocos.search;
+
+import com.cocos.cocos.api.search.service.SearchService;
+import com.cocos.cocos.db.member.entity.Member;
+import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.db.search.repository.SearchRepository;
+import com.cocos.cocos.enums.member.Platform;
+import com.cocos.cocos.enums.search.SearchType;
+import com.cocos.cocos.db.search.entity.Search;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@DataJpaTest
+@Import(SearchService.class)
+@ActiveProfiles("test")
+class SearchConcurrencyTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SearchService searchService;
+
+    @Autowired
+    private SearchRepository searchRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                .nickname("테스트유저")
+                .email("test@cocos.com")
+                .image("")
+                .platform(Platform.KAKAO)
+                .sub("")
+                .isAdmin(false)
+                .build();
+
+        member = memberRepository.save(member);
+        memberId = member.getId();
+    }
+
+    @Test
+    @DisplayName("동시에 검색어 저장 요청이 와도 insert는 한 번만 발생한다")
+    void addSearchConcurrency() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        String keyword = "피부과";
+        SearchType type = SearchType.HOSPITAL;
+
+        // when: 동시에 10개 요청
+        for (int i = 0; i < threadCount; i++) {
+            executor.execute(() -> {
+                try {
+                    searchService.addSearch(memberId, keyword, type);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        try {
+            latch.await();
+        } finally {
+            executor.shutdown();
+        }
+
+        // then
+        List<Search> results = searchRepository.findAllByMemberIdAndKeywordAndSearchType(memberId, keyword, type);
+        Assertions.assertThat(results).hasSize(1);
+    }
+}

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("최근 검색어 서비스 테스트")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class SearchServiceTest {
+class SearchServiceTest {
 
     @InjectMocks
     private SearchService searchService;
@@ -66,12 +66,12 @@ public class SearchServiceTest {
     }
 
     @Test
-    @DisplayName("동시에 요청해도 중복 insert 되지 않는다")
+    @DisplayName("이미 존재하는 검색어가 있을 경우 업데이트가 된다")
     void addSearch() {
         // given
-        Long memberId = 1L;
-        String keyword = "피부과";
-        SearchType searchType = SearchType.HOSPITAL;
+        final Long memberId = 1L;
+        final String keyword = "피부과";
+        final SearchType searchType = SearchType.HOSPITAL;
 
         final Search existingSearch = Mockito.mock(Search.class);
         BDDMockito.given(searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -15,12 +15,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("최근 검색어 서비스 테스트")
@@ -64,5 +63,43 @@ public class SearchServiceTest {
 
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("동시에 요청해도 중복 insert 되지 않는다")
+    void addSearch() {
+        // given
+        Long memberId = 1L;
+        String keyword = "피부과";
+        SearchType searchType = SearchType.HOSPITAL;
+
+        final Search existingSearch = Mockito.mock(Search.class);
+        BDDMockito.given(searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
+                .willReturn(existingSearch);
+
+        // when
+        searchService.addSearch(memberId, keyword, searchType);
+
+        // then
+        Mockito.verify(existingSearch, Mockito.times(1)).updateTime();
+        Mockito.verify(searchRepository, Mockito.never()).save(Mockito.any());
+    }
+
+    @Test
+    @DisplayName("동일한 검색어가 없으면 새로 저장한다")
+    void addSearchIfSearchDoesNotExist() {
+        // given
+        final Long memberId = 1L;
+        final String keyword = "피부과";
+        final SearchType searchType = SearchType.HOSPITAL;
+
+        BDDMockito.given(searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
+                .willReturn(null);
+
+        // when
+        searchService.addSearch(memberId, keyword, searchType);
+
+        // then
+        Mockito.verify(searchRepository, Mockito.times(1)).save(Mockito.any(Search.class));
     }
 }

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.search.dto.response.SearchResponse;
 import com.cocos.cocos.api.search.service.SearchService;
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
+import com.cocos.cocos.enums.search.SearchType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -33,20 +34,24 @@ public class SearchServiceTest {
     private SearchRepository searchRepository;
 
     @Test
-    @DisplayName("최근에 검색한 검색어 5개를 보여줄 수 있다.")
-    void getDiseases() {
+    @DisplayName("최근에 검색한 커뮤니티 검색어 5개를 보여줄 수 있다.")
+    void getSearch() {
         //given
         final Long memberId = 1L;
         final Search search1 = Search.builder()
                 .memberId(memberId)
                 .keyword("keyword1")
+                .searchType(SearchType.COMMUNITY)
                 .build();
         final Search search2 = Search.builder()
                 .memberId(memberId)
                 .keyword("keyword1")
+                .searchType(SearchType.COMMUNITY)
                 .build();
+        final SearchType searchType = SearchType.COMMUNITY;
+
         final List<Search> searchList = new ArrayList<>(List.of(search1, search2));
-        BDDMockito.given(searchRepository.findTop5ByMemberIdOrderByUpdatedAtDesc(any())).willReturn(searchList);
+        BDDMockito.given(searchRepository.findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(memberId, searchType)).willReturn(searchList);
 
         final SearchResponse expected = SearchResponse.of(
                 searchList.stream()
@@ -55,7 +60,7 @@ public class SearchServiceTest {
         );
 
         //when
-        final SearchResponse actual = searchService.getSearch(memberId);
+        final SearchResponse actual = searchService.getSearchByType(memberId, searchType);
 
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #146 

## 👷 **작업한 내용**
- 기존 커뮤니티 검색어 조회 API를 변경하여 병원 검색어 조회할 수 있도록 확장
- 기존 커뮤니티 검색어 추가 API를 변경하여 병원 검색어 추가할 수 있도록 확장
- 여러 번 삽입되려고 할 때의 상황을 가졍하여 테스트코드 추가
- test 환경을 위한 DB 분리 (yml 변경함)
- searchType Enum 추가

## 🚨 **참고 사항**
- 기존에 사용하던 `@Transactional(isolation = Isolation.SERIALIZABLE)` 방식은 **성능 저하 우려**가 있어 제거했습니다. 대신 DB 레벨에서 `(member_id, keyword, search_type)`에 **UNIQUE 제약을 추가**하여 중복 insert를 방지하도록 변경했습니다. 이에 대한 의견이 궁금합니다! 
- 동시에 여러 요청이 들어오는 상황에서도 insert가 1회만 발생하도록 `동시성 테스트`를 작성해 검증했습니다.
- 테스트가 실행되는 DB를 변경했습니다. 이를 위해 아래와 같은 코드를 gradle에 추가했습니다. 
``` testImplementation 'com.h2database:h2'```

## **TODO**
- [ ] yml에 테스트환경 반영
- [ ] 배포 DB 제약 조건 변경 
