### PR TITLE
Feat: 신고하기 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/report/controller/ReportController.java
+++ b/src/main/java/com/cocos/cocos/api/report/controller/ReportController.java
@@ -1,0 +1,29 @@
+package com.cocos.cocos.api.report.controller;
+
+import com.cocos.cocos.api.report.service.ReportService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.enums.report.ReportType;
+import com.cocos.cocos.util.PrincipalHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("${api.prefix}/reports")
+@RequiredArgsConstructor
+public class ReportController implements ReportControllerSwagger{
+
+    private final ReportService reportService;
+
+    @PostMapping("/{targetId}")
+    public ResponseEntity<BaseResponse<Void>> addReport(
+            @PathVariable(name = "targetId") final Long targetId,
+            @RequestParam(name = "reportType") final ReportType reportType
+    ) {
+        reportService.addReport(PrincipalHandler.getMemberIdFromPrincipal(), targetId, reportType);
+        return SuccessResponse.success(SuccessMessage.CREATED, null);
+    }
+
+}

--- a/src/main/java/com/cocos/cocos/api/report/controller/ReportControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/report/controller/ReportControllerSwagger.java
@@ -1,0 +1,28 @@
+package com.cocos.cocos.api.report.controller;
+
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.enums.report.ReportType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Report Controller", description = "신고 관련 API")
+public interface ReportControllerSwagger {
+
+    @Operation(summary = "신고 API", description = "신고하는 API 입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청이 성공했습니다. ")
+    @Parameter(name = "targetId", description = "신고 대상 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    @Parameter(name = "reportType", description = "신고 대상 타입(POST | REVIEW | COMMENT | SUB_COMMENT)", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "Enum"))
+    public ResponseEntity<BaseResponse<Void>> addReport(
+            @PathVariable(name = "targetId") final Long targetId,
+            @RequestParam(name = "reportType") final ReportType reportType
+    );
+}

--- a/src/main/java/com/cocos/cocos/api/report/service/ReportService.java
+++ b/src/main/java/com/cocos/cocos/api/report/service/ReportService.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.api.report.service;
+
+import com.cocos.cocos.db.report.entity.Report;
+import com.cocos.cocos.db.report.repository.ReportRepository;
+import com.cocos.cocos.enums.report.ReportType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    public void addReport(final Long memberId, final Long targetId, final ReportType reportType) {
+        reportRepository.save(
+                Report.builder()
+                        .reporterId(memberId)
+                        .targetId(targetId)
+                        .reportType(reportType)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/report/entity/Report.java
+++ b/src/main/java/com/cocos/cocos/db/report/entity/Report.java
@@ -1,0 +1,38 @@
+package com.cocos.cocos.db.report.entity;
+
+import com.cocos.cocos.db.BaseTime;
+import com.cocos.cocos.enums.report.ReportType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.tool.schema.TargetType;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "report")
+public class Report extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_type", nullable = false)
+    private ReportType reportType;
+
+    @Builder
+    public Report(Long reporterId, Long targetId, ReportType reportType) {
+        this.reporterId = reporterId;
+        this.targetId = targetId;
+        this.reportType = reportType;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/report/repository/ReportRepository.java
+++ b/src/main/java/com/cocos/cocos/db/report/repository/ReportRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.report.repository;
+
+import com.cocos.cocos.db.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/cocos/cocos/enums/report/ReportType.java
+++ b/src/main/java/com/cocos/cocos/enums/report/ReportType.java
@@ -1,0 +1,8 @@
+package com.cocos.cocos.enums.report;
+
+public enum ReportType {
+    POST,
+    REVIEW,
+    COMMENT,
+    SUB_COMMENT
+}

--- a/src/test/java/com/cocos/cocos/report/ReportServiceTest.java
+++ b/src/test/java/com/cocos/cocos/report/ReportServiceTest.java
@@ -1,0 +1,54 @@
+package com.cocos.cocos.report;
+
+import com.cocos.cocos.api.post.service.PostService;
+import com.cocos.cocos.api.report.service.ReportService;
+import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import com.cocos.cocos.db.report.entity.Report;
+import com.cocos.cocos.db.report.repository.ReportRepository;
+import com.cocos.cocos.enums.report.ReportType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("신고 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ReportServiceTest {
+
+    @InjectMocks
+    ReportService reportService;
+    @Mock
+    private ReportRepository reportRepository;
+
+
+    @Test
+    @DisplayName("게시글을 신고할 수 있다.")
+    void addPostReport() {
+        //given
+        final Long targetId = 1L;
+        final ReportType reportType = ReportType.POST;
+        final Long memberId = 1L;
+        final Report report = Report.builder()
+                .reporterId(memberId)
+                .reportType(reportType)
+                .targetId(targetId)
+                .build();
+
+        //when
+        reportService.addReport(memberId, targetId, reportType);
+
+        //then
+        BDDMockito.verify(reportRepository, times(1)).save(Mockito.any(Report.class));
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #151 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 신고하기 API를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 신고 타입을 Enum으로 만드는 과정에서 커뮤니티 신고라면 굳이 ERD 설계처럼 Enum으로 저장이 필요없을 것 같다고 생각했고, Enum을 Report에 저장하게 된다면 이후 리뷰, 댓글, 대댓글 신고 기능이 추가될 때 파라미터만 바꿔서 요청 받으면 하나의 API에서 처리할 수 있다고 생각했습니다! 이 부분에 대한 연진님의 의견은 어떠신지가 궁금합니다!

* 위의 고려사항에 따라 다음과 같이 변경을 했습니다.
1) ReportType Enum타입을 총 4개(댓글, 대댓글, 게시글, 병원 리뷰)로 구별했습니다.
2) 클라이언트 분들께 요청받는 값을 기존의 postId 하나에서 targetId, ReportType을 추가로 받도록 했습니다.
3) url은 기존 /posts/{postId}/report 에서 /reports/{targetId}로 수정했습니다.
