### PR TITLE
Feat: 사용자 위치(동정보) 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -39,6 +39,7 @@ public class CommentService {
 
     @Transactional
     public void addPostComment(final Long postId, final String content, final Long memberId) {
+        //TODO: pet이 없는 member는 댓글을 달지 못함.
         commentRepository.save(
                 Comment.builder()
                         .content(content)
@@ -63,10 +64,12 @@ public class CommentService {
 
     @Transactional
     public void addPostSubComment(final Long commentId, final String nickname, final String content, final Long memberId) {
+        //TODO: pet이 없는 member는 대댓글을 달지 못함.
+        final Member member = memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         subCommentRepository.save(
                 SubComment.builder()
                         .commentId(commentId)
-                        .mentionedMemberId(memberRepository.findByNickname(nickname).getId())
+                        .mentionedMemberId(member.getId())
                         .content(content)
                         .memberId(memberId)
                         .build()
@@ -233,10 +236,7 @@ public class CommentService {
 
     private Long findMemberByNickname(final String nickname, final Long memberId) {
         if (nickname != null) {
-            final Member member = memberRepository.findByNickname(nickname);
-            if (member == null) {
-                throw new CocosException((FailMessage.NOT_FOUND_MEMBER));
-            }
+            final Member member = memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
             return member.getId();
         } else {
             return memberId;

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
 import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
+import com.cocos.cocos.api.member.dto.response.MemberLocationResponse;
 import com.cocos.cocos.api.member.service.MemberService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
@@ -63,5 +64,10 @@ public class MemberController implements MemberControllerSwagger {
     @GetMapping("/refresh")
     public ResponseEntity<BaseResponse<ReissueTokenResponse>> reIssueToken() {
         return SuccessResponse.success(SuccessMessage.OK, memberService.reIssueToken(PrincipalHandler.getMemberIdFromPrincipal()));
+    }
+
+    @GetMapping("/location")
+    public ResponseEntity<BaseResponse<MemberLocationResponse>> getMemberLocation() {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberLocation(PrincipalHandler.getMemberIdFromPrincipal()));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
 import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
+import com.cocos.cocos.api.member.dto.response.MemberLocationResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -52,4 +53,11 @@ public interface MemberControllerSwagger {
             responseCode = "200",
             description = "요청에 성공했습니다. ")
     public ResponseEntity<BaseResponse<NicknameExistenceResponse>> checkNickname(@RequestParam final String nickname);
+
+    @Operation(summary = "사용자 위치 조회 API", description = "사용자위치에 등록된 동 정보를 반환합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다. "
+    )
+    public ResponseEntity<BaseResponse<MemberLocationResponse>> getMemberLocation();
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberLocationResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberLocationResponse.java
@@ -1,0 +1,16 @@
+package com.cocos.cocos.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 위치 응답 예시", example = "{\"townId\": 1, \"townName\": \"논현동\"}")
+public record MemberLocationResponse(
+        @Schema(description = "동 아이디", example = "1")
+        Long townId,
+
+        @Schema(description = "동 이름", example = "논현동")
+        String townName
+) {
+    public static MemberLocationResponse of(final Long townId, final String townName) {
+        return new MemberLocationResponse(townId, townName);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -1,16 +1,14 @@
 package com.cocos.cocos.api.member.service;
 
-import com.cocos.cocos.api.member.dto.response.LoginResponse;
-import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
-import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
-import com.cocos.cocos.api.member.dto.response.TokenResponse;
+import com.cocos.cocos.api.member.dto.response.*;
 import com.cocos.cocos.auth.JwtProvider;
-import com.cocos.cocos.api.member.dto.response.NicknameExistenceResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.entity.MemberToken;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
+import com.cocos.cocos.db.town.entity.Town;
+import com.cocos.cocos.db.town.repository.TownRepository;
 import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.KakaoLoginClient;
@@ -28,18 +26,14 @@ public class MemberService {
     private final KakaoLoginClient kakaoLoginClient;
     private final JwtProvider jwtProvider;
     private final MemberTokenRepository memberTokenRepository;
+    private final TownRepository townRepository;
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
-        //ToDo: ?의 역할을 findMember()라는 하나의 메소드 안에서 모두 해결 할 수 있을 것 같음
-        final Long selectedMemberId = (nickname != null) ? findMemberByNickname(nickname) : memberId;
-        //ToDo: 이 부분 또한 findMember, 즉 멤버를 찾는 메소드 안에서 한 번에 처리가능할 것 같음
-        final Member member = memberRepository.findById(selectedMemberId).orElseThrow(
-                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
-        );
+        final Member member = findMember(nickname, memberId);
         return MemberProfileResponse.of(member.getNickname(), memberDataS3Client.getPresignedUrl(member.getImage()));
     }
 
@@ -99,18 +93,6 @@ public class MemberService {
         return null;
     }
 
-    private Long findMemberByNickname(String nickname) {
-        if (nickname != null) {
-            final Member member = memberRepository.findByNickname(nickname);
-            if (member == null) {
-                throw new CocosException((FailMessage.NOT_FOUND_MEMBER));
-            }
-            return member.getId();
-        } else {
-            return null;
-        }
-    }
-
     @Transactional
     public NicknameExistenceResponse updateMemberProfile(final String nickname, final Long memberId) {
         if (memberRepository.existsByNickname(nickname)) {
@@ -125,13 +107,24 @@ public class MemberService {
         }
     }
 
-    //ToDo: Transactional(readOnly = true)필요
+    @Transactional(readOnly = true)
     public NicknameExistenceResponse checkNickname(final String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
-            return NicknameExistenceResponse.of(true);
-        } else {
-            return NicknameExistenceResponse.of(false);
+        return NicknameExistenceResponse.of(memberRepository.existsByNickname(nickname));
+    }
 
+    @Transactional(readOnly = true)
+    public MemberLocationResponse getMemberLocation(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+        final Town town = townRepository.findById(member.getTownId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
+        return MemberLocationResponse.of(
+                town.getId(), town.getName()
+        );
+    }
+
+    private Member findMember(final String nickname, final Long memberId) {
+        if (nickname != null) {
+            return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }
+        return memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -22,9 +22,8 @@ import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
-import com.cocos.cocos.external.AppDataS3Client;
 import com.cocos.cocos.external.MemberDataS3Client;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -75,52 +74,30 @@ public class PetService {
         }
     }
 
-    //ToDo: 인자에 final 키워드 필요
-    private void validatePetDiseases(List<Long> diseaseIds) {
-        //ToDo: existsAllByIdIn 등 쿼리문 하나로 이 메소드의 기능을 한 번에 수행할 수 있을 것 같음
-        List<Long> validDiseaseIds = diseaseRepository.findByIdIn(diseaseIds).stream()
-                .map(Disease::getId)
-                .toList();
-
-        List<Long> invalidDiseaseIds = diseaseIds.stream()
-                .filter(diseaseId -> !validDiseaseIds.contains(diseaseId))
-                .toList();
-
-        if (!invalidDiseaseIds.isEmpty()) {
+    private void validatePetDiseases(final List<Long> diseaseIds) {
+        final long diseaseCount = diseaseRepository.countByIdIn(diseaseIds);
+        if (diseaseCount != diseaseIds.size()) {
             throw new CocosException(FailMessage.NOT_FOUND_DISEASE);
         }
     }
 
-    //ToDo: 인자에 final 키워드 필요
-    private void validatePetSymptoms(List<Long> symptomIds) {
-        //ToDo: existsAllByIdIn 등 쿼리문 하나로 이 메소드의 기능을 한 번에 수행할 수 있을 것 같음
-        List<Long> validSymptomIds = symptomRepository.findByIdIn(symptomIds).stream()
-                .map(Symptom::getId)
-                .toList();
-
-        List<Long> invalidSymptomIds = symptomIds.stream()
-                .filter(symptomId -> !validSymptomIds.contains(symptomId))
-                .toList();
-
-        if (!invalidSymptomIds.isEmpty()) {
+    private void validatePetSymptoms(final List<Long> symptomIds) {
+        final long symptomCount = symptomRepository.countByIdIn(symptomIds);
+        if (symptomCount != symptomIds.size()) {
             throw new CocosException(FailMessage.NOT_FOUND_SYMPTOM);
         }
     }
 
     private void savePetSymptoms(final List<Long> symptomIds, Long petId) {
         final List<PetSymptom> petSymptoms = symptomIds.stream()
-                //ToDo: Builder패턴 사용
-                .map(symptomId -> new PetSymptom(petId, symptomId))
-                .toList();
+                .map(symptomId -> PetSymptom.builder().petId(petId).symptomId(symptomId).build()).toList();
 
         petSymptomRepository.saveAll(petSymptoms);
     }
 
     private void savePetDiseases(final List<Long> diseaseIds, Long petId) {
         final List<PetDisease> petDiseases = diseaseIds.stream()
-                //ToDo: Builder패턴 사용
-                .map(diseaseId -> new PetDisease(petId, diseaseId))
-                .toList();
+                .map(diseaseId -> PetDisease.builder().petId(petId).diseaseId(diseaseId).build()).toList();
 
         petDiseaseRepository.saveAll(petDiseases);
     }
@@ -155,7 +132,7 @@ public class PetService {
         }
     }
 
-    //ToDo: Transactional readOnly = true 추가 필요
+    @Transactional(readOnly = true)
     public PetResponse getPet(final String nickname, final Long memberId) {
         if (nickname != null && !memberRepository.existsByNickname(nickname)) {
             throw new CocosException(FailMessage.NOT_FOUND_MEMBER);
@@ -163,7 +140,7 @@ public class PetService {
 
         //ToDo: 메소드로 통일시켜도 좋을 것 같음(이전 다른 곳에서 사용되었던 코드와 통일 시키는 것이 좋아보임)
         final Long selectedMemberId = (nickname != null)
-                ? memberRepository.findByNickname(nickname).getId()
+                ? memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER)).getId()
                 : memberId;
 
         final Pet pet = petRepository.findByMemberId(selectedMemberId);
@@ -181,21 +158,19 @@ public class PetService {
 
         final List<PetDisease> petDiseases = petDiseaseRepository.findAllByPetId(pet.getId());
         final List<Disease> diseases = petDiseases.stream()
-                .map(petDisease -> {
-                    //ToDo: return 문 제거 가능
-                    return diseaseRepository.findById(petDisease.getDiseaseId()).orElseThrow(
-                            () -> new CocosException(FailMessage.NOT_FOUND_DISEASE)
-                    );
-                }).toList();
+                .map(petDisease ->
+                        diseaseRepository.findById(petDisease.getDiseaseId()).orElseThrow(
+                                () -> new CocosException(FailMessage.NOT_FOUND_DISEASE)
+                        )
+                ).toList();
 
         final List<PetSymptom> petSymptoms = petSymptomRepository.findAllByPetId(pet.getId());
         final List<Symptom> symptoms = petSymptoms.stream()
-                .map(petSymptom -> {
-                    //ToDo: return 문 제거 가능
-                    return symptomRepository.findById(petSymptom.getSymptomId()).orElseThrow(
-                            () -> new CocosException(FailMessage.NOT_FOUND_SYMPTOM)
-                    );
-                }).toList();
+                .map(petSymptom ->
+                        symptomRepository.findById(petSymptom.getSymptomId()).orElseThrow(
+                                () -> new CocosException(FailMessage.NOT_FOUND_SYMPTOM)
+                        )
+                ).toList();
 
         return PetResponse.of(
                 pet.getId(),

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -435,12 +435,7 @@ public class PostService {
 
     private Member findMember(final Long memberId, final String nickname) {
         if (nickname != null) {
-            final Member member = memberRepository.findByNickname(nickname);
-            if (member == null) {
-                throw new CocosException(FailMessage.NOT_FOUND_MEMBER);
-            } else {
-                return member;
-            }
+            return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }
         return memberRepository.findById(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)

--- a/src/main/java/com/cocos/cocos/db/disease/repository/DiseaseRepository.java
+++ b/src/main/java/com/cocos/cocos/db/disease/repository/DiseaseRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface DiseaseRepository extends JpaRepository<Disease, Long> {
 
     List<Disease> findAllByBodyId(final Long bodyId);
-    List<Disease> findByIdIn(final List<Long> ids);
+
+    long countByIdIn(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -37,14 +37,18 @@ public class Member extends BaseTime {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin;
 
+    @Column(name = "town_id", nullable = false)
+    private Long townId;
+
     @Builder
-    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin) {
+    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin, final Long townId) {
         this.nickname = nickname;
         this.email = email;
         this.image = image;
         this.platform = platform;
         this.sub = sub;
         this.isAdmin = isAdmin;
+        this.townId = townId;
     }
 
     public void updateFields(final String nickname) {

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberRepository.java
@@ -4,9 +4,11 @@ import com.cocos.cocos.db.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Member findByNickname(final String nickname);
+    Optional<Member> findByNickname(final String nickname);
 
     boolean existsBySub(final String sub);
 

--- a/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Repository
 public interface SymptomRepository extends JpaRepository<Symptom, Long> {
 
-    List<Symptom> findAllByBodyId(final Long BodyId);
+    List<Symptom> findAllByBodyId(final Long bodyId);
 
     long countByIdIn(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/symptom/repository/SymptomRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface SymptomRepository extends JpaRepository<Symptom, Long> {
 
     List<Symptom> findAllByBodyId(final Long BodyId);
-    List<Symptom> findByIdIn(final List<Long> ids);
+
+    long countByIdIn(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -52,6 +52,7 @@ public enum FailMessage {
     NOT_FOUND_SUB_COMMENT(HttpStatus.NOT_FOUND, 40414, "대댓글을 찾을 수 없습니다."),
     NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "애완동물을 찾을 수 없습니다. "),
     NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
+    NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, 40417, "동을 찾을 수 없습니다. "),
 
     /**
      * 405


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #157 

## 👷 **작업한 내용**
- member 위치 조회 API 구현했습니다.
- findByNickname에서 Optional<Member>를 반환하도록 변경했습니다. (리팩)
- 유효한 symptom, disease 판단할 때 count해서 비교하도록 변경했습니다. (리팩)

## 🚨 **참고 사항**
- townId만 필요해서 Member entity에 townId만 추가하였습니다. 