### PR TITLE
Fix: 사용자 회원정보 업데이트 API 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.request.ProfileUpdateRequest;
 import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
@@ -35,9 +36,19 @@ public class MemberController implements MemberControllerSwagger {
 
     @PatchMapping
     public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(
-            @RequestParam(name = "nickname") final String nickname
+            @RequestBody final ProfileUpdateRequest profileUpdateRequest
     ) {
-        final NicknameExistenceResponse nicknameExistenceResponse = memberService.updateMemberProfile(nickname, PrincipalHandler.getMemberIdFromPrincipal());
+        final NicknameExistenceResponse nicknameExistenceResponse = memberService.updateMemberProfile(
+                PrincipalHandler.getMemberIdFromPrincipal(),
+                profileUpdateRequest.nickname(),
+                profileUpdateRequest.address(),
+                profileUpdateRequest.roadAddress(),
+                profileUpdateRequest.cityName(),
+                profileUpdateRequest.districtName(),
+                profileUpdateRequest.townName(),
+                profileUpdateRequest.latitude(),
+                profileUpdateRequest.longitude()
+        );
         return SuccessResponse.success(SuccessMessage.OK, nicknameExistenceResponse);
     }
 

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.member.controller;
 
 import com.cocos.cocos.api.member.dto.request.LoginRequest;
+import com.cocos.cocos.api.member.dto.request.ProfileUpdateRequest;
 import com.cocos.cocos.api.member.dto.response.LoginResponse;
 import com.cocos.cocos.api.member.dto.response.MemberProfileResponse;
 import com.cocos.cocos.api.member.dto.response.ReissueTokenResponse;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member Controller", description = "사용자 관련 API")
@@ -46,7 +48,7 @@ public interface MemberControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "요청에 성공했습니다. ")
-    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(@RequestParam final String nickname);
+    public ResponseEntity<BaseResponse<NicknameExistenceResponse>> updateMemberProfile(@RequestBody final ProfileUpdateRequest profileUpdateRequest);
 
     @Operation(summary = "닉네임 중복 조회 API", description = "중복된 닉네임이 있는지 검사합니다. ")
     @ApiResponse(

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.cocos.cocos.api.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProfileUpdateRequest(
+        @Schema(description = "닉네임", example = "코코스")
+        String nickname,
+        @Schema(description = "주소", example = "~시 ~구 ~동")
+        String address,
+        @Schema(description = "도로명 주소", example = "~시 ~로 ~번길")
+        String roadAddress,
+        @Schema(description = "시/도 이름", example = "경기도")
+        String cityName,
+        @Schema(description = "시/군/구", example = "평택시")
+        String districtName,
+        @Schema(description = "읍/면/동", example = "비전2동")
+        String townName,
+        @Schema(description = "위도", example = "35.xxxx")
+        Double latitude,
+        @Schema(description = "경도", example = "128.xxx")
+        Double longitude
+) {
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -3,8 +3,14 @@ package com.cocos.cocos.api.member.service;
 import com.cocos.cocos.api.member.dto.response.*;
 import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.city.entity.City;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.entity.District;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.member.entity.Member;
+import com.cocos.cocos.db.member.entity.MemberAddress;
 import com.cocos.cocos.db.member.entity.MemberToken;
+import com.cocos.cocos.db.member.repository.MemberAddressRepository;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
 import com.cocos.cocos.db.town.entity.Town;
@@ -27,9 +33,13 @@ public class MemberService {
     private final JwtProvider jwtProvider;
     private final MemberTokenRepository memberTokenRepository;
     private final TownRepository townRepository;
+    private final MemberAddressRepository memberAddressRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
+    private static final Long DEFAULT_TOWN_ID = 1L;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
@@ -70,6 +80,16 @@ public class MemberService {
         } else {
             memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
         }
+        memberAddressRepository.save(
+                MemberAddress.builder()
+                        .memberId(member.getId())
+                        .address("주소를 설정해주세요!")
+                        .roadAddress("도로명 주소를 설정해주세요!")
+                        .latitude(0.0)
+                        .longitude(0.0)
+                        .townId(DEFAULT_TOWN_ID)
+                        .build()
+        );
         return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
     }
 
@@ -94,13 +114,23 @@ public class MemberService {
     }
 
     @Transactional
-    public NicknameExistenceResponse updateMemberProfile(final String nickname, final Long memberId) {
+    public NicknameExistenceResponse updateMemberProfile(final Long memberId, final String nickname,
+                                                         final String address, final String roadAddress,
+                                                         final String cityName, final String districtName, final String townName,
+                                                         final Double latitude, final Double longitude) {
+
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+
+        if (address != null && roadAddress != null) {
+            updateMemberLocation(memberId, address, roadAddress, cityName, districtName, townName, latitude, longitude);
+
+        }
+
         if (memberRepository.existsByNickname(nickname)) {
             return NicknameExistenceResponse.of(true);
         } else {
-            final Member member = memberRepository.findById(memberId).orElseThrow(
-                    () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
-            );
             member.updateFields(nickname);
             return NicknameExistenceResponse.of(false);
 
@@ -114,8 +144,8 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberLocationResponse getMemberLocation(final Long memberId) {
-        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
-        final Town town = townRepository.findById(member.getTownId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
+        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId);
+        final Town town = townRepository.findById(memberAddress.getTownId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
         return MemberLocationResponse.of(
                 town.getId(), town.getName()
         );
@@ -126,5 +156,18 @@ public class MemberService {
             return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }
         return memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+    }
+
+    private void updateMemberLocation(final Long memberId, final String address, final String roadAddress,
+                                      final String cityName, final String districtName, final String townName,
+                                      final Double latitude, final Double longitude) {
+        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId);
+        memberAddress.updateAddress(address, roadAddress, findTown(townName, districtName, cityName), latitude, longitude);
+    }
+
+    private Long findTown(final String townName, final String districtName, final String cityName) {
+        final City city = cityRepository.findByName(cityName);
+        final District district = districtRepository.findDistrictByNameAndCityId(districtName, city.getId());
+        return townRepository.findByNameAndDistrictId(townName, district.getId()).getId();
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -128,7 +128,7 @@ public class MemberService {
         if (memberRepository.existsByNickname(nickname)) {
             return NicknameExistenceResponse.of(true);
         } else {
-            member.updateFields(nickname);
+            member.updateNickname(nickname);
             return NicknameExistenceResponse.of(false);
 
         }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -40,6 +40,10 @@ public class MemberService {
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
     private static final Long DEFAULT_TOWN_ID = 1L;
+    private static final String DEFAULT_ADDRESS = "주소를 설정해주세요!";
+    private static final String DEFAULT_ROAD_ADDRESS = "도로명 주소를 설정해주세요!";
+    private static final Double DEFAULT_LATITUDE = 0.0;
+    private static final Double DEFAULT_LONGITUDE = 0.0;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
@@ -81,14 +85,7 @@ public class MemberService {
             memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
         }
         memberAddressRepository.save(
-                MemberAddress.builder()
-                        .memberId(member.getId())
-                        .address("주소를 설정해주세요!")
-                        .roadAddress("도로명 주소를 설정해주세요!")
-                        .latitude(0.0)
-                        .longitude(0.0)
-                        .townId(DEFAULT_TOWN_ID)
-                        .build()
+                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_TOWN_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
         );
         return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
     }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -141,7 +141,9 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberLocationResponse getMemberLocation(final Long memberId) {
-        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId);
+        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
+        );
         final Town town = townRepository.findById(memberAddress.getTownId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
         return MemberLocationResponse.of(
                 town.getId(), town.getName()
@@ -158,13 +160,15 @@ public class MemberService {
     private void updateMemberLocation(final Long memberId, final String address, final String roadAddress,
                                       final String cityName, final String districtName, final String townName,
                                       final Double latitude, final Double longitude) {
-        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId);
+        final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
+        );
         memberAddress.updateAddress(address, roadAddress, findTown(townName, districtName, cityName), latitude, longitude);
     }
 
     private Long findTown(final String townName, final String districtName, final String cityName) {
         final City city = cityRepository.findByName(cityName);
-        final District district = districtRepository.findDistrictByNameAndCityId(districtName, city.getId());
+        final District district = districtRepository.findByNameAndCityId(districtName, city.getId());
         return townRepository.findByNameAndDistrictId(townName, district.getId()).getId();
     }
 }

--- a/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
+++ b/src/main/java/com/cocos/cocos/db/city/repository/CityRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CityRepository extends JpaRepository<City, Long> {
+    City findByName(final String name);
 }

--- a/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
+++ b/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface DistrictRepository extends JpaRepository<District, Long> {
 
     List<District> findByCityId(final Long cityId);
+
+    District findDistrictByNameAndCityId(final String name, final Long cityId);
 }

--- a/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
+++ b/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
@@ -11,5 +11,5 @@ public interface DistrictRepository extends JpaRepository<District, Long> {
 
     List<District> findByCityId(final Long cityId);
 
-    District findDistrictByNameAndCityId(final String name, final Long cityId);
+    District findByNameAndCityId(final String name, final Long cityId);
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -37,18 +37,15 @@ public class Member extends BaseTime {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin;
 
-    @Column(name = "town_id", nullable = false)
-    private Long townId;
 
     @Builder
-    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin, final Long townId) {
+    public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin) {
         this.nickname = nickname;
         this.email = email;
         this.image = image;
         this.platform = platform;
         this.sub = sub;
         this.isAdmin = isAdmin;
-        this.townId = townId;
     }
 
     public void updateFields(final String nickname) {

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -48,7 +48,7 @@ public class Member extends BaseTime {
         this.isAdmin = isAdmin;
     }
 
-    public void updateFields(final String nickname) {
+    public void updateNickname(final String nickname) {
         if (nickname != null) this.nickname = nickname;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
@@ -1,0 +1,54 @@
+package com.cocos.cocos.db.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "member_address")
+public class MemberAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "member_id", unique = true)
+    private Long memberId;
+
+    @Column(name = "address", unique = true)
+    private String address;
+
+    @Column(name = "road_address", unique = true)
+    private String roadAddress;
+
+    @Column(name = "town_id", unique = true)
+    private Long townId;
+
+    @Column(name = "latitude", unique = true)
+    private Double latitude;
+
+    @Column(name = "longitude", unique = true)
+    private Double longitude;
+
+    @Builder
+    public MemberAddress(final Long memberId, final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+        this.memberId = memberId;
+        this.address = address;
+        this.roadAddress = roadAddress;
+        this.townId = townId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public void updateAddress(final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+        this.address = address;
+        this.roadAddress = roadAddress;
+        this.townId = townId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
@@ -51,4 +51,15 @@ public class MemberAddress {
         this.latitude = latitude;
         this.longitude = longitude;
     }
+
+    public static MemberAddress createDefaultMemberAddress(final Long memberId, final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+        return MemberAddress.builder()
+                .memberId(memberId)
+                .address(address)
+                .roadAddress(roadAddress)
+                .latitude(latitude)
+                .longitude(longitude)
+                .townId(townId)
+                .build();
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
@@ -4,7 +4,9 @@ import com.cocos.cocos.db.member.entity.MemberAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long> {
-    MemberAddress findByMemberId(final Long memberId);
+    Optional<MemberAddress> findByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
@@ -6,7 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long> {
-    boolean existsByMemberId(final Long memberId);
-
     MemberAddress findByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.db.member.repository;
+
+import com.cocos.cocos.db.member.entity.MemberAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long> {
+    boolean existsByMemberId(final Long memberId);
+
+    MemberAddress findByMemberId(final Long memberId);
+}

--- a/src/main/java/com/cocos/cocos/db/town/repository/TownRepository.java
+++ b/src/main/java/com/cocos/cocos/db/town/repository/TownRepository.java
@@ -4,6 +4,9 @@ import com.cocos.cocos.db.town.entity.Town;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TownRepository extends JpaRepository<Town, Long> {
+    Town findByNameAndDistrictId(final String name, final Long districtId);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -53,6 +53,7 @@ public enum FailMessage {
     NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "애완동물을 찾을 수 없습니다. "),
     NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
     NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, 40417, "동을 찾을 수 없습니다. "),
+    NOT_FOUND_MEMBER_ADDRESS(HttpStatus.NOT_FOUND, 40418, "사용자 위치를 찾을 수 없습니다."),
 
     /**
      * 405


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #154 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

* MemberAddress 테이블을 따로 두고 Member에 있던 townId와 주소, 도로명 주소, 좌표 등의 정보를 담도록 설계했습니다.
* 로그인 시에는 병원리뷰를 보려고 할 때 사용자에게 설정된 도시 주소를 통해 가져와야하는데, 처음 사용자가 로그인 한 후 병원리뷰를 볼 때는 도시가 설정되어 있지 않으므로 로그인 과정에서 기본 townId를 1로 설정한 MemberAddress정보를 저장했습니다.
* 이에 따라서 사용자의 위치정보를 조회하는 경우에도 MemberAddress 객체에서 들고 오도록 수정했습니다.
* 동이 겹치는 상황을 고려하여 모든 정보가 일치하는 동을 찾도록 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
