### PR TITLE
Hotfix: 회원가입 시에만 기본 주소 추가하도록 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -83,9 +83,12 @@ public class MemberService {
         } else {
             memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
         }
-        memberAddressRepository.save(
-                MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_LOCATION_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_LOCATION_TYPE)
-        );
+        if (!memberAddressRepository.existsByMemberId(member.getId())) {
+            memberAddressRepository.save(
+                    MemberAddress.createDefaultMemberAddress(member.getId(), DEFAULT_ADDRESS, DEFAULT_ROAD_ADDRESS, DEFAULT_LOCATION_ID, DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_LOCATION_TYPE)
+            );
+        }
+
         return LoginResponse.of(TokenResponse.of(accessToken, refreshToken), isCompletedSignUp);
     }
 

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long> {
     Optional<MemberAddress> findByMemberId(final Long memberId);
+
+    boolean existsByMemberId(final Long memberId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #165 

## 👷 **작업한 내용**
- 회원가입 시에만 기본 주소 추가하도록 수정

## 🚨 **참고 사항**
- 로그인할 때도 주소가 저장되도록 되어있어서 로그인할 때마다 주소가 생성되는 오류를 해결했습니다. 
- 디비에 중복되어 생성된 데이터도 지웠습니다. 
