### PR TITLE
Fix: MemberAddress 필드 수정에 따른 API 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -43,9 +43,8 @@ public class MemberController implements MemberControllerSwagger {
                 profileUpdateRequest.nickname(),
                 profileUpdateRequest.address(),
                 profileUpdateRequest.roadAddress(),
-                profileUpdateRequest.cityName(),
-                profileUpdateRequest.districtName(),
-                profileUpdateRequest.townName(),
+                profileUpdateRequest.locationId(),
+                profileUpdateRequest.locationType(),
                 profileUpdateRequest.latitude(),
                 profileUpdateRequest.longitude()
         );

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.api.member.dto.request;
 
+import com.cocos.cocos.enums.location.LocationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProfileUpdateRequest(
@@ -18,6 +19,10 @@ public record ProfileUpdateRequest(
         @Schema(description = "위도", example = "35.xxxx")
         Double latitude,
         @Schema(description = "경도", example = "128.xxx")
-        Double longitude
+        Double longitude,
+        @Schema(description = "위치 아이디", example = "1")
+        Long locationId,
+        @Schema(description = "위치 종류", example = "CITY | DISTRICT")
+        LocationType locationType
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberLocationResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberLocationResponse.java
@@ -4,13 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원 위치 응답 예시", example = "{\"townId\": 1, \"townName\": \"논현동\"}")
 public record MemberLocationResponse(
-        @Schema(description = "동 아이디", example = "1")
-        Long townId,
-
-        @Schema(description = "동 이름", example = "논현동")
-        String townName
+        @Schema(description = "위치 아이디", example = "1")
+        Long locationId,
+        @Schema(description = "위치 이름", example = "강남구")
+        String locationName,
+        @Schema(description = "위치 타입", example = "CITY | DISTRICT")
+        String locationType
 ) {
-    public static MemberLocationResponse of(final Long townId, final String townName) {
-        return new MemberLocationResponse(townId, townName);
+    public static MemberLocationResponse of(final Long locationId, final String locationName, final String locationType) {
+        return new MemberLocationResponse(locationId, locationName, locationType);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -3,14 +3,16 @@ package com.cocos.cocos.api.member.service;
 import com.cocos.cocos.api.member.dto.response.*;
 import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.city.entity.City;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.entity.District;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.entity.MemberAddress;
 import com.cocos.cocos.db.member.entity.MemberToken;
 import com.cocos.cocos.db.member.repository.MemberAddressRepository;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
-import com.cocos.cocos.db.town.entity.Town;
-import com.cocos.cocos.db.town.repository.TownRepository;
 import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
@@ -29,8 +31,9 @@ public class MemberService {
     private final KakaoLoginClient kakaoLoginClient;
     private final JwtProvider jwtProvider;
     private final MemberTokenRepository memberTokenRepository;
-    private final TownRepository townRepository;
     private final MemberAddressRepository memberAddressRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
@@ -140,10 +143,18 @@ public class MemberService {
         final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
         );
-        final Town town = townRepository.findById(memberAddress.getLocationId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
-        return MemberLocationResponse.of(
-                town.getId(), town.getName()
-        );
+        if (memberAddress.getLocationType().equals(LocationType.CITY)) {
+            final City city = cityRepository.findById(memberAddress.getLocationId()).orElseThrow(
+                    () -> new CocosException(FailMessage.NOT_FOUND_CITY)
+            );
+            return MemberLocationResponse.of(city.getId(), city.getName(), LocationType.CITY.toString());
+        } else if (memberAddress.getLocationType().equals(LocationType.DISTRICT)) {
+            final District district = districtRepository.findById(memberAddress.getLocationId()).orElseThrow(
+                    () -> new CocosException(FailMessage.NOT_FOUND_DISTRICT)
+            );
+            return MemberLocationResponse.of(district.getId(), district.getName(), LocationType.DISTRICT.toString());
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST);
     }
 
     private Member findMember(final String nickname, final Long memberId) {

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -3,10 +3,6 @@ package com.cocos.cocos.api.member.service;
 import com.cocos.cocos.api.member.dto.response.*;
 import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.common.exception.CocosException;
-import com.cocos.cocos.db.city.entity.City;
-import com.cocos.cocos.db.city.repository.CityRepository;
-import com.cocos.cocos.db.district.entity.District;
-import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.entity.MemberAddress;
 import com.cocos.cocos.db.member.entity.MemberToken;
@@ -15,6 +11,7 @@ import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
 import com.cocos.cocos.db.town.entity.Town;
 import com.cocos.cocos.db.town.repository.TownRepository;
+import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.KakaoLoginClient;
@@ -34,8 +31,6 @@ public class MemberService {
     private final MemberTokenRepository memberTokenRepository;
     private final TownRepository townRepository;
     private final MemberAddressRepository memberAddressRepository;
-    private final CityRepository cityRepository;
-    private final DistrictRepository districtRepository;
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
@@ -44,6 +39,7 @@ public class MemberService {
     private static final String DEFAULT_ROAD_ADDRESS = "도로명 주소를 설정해주세요!";
     private static final Double DEFAULT_LATITUDE = 0.0;
     private static final Double DEFAULT_LONGITUDE = 0.0;
+    private static final LocationType DEFAULT_LOCATION_TYPE = LocationType.DISTRICT;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
@@ -85,7 +81,7 @@ public class MemberService {
             memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
         }
         memberAddressRepository.save(
-                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_TOWN_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
+                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_TOWN_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_LOCATION_TYPE)
         );
         return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
     }
@@ -113,7 +109,7 @@ public class MemberService {
     @Transactional
     public NicknameExistenceResponse updateMemberProfile(final Long memberId, final String nickname,
                                                          final String address, final String roadAddress,
-                                                         final String cityName, final String districtName, final String townName,
+                                                         final Long locationId, final LocationType locationType,
                                                          final Double latitude, final Double longitude) {
 
         final Member member = memberRepository.findById(memberId).orElseThrow(
@@ -121,7 +117,7 @@ public class MemberService {
         );
 
         if (address != null && roadAddress != null) {
-            updateMemberLocation(memberId, address, roadAddress, cityName, districtName, townName, latitude, longitude);
+            updateMemberLocation(memberId, address, roadAddress, locationId, locationType, latitude, longitude);
 
         }
 
@@ -144,7 +140,7 @@ public class MemberService {
         final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
         );
-        final Town town = townRepository.findById(memberAddress.getTownId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
+        final Town town = townRepository.findById(memberAddress.getLocationId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_TOWN));
         return MemberLocationResponse.of(
                 town.getId(), town.getName()
         );
@@ -158,17 +154,11 @@ public class MemberService {
     }
 
     private void updateMemberLocation(final Long memberId, final String address, final String roadAddress,
-                                      final String cityName, final String districtName, final String townName,
+                                      final Long locationId, final LocationType locationType,
                                       final Double latitude, final Double longitude) {
         final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
         );
-        memberAddress.updateAddress(address, roadAddress, findTown(townName, districtName, cityName), latitude, longitude);
-    }
-
-    private Long findTown(final String townName, final String districtName, final String cityName) {
-        final City city = cityRepository.findByName(cityName);
-        final District district = districtRepository.findByNameAndCityId(districtName, city.getId());
-        return townRepository.findByNameAndDistrictId(townName, district.getId()).getId();
+        memberAddress.updateAddress(address, roadAddress, locationId, latitude, longitude, locationType);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
 
     //ToDo: yml에 기입해야하는 지 고민 중
     private static final String MEMBER_BASE_IMAGE_URL = "member/baseProfileImage.png";
-    private static final Long DEFAULT_TOWN_ID = 1L;
+    private static final Long DEFAULT_LOCATION_ID = 1L;
     private static final String DEFAULT_ADDRESS = "주소를 설정해주세요!";
     private static final String DEFAULT_ROAD_ADDRESS = "도로명 주소를 설정해주세요!";
     private static final Double DEFAULT_LATITUDE = 0.0;
@@ -81,7 +81,7 @@ public class MemberService {
             memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
         }
         memberAddressRepository.save(
-                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_TOWN_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_LOCATION_TYPE)
+                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_LOCATION_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_LOCATION_TYPE)
         );
         return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
     }

--- a/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.db.member.entity;
 
+import com.cocos.cocos.enums.location.LocationType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,8 +26,12 @@ public class MemberAddress {
     @Column(name = "road_address", nullable = false)
     private String roadAddress;
 
-    @Column(name = "town_id", nullable = false)
-    private Long townId;
+    @Column(name = "location_id", nullable = false)
+    private Long locationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "locatoin_type", nullable = false)
+    private LocationType locationType;
 
     @Column(name = "latitude", nullable = false)
     private Double latitude;
@@ -35,31 +40,34 @@ public class MemberAddress {
     private Double longitude;
 
     @Builder
-    public MemberAddress(final Long memberId, final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+    public MemberAddress(final Long memberId, final String address, final String roadAddress, final Long locationId, final Double latitude, final Double longitude, final LocationType locationType) {
         this.memberId = memberId;
         this.address = address;
         this.roadAddress = roadAddress;
-        this.townId = townId;
+        this.locationId = locationId;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.locationType = locationType;
     }
 
-    public void updateAddress(final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+    public void updateAddress(final String address, final String roadAddress, final Long locationId, final Double latitude, final Double longitude, final LocationType locationType) {
         this.address = address;
         this.roadAddress = roadAddress;
-        this.townId = townId;
+        this.locationId = locationId;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.locationType = locationType;
     }
 
-    public static MemberAddress createDefaultMemberAddress(final Long memberId, final String address, final String roadAddress, final Long townId, final Double latitude, final Double longitude) {
+    public static MemberAddress createDefaultMemberAddress(final Long memberId, final String address, final String roadAddress, final Long locationId, final Double latitude, final Double longitude, final LocationType locationType) {
         return MemberAddress.builder()
                 .memberId(memberId)
                 .address(address)
                 .roadAddress(roadAddress)
                 .latitude(latitude)
                 .longitude(longitude)
-                .townId(townId)
+                .locationId(locationId)
+                .locationType(locationType)
                 .build();
     }
 }

--- a/src/main/java/com/cocos/cocos/enums/location/LocationType.java
+++ b/src/main/java/com/cocos/cocos/enums/location/LocationType.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.enums.location;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
+
+public enum LocationType {
+    CITY,
+    DISTRICT;
+
+    public static LocationType create(final String locationType) {
+        for (LocationType value : LocationType.values()) {
+            if (value.toString().equals(locationType)) {
+                return value;
+            }
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_LOCATION_TYPE);
+    }
+}

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -56,6 +56,8 @@ public enum FailMessage {
     NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
     NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, 40417, "동을 찾을 수 없습니다. "),
     NOT_FOUND_MEMBER_ADDRESS(HttpStatus.NOT_FOUND, 40418, "사용자 위치를 찾을 수 없습니다."),
+    NOT_FOUND_CITY(HttpStatus.NOT_FOUND, 40419, "시/도를 찾을 수 없습니다."),
+    NOT_FOUND_DISTRICT(HttpStatus.NOT_FOUND, 40420, "시/군/구를 찾을 수 없습니다."),
 
     /**
      * 405

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -18,6 +18,8 @@ public enum FailMessage {
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40004, "json 오류 혹은 reqeust body 필드 오류 입니다. "),
     BAD_REQUEST_INVALID_SORT_CRITERIA(HttpStatus.BAD_REQUEST, 40005, "유효하지 않은 정렬 기준입니다."),
     BAD_REQUEST_INVALID_TOKEN(HttpStatus.BAD_REQUEST, 40006, "유효하지 않은 인증정보입니다."),
+    BAD_REQUEST_INVALID_LOCATION_TYPE(HttpStatus.BAD_REQUEST, 40007, "유효하지 않은 위치 타입입니다."),
+
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/util/LocationTypeConvertor.java
+++ b/src/main/java/com/cocos/cocos/util/LocationTypeConvertor.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.util;
+
+import com.cocos.cocos.enums.location.LocationType;
+import org.springframework.core.convert.converter.Converter;
+
+public class LocationTypeConvertor implements Converter<String, LocationType> {
+
+    @Override
+    public LocationType convert(final String locationType) {
+        return LocationType.create(locationType.toUpperCase());
+    }
+
+
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #163 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* MemberAddress에 있던 townId를 locationId로 수정한 뒤 LocationType(CITY, DISTRICT)를 저장하도록 수정했습니다.
* cityiId와 districtId를 받아 cityId가 null인 경우를 나눠서 저장하려고 했지만 id를 저장해도 이 id가 CITY인지 DISTRICT인지를 표시하는 것이 불가피하다고 생각했습니다. 그래서 Enum을 만들고 보니 입력 받을 때 차라리 CITY와 DISTRICT를 받으면 null검증 로직 없이 바로 저장할 수 있을 거라 생각했습니다.


## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
