### PR TITLE
Feat: 병원 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/controller/HospitalController.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/controller/HospitalController.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.hospital.controller;
 
 import com.cocos.cocos.api.hospital.dto.request.HospitalListRequest;
+import com.cocos.cocos.api.hospital.dto.response.HospitalDetailResponse;
 import com.cocos.cocos.api.hospital.dto.response.HospitalListResponse;
 import com.cocos.cocos.api.hospital.service.HospitalService;
 import com.cocos.cocos.common.response.BaseResponse;
@@ -22,5 +23,12 @@ public class HospitalController implements HospitalControllerSwagger {
     public ResponseEntity<BaseResponse<HospitalListResponse>> getHospitals(
             @Valid @RequestBody HospitalListRequest hospitalListRequest) {
         return SuccessResponse.success(SuccessMessage.OK, hospitalService.getHospitals(hospitalListRequest.townId(), hospitalListRequest.cursorId(), hospitalListRequest.size(), hospitalListRequest.keyword(), hospitalListRequest.sortBy(), hospitalListRequest.cursorReviewCount()));
+    }
+
+    @GetMapping("/{hospitalId}")
+    public ResponseEntity<BaseResponse<HospitalDetailResponse>> getHospitalDetail(
+            @PathVariable(name = "hospitalId") final Long hospitalId
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, hospitalService.getHospitalDetail(hospitalId));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/controller/HospitalControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/controller/HospitalControllerSwagger.java
@@ -1,13 +1,19 @@
 package com.cocos.cocos.api.hospital.controller;
 
 import com.cocos.cocos.api.hospital.dto.request.HospitalListRequest;
+import com.cocos.cocos.api.hospital.dto.response.HospitalDetailResponse;
 import com.cocos.cocos.api.hospital.dto.response.HospitalListResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Hospital Controller", description = "병원 관련 API")
@@ -20,5 +26,15 @@ public interface HospitalControllerSwagger {
     )
     public ResponseEntity<BaseResponse<HospitalListResponse>> getHospitals(
             @Valid @RequestBody HospitalListRequest hospitalListRequest
+    );
+
+    @Operation(summary = "병원 상세 조회 API", description = "병원 상세 정보 조회 API입니다. ")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다."
+    )
+    @Parameter(name = "hospitalId", description = "병원 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    public ResponseEntity<BaseResponse<HospitalDetailResponse>> getHospitalDetail(
+            @PathVariable final Long hospitalId
     );
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
@@ -15,12 +15,10 @@ public record HospitalDetailResponse(
         String introduction,
         @Schema(description = "병원 주소", example = "서울특별시 강남구 논현동")
         String address,
-        @Schema(description = "병원 도로명 주소", example = "서울특별시 강남구 테헤란로")
-        String roadAddress,
         @Schema(description = "병원 이미지", example = "https://www.~~")
         String image
 ) {
-    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String roadAddress, final String image) {
-        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, roadAddress, image);
+    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String image) {
+        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, image);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
@@ -1,0 +1,26 @@
+package com.cocos.cocos.api.hospital.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record HospitalDetailResponse(
+        @Schema(description = "병원 이름", example = "코코스 동물병원")
+        String name,
+        @Schema(description = "병원 전화번호", example = "02-1234-5671")
+        String phoneNumber,
+        @Schema(description = "병원 태그", example = "{강아지, 심장병}")
+        List<String> tags,
+        @Schema(description = "병원 소개", example = "이 동물병원은 지상 최고의 동물병원입니다.")
+        String introduction,
+        @Schema(description = "병원 주소", example = "서울특별시 강남구 논현동")
+        String address,
+        @Schema(description = "병원 도로명 주소", example = "서울특별시 강남구 테헤란로")
+        String roadAddress,
+        @Schema(description = "병원 이미지", example = "https://www.~~")
+        String image
+) {
+    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String roadAddress, final String image) {
+        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, roadAddress, image);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
@@ -9,7 +9,7 @@ public record HospitalDetailResponse(
         String name,
         @Schema(description = "병원 전화번호", example = "02-1234-5671")
         String phoneNumber,
-        @Schema(description = "병원 태그", example = "{강아지, 심장병}")
+        @Schema(description = "병원 태그", example = "[강아지, 심장병]")
         List<String> tags,
         @Schema(description = "병원 소개", example = "이 동물병원은 지상 최고의 동물병원입니다.")
         String introduction,

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -86,9 +86,7 @@ public class HospitalService {
                 () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
         );
         final List<Long> hospitalTagIds = getHospitalTagIds(hospitalId);
-        final List<String> hospitalTags = hospitalTagRepository.findAllByIdIn(hospitalTagIds).stream()
-                .map(HospitalTag::getLabel)
-                .toList();
+        final List<String> hospitalTags = getHospitalTagLabels(hospitalTagIds);
 
         return HospitalDetailResponse.of(
                 hospital.getName(),
@@ -104,6 +102,12 @@ public class HospitalService {
     private List<Long> getHospitalTagIds(final Long hospitalId) {
         return hospitalTagMappingRepository.findAllByHospitalId(hospitalId).stream()
                 .map(HospitalTagMapping::getHospitalTagId)
+                .toList();
+    }
+
+    private List<String> getHospitalTagLabels(final List<Long> hospitalTagIds) {
+        return hospitalTagRepository.findAllByIdIn(hospitalTagIds).stream()
+                .map(HospitalTag::getLabel)
                 .toList();
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -93,8 +93,7 @@ public class HospitalService {
                 hospital.getPhoneNumber(),
                 hospitalTags,
                 hospital.getIntroduction(),
-                hospital.getAddress(),
-                hospital.getRoadAddress(),
+                getHospitalAddress(hospital),
                 appDataS3Client.getPresignedUrl(hospital.getImage())
         );
     }
@@ -109,5 +108,12 @@ public class HospitalService {
         return hospitalTagRepository.findAllByIdIn(hospitalTagIds).stream()
                 .map(HospitalTag::getLabel)
                 .toList();
+    }
+
+    private String getHospitalAddress(final Hospital hospital) {
+        if (hospital.getRoadAddress() == null) {
+            return hospital.getAddress();
+        }
+        return hospital.getRoadAddress();
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -85,9 +85,7 @@ public class HospitalService {
         final Hospital hospital = hospitalRepository.findById(hospitalId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
         );
-        final List<Long> hospitalTagIds = hospitalTagMappingRepository.findAllByHospitalId(hospitalId).stream()
-                .map(HospitalTagMapping::getHospitalTagId)
-                .toList();
+        final List<Long> hospitalTagIds = getHospitalTagIds(hospitalId);
         final List<String> hospitalTags = hospitalTagRepository.findAllByIdIn(hospitalTagIds).stream()
                 .map(HospitalTag::getLabel)
                 .toList();
@@ -101,5 +99,11 @@ public class HospitalService {
                 hospital.getRoadAddress(),
                 appDataS3Client.getPresignedUrl(hospital.getImage())
         );
+    }
+
+    private List<Long> getHospitalTagIds(final Long hospitalId) {
+        return hospitalTagMappingRepository.findAllByHospitalId(hospitalId).stream()
+                .map(HospitalTagMapping::getHospitalTagId)
+                .toList();
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -1,12 +1,18 @@
 package com.cocos.cocos.api.hospital.service;
 
+import com.cocos.cocos.api.hospital.dto.response.HospitalDetailResponse;
 import com.cocos.cocos.api.hospital.dto.response.HospitalListResponse;
 import com.cocos.cocos.api.hospital.dto.response.HospitalResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.hospital.entity.Hospital;
+import com.cocos.cocos.db.hospital.entity.HospitalTag;
+import com.cocos.cocos.db.hospital.entity.HospitalTagMapping;
 import com.cocos.cocos.db.hospital.repository.HospitalRepository;
+import com.cocos.cocos.db.hospital.repository.HospitalTagMappingRepository;
+import com.cocos.cocos.db.hospital.repository.HospitalTagRepository;
 import com.cocos.cocos.enums.hospital.HospitalSortCriteria;
 import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.external.AppDataS3Client;
 import com.cocos.cocos.util.SortConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +28,9 @@ import java.util.List;
 public class HospitalService {
 
     private final HospitalRepository hospitalRepository;
+    private final HospitalTagRepository hospitalTagRepository;
+    private final HospitalTagMappingRepository hospitalTagMappingRepository;
+    private final AppDataS3Client appDataS3Client;
 
     @Transactional(readOnly = true)
     public HospitalListResponse getHospitals(
@@ -69,5 +78,28 @@ public class HospitalService {
             }
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SORT_CRITERIA);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public HospitalDetailResponse getHospitalDetail(final Long hospitalId) {
+        final Hospital hospital = hospitalRepository.findById(hospitalId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
+        );
+        final List<Long> hospitalTagIds = hospitalTagMappingRepository.findAllByHospitalId(hospitalId).stream()
+                .map(HospitalTagMapping::getHospitalTagId)
+                .toList();
+        final List<String> hospitalTags = hospitalTagRepository.findAllByIdIn(hospitalTagIds).stream()
+                .map(HospitalTag::getLabel)
+                .toList();
+
+        return HospitalDetailResponse.of(
+                hospital.getName(),
+                hospital.getPhoneNumber(),
+                hospitalTags,
+                hospital.getIntroduction(),
+                hospital.getAddress(),
+                hospital.getRoadAddress(),
+                appDataS3Client.getPresignedUrl(hospital.getImage())
+        );
     }
 }

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -29,10 +29,9 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/api/dev/test/**",
             "/api/dev/locations",
-            "/api/local/hospitals",
-            "/api/dev/hospitals",
+            "/api/local/hospitals/**",
+            "/api/dev/hospitals/**",
             "api/local/members/login",
-            "/api/dev/hospitals"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
             "/api/dev/locations",
             "/api/local/hospitals",
             "/api/dev/hospitals",
-            "api/local/members/login"
+            "api/local/members/login",
+            "/api/dev/hospitals"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
@@ -25,13 +25,13 @@ public class Hospital {
     @Column(name = "road_address", nullable = true)
     private String roadAddress;
 
-    @Column(name = "image", nullable = false)
+    @Column(name = "image", nullable = true)
     private String image;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(name = "latitude", nullable = true)
     private Double latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(name = "longitude", nullable = true)
     private Double longitude;
 
     @Column(name = "review_count", nullable = false)
@@ -40,10 +40,10 @@ public class Hospital {
     @Column(name = "town_id", nullable = false)
     private Long townId;
 
-    @Column(name = "phone_number", nullable = false)
+    @Column(name = "phone_number", nullable = true)
     private String phoneNumber;
 
-    @Column(name = "introduction", nullable = false)
+    @Column(name = "introduction", nullable = true)
     private String introduction;
 
     @Builder

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
@@ -19,10 +19,10 @@ public class Hospital {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "address", nullable = false)
+    @Column(name = "address", nullable = true)
     private String address;
 
-    @Column(name = "road_address", nullable = false)
+    @Column(name = "road_address", nullable = true)
     private String roadAddress;
 
     @Column(name = "image", nullable = false)

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
@@ -22,6 +22,9 @@ public class Hospital {
     @Column(name = "address", nullable = false)
     private String address;
 
+    @Column(name = "road_address", nullable = false)
+    private String roadAddress;
+
     @Column(name = "image", nullable = false)
     private String image;
 
@@ -37,15 +40,24 @@ public class Hospital {
     @Column(name = "town_id", nullable = false)
     private Long townId;
 
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column(name = "introduction", nullable = false)
+    private String introduction;
+
     @Builder
-    public Hospital(final String name, final String address, final String image, final Double latitude, final Double longitude, final int reviewCount, final Long townId) {
+    public Hospital(final String name, final String address, final String roadAddress, final String image, final Double latitude, final Double longitude, final int reviewCount, final Long townId, final String phoneNumber, final String introduction) {
         this.name = name;
         this.address = address;
+        this.roadAddress = roadAddress;
         this.image = image;
         this.latitude = latitude;
         this.longitude = longitude;
         this.reviewCount = reviewCount;
         this.townId = townId;
+        this.phoneNumber = phoneNumber;
+        this.introduction = introduction;
     }
 
     public void addReview() {

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/HospitalTag.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/HospitalTag.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.db.hospital.entity;
+
+import com.cocos.cocos.db.BaseTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "hospital_tag")
+public class HospitalTag extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "label", nullable = false)
+    private String label;
+
+    @Builder
+    public HospitalTag(final String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/HospitalTagMapping.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/HospitalTagMapping.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.db.hospital.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "hospital_tag_mapping")
+public class HospitalTagMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "hospital_id", nullable = false)
+    private Long hospitalId;
+
+    @Column(name = "hospital_tag_id", nullable = false)
+    private Long hospitalTagId;
+
+    @Builder
+    public HospitalTagMapping(final Long hospitalId, final Long hospitalTagId) {
+        this.hospitalId = hospitalId;
+        this.hospitalTagId = hospitalTagId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalTagMappingRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalTagMappingRepository.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.db.hospital.repository;
+
+import com.cocos.cocos.db.hospital.entity.HospitalTag;
+import com.cocos.cocos.db.hospital.entity.HospitalTagMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HospitalTagMappingRepository extends JpaRepository<HospitalTagMapping, Long> {
+    List<HospitalTagMapping> findAllByHospitalId(final Long hospitalId);
+
+}

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalTagRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalTagRepository.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.db.hospital.repository;
+
+import com.cocos.cocos.db.hospital.entity.HospitalTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HospitalTagRepository extends JpaRepository<HospitalTag, Long> {
+    List<HospitalTag> findAllByIdIn(final List<Long> hospitalIds);
+}

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -58,6 +58,7 @@ public enum FailMessage {
     NOT_FOUND_MEMBER_ADDRESS(HttpStatus.NOT_FOUND, 40418, "사용자 위치를 찾을 수 없습니다."),
     NOT_FOUND_CITY(HttpStatus.NOT_FOUND, 40419, "시/도를 찾을 수 없습니다."),
     NOT_FOUND_DISTRICT(HttpStatus.NOT_FOUND, 40420, "시/군/구를 찾을 수 없습니다."),
+    NOT_FOUND_HOSPITAL(HttpStatus.NOT_FOUND, 40421, "병원을 찾을 수 없습니다."),
 
     /**
      * 405

--- a/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
+++ b/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
@@ -47,8 +47,8 @@ public class HospitalServiceTest {
     private AppDataS3Client appDataS3Client;
 
     @Test
-    @DisplayName("병원 상세 정보를 조회할 수 있다.")
-    void getHospitalDetail() {
+    @DisplayName("도로명 주소가 있는 병원 상세 정보를 조회할 수 있다.")
+    void getHospitalDetailWithRoadAddress() {
         //given
         final Long hospitalId = 1L;
         final Long hospitalTagId1 = 2L;
@@ -92,8 +92,64 @@ public class HospitalServiceTest {
                 "병원 전화번호",
                 new ArrayList<>(List.of("라벨1")),
                 "병원 소개",
-                "병원 주소",
                 "병원 도로명주소",
+                "병원 이미지"
+        );
+
+        //when
+        final HospitalDetailResponse actual = hospitalService.getHospitalDetail(hospitalId);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveAssertion().isEqualTo(expected);
+        Assertions.assertThat(actual.address()).isEqualTo("병원 도로명주소");
+    }
+
+    @Test
+    @DisplayName("도로명 주소가 없는 병원 상세 정보를 조회할 수 있다.")
+    void getHospitalDetailWithoutRoadAddress() {
+        //given
+        final Long hospitalId = 1L;
+        final Long hospitalTagId1 = 2L;
+
+        final Hospital hospital = Hospital.builder()
+                .name("병원 이름")
+                .image("병원 이미지")
+                .introduction("병원 소개")
+                .phoneNumber("병원 전화번호")
+                .address("병원 주소")
+                .latitude(35.0)
+                .longitude(128.0)
+                .reviewCount(0)
+                .townId(1L)
+                .build();
+
+        final HospitalTag hospitalTag1 = HospitalTag.builder()
+                .label("라벨1")
+                .build();
+
+        final HospitalTag hospitalTag2 = HospitalTag.builder()
+                .label("라벨2")
+                .build();
+
+        final HospitalTagMapping hospitalTagMapping = HospitalTagMapping.builder()
+                .hospitalTagId(hospitalTagId1)
+                .hospitalId(hospitalId)
+                .build();
+
+        final List<HospitalTagMapping> hospitalTagMappings = new ArrayList<>(List.of(hospitalTagMapping));
+        final List<HospitalTag> hospitalTags = new ArrayList<>(List.of(hospitalTag1));
+
+        BDDMockito.given(hospitalRepository.findById(any())).willReturn(Optional.ofNullable(hospital));
+        BDDMockito.given(hospitalTagMappingRepository.findAllByHospitalId(any())).willReturn(hospitalTagMappings);
+        BDDMockito.given(hospitalTagRepository.findAllByIdIn(any())).willReturn(hospitalTags);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(any())).willReturn(hospital.getImage());
+
+        final HospitalDetailResponse expected = HospitalDetailResponse.of(
+                "병원 이름",
+                "병원 전화번호",
+                new ArrayList<>(List.of("라벨1")),
+                "병원 소개",
+                "병원 주소",
                 "병원 이미지"
         );
 

--- a/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
+++ b/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
@@ -1,0 +1,108 @@
+package com.cocos.cocos.hospital;
+
+import com.cocos.cocos.api.hospital.dto.response.HospitalDetailResponse;
+import com.cocos.cocos.api.hospital.service.HospitalService;
+import com.cocos.cocos.db.hospital.entity.Hospital;
+import com.cocos.cocos.db.hospital.entity.HospitalTag;
+import com.cocos.cocos.db.hospital.entity.HospitalTagMapping;
+import com.cocos.cocos.db.hospital.repository.HospitalRepository;
+import com.cocos.cocos.db.hospital.repository.HospitalTagMappingRepository;
+import com.cocos.cocos.db.hospital.repository.HospitalTagRepository;
+import com.cocos.cocos.external.AppDataS3Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("병원 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class HospitalServiceTest {
+
+    @InjectMocks
+    private HospitalService hospitalService;
+
+    @Mock
+    private HospitalRepository hospitalRepository;
+
+    @Mock
+    private HospitalTagRepository hospitalTagRepository;
+
+    @Mock
+    private HospitalTagMappingRepository hospitalTagMappingRepository;
+
+    @Mock
+    private AppDataS3Client appDataS3Client;
+
+    @Test
+    @DisplayName("병원 상세 정보를 조회할 수 있다.")
+    void getHospitalDetail() {
+        //given
+        final Long hospitalId = 1L;
+        final Long hospitalTagId1 = 2L;
+
+        final Hospital hospital = Hospital.builder()
+                .name("병원 이름")
+                .image("병원 이미지")
+                .introduction("병원 소개")
+                .phoneNumber("병원 전화번호")
+                .address("병원 주소")
+                .roadAddress("병원 도로명주소")
+                .latitude(35.0)
+                .longitude(128.0)
+                .reviewCount(0)
+                .townId(1L)
+                .build();
+
+        final HospitalTag hospitalTag1 = HospitalTag.builder()
+                .label("라벨1")
+                .build();
+
+        final HospitalTag hospitalTag2 = HospitalTag.builder()
+                .label("라벨2")
+                .build();
+
+        final HospitalTagMapping hospitalTagMapping = HospitalTagMapping.builder()
+                .hospitalTagId(hospitalTagId1)
+                .hospitalId(hospitalId)
+                .build();
+
+        final List<HospitalTagMapping> hospitalTagMappings = new ArrayList<>(List.of(hospitalTagMapping));
+        final List<HospitalTag> hospitalTags = new ArrayList<>(List.of(hospitalTag1));
+
+        BDDMockito.given(hospitalRepository.findById(any())).willReturn(Optional.ofNullable(hospital));
+        BDDMockito.given(hospitalTagMappingRepository.findAllByHospitalId(any())).willReturn(hospitalTagMappings);
+        BDDMockito.given(hospitalTagRepository.findAllByIdIn(any())).willReturn(hospitalTags);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(any())).willReturn(hospital.getImage());
+
+        final HospitalDetailResponse expected = HospitalDetailResponse.of(
+                "병원 이름",
+                "병원 전화번호",
+                new ArrayList<>(List.of("라벨1")),
+                "병원 소개",
+                "병원 주소",
+                "병원 도로명주소",
+                "병원 이미지"
+        );
+
+        //when
+        final HospitalDetailResponse actual = hospitalService.getHospitalDetail(hospitalId);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveAssertion().isEqualTo(expected);
+        Assertions.assertThat(actual.address()).isEqualTo("병원 주소");
+    }
+}
+


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #167 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 병원 상세 조회 API를 구현했습니다.
* 병원 태그, 병원이 가지고 있는 태그(중간 테이블)을 생성했습니다.
* 병원 엔티티에 도로명 주소, 전화번호, 소개 필드를 추가했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->

