### PR TITLE
Fix: 회원정보 변경 API 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -9,7 +9,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
-import com.cocos.cocos.util.validation.EntityExistsValidator;
+import com.cocos.cocos.validation.EntityExistsValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.request.MemberProfileUpdateRequest;
 import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
@@ -10,8 +11,10 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,9 +37,9 @@ public class MemberController implements MemberControllerSwagger {
 
     @PatchMapping
     public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(
-            @RequestParam(name = "nickname") final String nickname
+            @RequestBody @Valid final MemberProfileUpdateRequest memberProfileUpdateRequest
     ) {
-        final NicknameExistenceResponse nicknameExistenceResponse = memberService.updateMemberProfile(nickname, PrincipalHandler.getMemberIdFromPrincipal());
+        final NicknameExistenceResponse nicknameExistenceResponse = memberService.updateMemberProfile(PrincipalHandler.getMemberIdFromPrincipal(), memberProfileUpdateRequest.nickname(), memberProfileUpdateRequest.locationType(), memberProfileUpdateRequest.townId());
         return SuccessResponse.success(SuccessMessage.OK, nicknameExistenceResponse);
     }
 

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.request.MemberProfileUpdateRequest;
 import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
@@ -45,7 +46,9 @@ public interface MemberControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "요청에 성공했습니다. ")
-    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(@RequestParam final String nickname);
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(
+            final MemberProfileUpdateRequest memberProfileUpdateRequest
+    );
 
     @Operation(summary = "닉네임 중복 조회 API", description = "중복된 닉네임이 있는지 검사합니다. ")
     @ApiResponse(

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/MemberProfileUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.api.member.dto.request;
+
+import com.cocos.cocos.enums.location.LocationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberProfileUpdateRequest(
+        @Schema(description = "닉네임", example = "코코스")
+        String nickname,
+        @Schema(description = "위치 정보 종류", example = "CITY | DISTRICT | TOWN")
+        LocationType locationType,
+        @Schema(description = "위치 아이디", example = "3")
+        Long townId
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -7,10 +7,13 @@ import com.cocos.cocos.api.member.dto.response.TokenResponse;
 import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
 import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.entity.MemberToken;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
+import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.KakaoLoginClient;
@@ -28,6 +31,8 @@ public class MemberService {
     private final KakaoLoginClient kakaoLoginClient;
     private final JwtProvider jwtProvider;
     private final MemberTokenRepository memberTokenRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
@@ -64,6 +69,9 @@ public class MemberService {
                     .isAdmin(false)
                     .platform(Platform.KAKAO)
                     .sub(sub)
+                    .townId(1L)
+                    .locationType(LocationType.CITY)
+                    .currentAddress("현재 주소를 업데이트 해주세요!")
                     .build()
             );
             isCompletedSignUp = false;
@@ -112,20 +120,33 @@ public class MemberService {
     }
 
     @Transactional
-    public NicknameExistenceResponse updateMemberProfile(final String nickname, final Long memberId) {
+    public NicknameExistenceResponse updateMemberProfile(final Long memberId, final String nickname, final LocationType locationType, final Long townId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+        updateCurrentAddress(member, locationType, townId);
         if (memberRepository.existsByNickname(nickname)) {
             return NicknameExistenceResponse.of(true);
         } else {
-            final Member member = memberRepository.findById(memberId).orElseThrow(
-                    () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
-            );
-            member.updateFields(nickname);
+            member.updateNickname(nickname);
             return NicknameExistenceResponse.of(false);
 
         }
     }
 
-    //ToDo: Transactional(readOnly = true)필요
+    private void updateCurrentAddress(final Member member, final LocationType locationType, final Long townId) {
+        if (locationType != null && townId != null) {
+            if (locationType.equals(LocationType.CITY) && !cityRepository.existsById(townId)) {
+                throw new CocosException((FailMessage.NOT_FOUND_CITY));
+            }
+            if (locationType.equals(LocationType.DISTRICT) && !districtRepository.existsById(townId)) {
+                throw new CocosException((FailMessage.NOT_FOUND_DISTRICT));
+            }
+            member.updateLocation(locationType, townId);
+        }
+    }
+
+    @Transactional(readOnly = true)
     public NicknameExistenceResponse checkNickname(final String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
             return NicknameExistenceResponse.of(true);

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -30,7 +30,6 @@ public class SecurityConfig {
             "/api/dev/test/**",
             "/api/dev/locations",
             "/api/local/locations",
-            "/api/local/**"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             "/api/dev/test/**",
             "/api/dev/locations",
             "/api/local/locations",
+            "/api/local/**"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/config/WebConfig.java
+++ b/src/main/java/com/cocos/cocos/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.config;
 
+import com.cocos.cocos.util.LocationTypeEnumConverter;
 import com.cocos.cocos.util.PetProblemEnumConverter;
 import com.cocos.cocos.util.SortCriteriaEnumConverter;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new SortCriteriaEnumConverter());
         registry.addConverter(new PetProblemEnumConverter());
+        registry.addConverter(new LocationTypeEnumConverter());
     }
 
     @Override

--- a/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
+++ b/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CityRepository extends JpaRepository<City, Long> {
+
+    boolean existsById(final Long id);
 }

--- a/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
+++ b/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface DistrictRepository extends JpaRepository<District, Long> {
 
     List<District> findByCityId(final Long cityId);
+
+    boolean existsById(final Long id);
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.member.entity;
 
 import com.cocos.cocos.db.BaseTime;
+import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -37,17 +38,35 @@ public class Member extends BaseTime {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin;
 
+    @Column(name = "current_address", nullable = false)
+    private String currentAddress;
+
+    @Column(name = "town_id", nullable = false)
+    private Long townId;
+
+    @Column(name = "location_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LocationType locationType;
+
     @Builder
-    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin) {
+    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin, final String currentAddress, final Long townId, final LocationType locationType) {
         this.nickname = nickname;
         this.email = email;
         this.image = image;
         this.platform = platform;
         this.sub = sub;
         this.isAdmin = isAdmin;
+        this.currentAddress = currentAddress;
+        this.townId = townId;
+        this.locationType = locationType;
     }
 
-    public void updateFields(final String nickname) {
+    public void updateNickname(final String nickname) {
         if (nickname != null) this.nickname = nickname;
+    }
+
+    public void updateLocation(final LocationType locationType, final Long townId) {
+        this.locationType = locationType;
+        this.townId = townId;
     }
 }

--- a/src/main/java/com/cocos/cocos/enums/location/LocationType.java
+++ b/src/main/java/com/cocos/cocos/enums/location/LocationType.java
@@ -1,0 +1,19 @@
+package com.cocos.cocos.enums.location;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
+
+public enum LocationType {
+    CITY,
+    DISTRICT,
+    TOWN;
+
+    public static LocationType create(final String locationType) {
+        for (LocationType value : LocationType.values()) {
+            if (value.toString().equals(locationType)) {
+                return value;
+            }
+        }
+        throw new CocosException(FailMessage.NOT_FOUND_LOCATION_TYPE);
+    }
+}

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -16,6 +16,7 @@ public enum FailMessage {
     BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST, 40002, "필수 param이 없습니다. "),
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40003, "메서드 인자타입이 잘못되었습니다. "),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40004, "json 오류 혹은 reqeust body 필드 오류 입니다. "),
+    BAD_REQUEST_NOT_EXISTS_DTO_FIELD(HttpStatus.BAD_REQUEST, 40005, "해당하는 DTO 필드가 존재하지 않습니다."),
 
     /**
      * 401
@@ -31,6 +32,8 @@ public enum FailMessage {
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "권한이 없습니다. "),
     FORBIDDEN_COMMENT_DELETE(HttpStatus.FORBIDDEN, 40301, "댓글을 삭제할 권한이 없습니다. "),
     FORBIDDEN_PET_UPDATE(HttpStatus.FORBIDDEN, 40302, "애완동물 정보를 수정할 권리가 없습니다. "),
+    FORBIDDEN_FIELD(HttpStatus.FORBIDDEN, 40302, "해당 필드에 접근할 수 없습니다."),
+
     /**
      * 404
      */
@@ -51,6 +54,9 @@ public enum FailMessage {
     NOT_FOUND_SUB_COMMENT(HttpStatus.NOT_FOUND, 40414, "대댓글을 찾을 수 없습니다."),
     NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "애완동물을 찾을 수 없습니다. "),
     NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
+    NOT_FOUND_LOCATION_TYPE(HttpStatus.BAD_REQUEST, 40417, "지역 종류를 찾을 수 없습니다."),
+    NOT_FOUND_CITY(HttpStatus.BAD_REQUEST, 40418, "시/도를 찾을 수 없습니다."),
+    NOT_FOUND_DISTRICT(HttpStatus.BAD_REQUEST, 40419, "시/군/구를 찾을 수 없습니다."),
 
     /**
      * 405

--- a/src/main/java/com/cocos/cocos/util/LocationTypeEnumConverter.java
+++ b/src/main/java/com/cocos/cocos/util/LocationTypeEnumConverter.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.util;
+
+import com.cocos.cocos.enums.location.LocationType;
+import org.springframework.core.convert.converter.Converter;
+
+public class LocationTypeEnumConverter implements Converter<String, LocationType> {
+
+    @Override
+    public LocationType convert(String requestCategory) {
+        return LocationType.create(requestCategory.toUpperCase());
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/EntityExistsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/EntityExistsValidator.java
@@ -1,7 +1,6 @@
-package com.cocos.cocos.util.validation;
+package com.cocos.cocos.validation;
 
 import com.cocos.cocos.common.exception.CocosException;
-import com.cocos.cocos.db.breed.repository.BreedRepository;
 import com.cocos.cocos.db.comment.repository.CommentRepository;
 import com.cocos.cocos.db.comment.repository.SubCommentRepository;
 import com.cocos.cocos.db.member.repository.MemberRepository;
@@ -19,7 +18,6 @@ public class EntityExistsValidator {
     private final SubCommentRepository subCommentRepository;
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
-    private final BreedRepository breedRepository;
     private final PostRepository postRepository;
 
     public void validatePostByPostId(final Long postId) {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #154 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 회원정보 변경 API를 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 위치 정보를 받아오면서 기존에 수정 시 쿼리 파라미터로 닉네임을 받아오던 방식에서 DTO를 만들어 한 번에 모든 정보를 받아오도록 수정했습니다. 이에 따라 이 부분이 반영되면 클라이언트 쌤들에게 노티를 드려야 할 것 같습니다.
* 네이밍 짓기가 너무 어려운데 추천해주세요...
* 어노테이션 기반으로 DTO 기반의 유효성 검사를 진행하려고 했는데, DTO가 현재 record 기반으로 되어 있어서 어노테이션이 인식을 못하는 상황이 있었습니다! 이러한 부분에 대해서도 논의를 나누면 좋을 것 같습니다! (DTO를 record말고 Class로 만들어서 하던지, 각 필드마다 제약 조건을 달지?)