### PR TITLE
Feat: 리뷰 작성 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -1,0 +1,33 @@
+package com.cocos.cocos.api.review.controller;
+
+import com.cocos.cocos.api.review.dto.request.ReviewAddRequest;
+import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.api.review.service.ReviewService;
+import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.common.response.SuccessResponse;
+import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.util.PrincipalHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("${api.prefix}/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("/{hospitalId}")
+    public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
+            @PathVariable(name = "hospitalId") final Long hospitalId,
+            @RequestBody final ReviewAddRequest reviewAddRequest
+    ) {
+        return SuccessResponse.success(SuccessMessage.CREATED, reviewService.addReview(
+                PrincipalHandler.getMemberIdFromPrincipal(), hospitalId, reviewAddRequest.breedId(), reviewAddRequest.gender(),
+                reviewAddRequest.weight(), reviewAddRequest.visitedAt(), reviewAddRequest.content(),
+                reviewAddRequest.purposeId(), reviewAddRequest.diseaseId(), reviewAddRequest.symptomIds(),
+                reviewAddRequest.goodReviewIds(), reviewAddRequest.badReviewIds(), reviewAddRequest.images()
+        ));
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -18,7 +18,7 @@ public class ReviewController implements ReviewControllerSwagger {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/{hospitalId}")
+    @PostMapping("/{hospitalId}")
     public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
             @PathVariable(name = "hospitalId") final Long hospitalId,
             @RequestBody final ReviewAddRequest reviewAddRequest

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("${api.prefix}/reviews")
 @RequiredArgsConstructor
-public class ReviewController {
+public class ReviewController implements ReviewControllerSwagger {
 
     private final ReviewService reviewService;
 

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
@@ -1,0 +1,29 @@
+package com.cocos.cocos.api.review.controller;
+
+import com.cocos.cocos.api.review.dto.request.ReviewAddRequest;
+import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Review Controller", description = "리뷰 관련 API")
+public interface ReviewControllerSwagger {
+
+    @Operation(summary = "리뷰 작성 API", description = "병원 리뷰를 작성하는 API입니다. ")
+    @ApiResponse(
+            responseCode = "201",
+            description = "요청에 성공했습니다."
+    )
+    @Parameter(name = "hospitalId", description = "병원 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
+    public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
+            @PathVariable(name = "hospitalId") final Long hospitalId,
+            @RequestBody final ReviewAddRequest reviewAddRequest
+    );
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 
 import java.util.List;
 
-@Builder
 public record ReviewAddRequest(
         Long breedId,
         Gender gender,
@@ -19,21 +18,4 @@ public record ReviewAddRequest(
         List<Long> badReviewIds,
         List<String> images
 ) {
-    public static ReviewAddRequest of(final Long breedId, final Gender gender, final Integer weight,
-                                      final String visitedAt, final String content, final Long purposeId, final Long diseaseId,
-                                      final List<Long> symptomIds, final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
-        return ReviewAddRequest.builder()
-                .breedId(breedId)
-                .gender(gender)
-                .weight(weight)
-                .visitedAt(visitedAt)
-                .content(content)
-                .purposeId(purposeId)
-                .diseaseId(diseaseId)
-                .symptomIds(symptomIds)
-                .goodReviewIds(goodReviewIds)
-                .badReviewIds(badReviewIds)
-                .images(images)
-                .build();
-    }
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
@@ -1,7 +1,6 @@
 package com.cocos.cocos.api.review.dto.request;
 
 import com.cocos.cocos.enums.pet.Gender;
-import lombok.Builder;
 
 import java.util.List;
 

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
@@ -1,20 +1,32 @@
 package com.cocos.cocos.api.review.dto.request;
 
 import com.cocos.cocos.enums.pet.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record ReviewAddRequest(
+        @Schema(description = "종 아이디", nullable = true, example = "1")
         Long breedId,
+        @Schema(description = "성별", nullable = true, example = "F | M")
         Gender gender,
+        @Schema(description = "몸무게", nullable = true, example = "5")
         Integer weight,
+        @Schema(description = "방문 날짜", nullable = true, example = "2025.04.22")
         String visitedAt,
+        @Schema(description = "내용", nullable = true, example = "병원 시설이 너무 깔끔해요.")
         String content,
+        @Schema(description = "방문 목적 아이디", nullable = true, example = "1")
         Long purposeId,
+        @Schema(description = "질병 아이디", nullable = true, example = "7")
         Long diseaseId,
+        @Schema(description = "증상 아이디 리스트", nullable = true, example = "[5,30...]")
         List<Long> symptomIds,
+        @Schema(description = "좋은 간단 리뷰 아이디 리스트", nullable = true, example = "[1,2,3...]")
         List<Long> goodReviewIds,
+        @Schema(description = "나쁜 간단 리뷰 아이디 리스트", nullable = true, example = "[1,2,3...]")
         List<Long> badReviewIds,
+        @Schema(description = "리뷰 이미지 리스트", nullable = true, example = "[image1, image2...]")
         List<String> images
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record ReviewRequest(
+public record ReviewAddRequest(
         Long breedId,
         Gender gender,
         Integer weight,
@@ -19,10 +19,10 @@ public record ReviewRequest(
         List<Long> badReviewIds,
         List<String> images
 ) {
-    public static ReviewRequest of(final Long breedId, final Gender gender, final Integer weight,
-                                   final String visitedAt, final String content, final Long purposeId, final Long diseaseId,
-                                   final List<Long> symptomIds, final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
-        return ReviewRequest.builder()
+    public static ReviewAddRequest of(final Long breedId, final Gender gender, final Integer weight,
+                                      final String visitedAt, final String content, final Long purposeId, final Long diseaseId,
+                                      final List<Long> symptomIds, final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+        return ReviewAddRequest.builder()
                 .breedId(breedId)
                 .gender(gender)
                 .weight(weight)

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewRequest.java
@@ -1,0 +1,39 @@
+package com.cocos.cocos.api.review.dto.request;
+
+import com.cocos.cocos.enums.pet.Gender;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReviewRequest(
+        Long breedId,
+        Gender gender,
+        Integer weight,
+        String visitedAt,
+        String content,
+        Long purposeId,
+        Long diseaseId,
+        List<Long> symptomIds,
+        List<Long> goodReviewIds,
+        List<Long> badReviewIds,
+        List<String> images
+) {
+    public static ReviewRequest of(final Long breedId, final Gender gender, final Integer weight,
+                                   final String visitedAt, final String content, final Long purposeId, final Long diseaseId,
+                                   final List<Long> symptomIds, final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+        return ReviewRequest.builder()
+                .breedId(breedId)
+                .gender(gender)
+                .weight(weight)
+                .visitedAt(visitedAt)
+                .content(content)
+                .purposeId(purposeId)
+                .diseaseId(diseaseId)
+                .symptomIds(symptomIds)
+                .goodReviewIds(goodReviewIds)
+                .badReviewIds(badReviewIds)
+                .images(images)
+                .build();
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/ReviewAddResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/ReviewAddResponse.java
@@ -1,0 +1,11 @@
+package com.cocos.cocos.api.review.dto.response;
+
+import java.util.List;
+
+public record ReviewAddResponse(
+        List<String> images
+) {
+    public static ReviewAddResponse of(final List<String> images) {
+        return new ReviewAddResponse(images);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/ReviewAddResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/ReviewAddResponse.java
@@ -1,8 +1,11 @@
 package com.cocos.cocos.api.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record ReviewAddResponse(
+        @Schema(description = "리뷰 이미지 presigned url", example = "[https://~, https://~]")
         List<String> images
 ) {
     public static ReviewAddResponse of(final List<String> images) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -52,12 +52,14 @@ public class ReviewService {
         addReviewSummary(review.getId(), badReviewIds);
 
         // ToDo: 리뷰 요약 추가 로직과 비슷하기 때문에 이 부분 enum으로 구분하고 하나의 로직으로 합치는 것 고려
-        symptomIds.forEach(symptomId -> reviewSymptomRepository.save(
-                ReviewSymptom.builder()
-                        .reviewId(review.getId())
-                        .symptomId(symptomId)
-                        .build()
-        ));
+        if (symptomIds != null && !symptomIds.isEmpty()) {
+            symptomIds.forEach(symptomId -> reviewSymptomRepository.save(
+                    ReviewSymptom.builder()
+                            .reviewId(review.getId())
+                            .symptomId(symptomId)
+                            .build()
+            ));
+        }
 
         if (images != null && !images.isEmpty()) {
             return ReviewAddResponse.of(images.stream()
@@ -82,12 +84,14 @@ public class ReviewService {
     }
 
     private void addReviewSummary(final Long reviewId, final List<Long> reviewSummaryIds) {
-        reviewSummaryIds.forEach(reviewSummaryId -> reviewSummaryRepository.save(
-                        ReviewSummary.builder()
-                                .reviewId(reviewId)
-                                .reviewSummaryOptionId(reviewSummaryId)
-                                .build()
-                )
-        );
+        if (reviewSummaryIds != null && !reviewSummaryIds.isEmpty()) {
+            reviewSummaryIds.forEach(reviewSummaryId -> reviewSummaryRepository.save(
+                            ReviewSummary.builder()
+                                    .reviewId(reviewId)
+                                    .reviewSummaryOptionId(reviewSummaryId)
+                                    .build()
+                    )
+            );
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -52,7 +52,6 @@ public class ReviewService {
                 )
         );
 
-
         return null;
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -50,6 +50,7 @@ public class ReviewService {
         addReviewSummary(review.getId(), goodReviewIds);
         addReviewSummary(review.getId(), badReviewIds);
 
+        // ToDo: 리뷰 요약 추가 로직과 비슷하기 때문에 이 부분 enum으로 구분하고 하나의 로직으로 합치는 것 고려
         symptomIds.forEach(symptomId -> reviewSymptomRepository.save(
                 ReviewSymptom.builder()
                         .reviewId(review.getId())

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.review.service;
 
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.review.db.Review;
 import com.cocos.cocos.db.review.db.ReviewSummary;
 import com.cocos.cocos.db.review.db.ReviewSymptom;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -32,7 +32,7 @@ public class ReviewService {
     private static final String REVIEW_IMAGE_PACKAGE = "reviewImage";
 
     @Transactional
-    public ReviewAddResponse of(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
+    public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
                                 final Integer weight, final String visitedAt, final String content,
                                 final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
                                 final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -3,12 +3,15 @@ package com.cocos.cocos.api.review.service;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.review.db.Review;
+import com.cocos.cocos.db.review.db.ReviewImage;
 import com.cocos.cocos.db.review.db.ReviewSummary;
 import com.cocos.cocos.db.review.db.ReviewSymptom;
+import com.cocos.cocos.db.review.repository.ReviewImageRepository;
 import com.cocos.cocos.db.review.repository.ReviewRepository;
 import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
 import com.cocos.cocos.db.review.repository.ReviewSymptomRepository;
 import com.cocos.cocos.enums.pet.Gender;
+import com.cocos.cocos.external.MemberDataS3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,10 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewSummaryRepository reviewSummaryRepository;
     private final ReviewSymptomRepository reviewSymptomRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final MemberDataS3Client memberDataS3Client;
+
+    private static final String REVIEW_IMAGE_PACKAGE = "reviewImage";
 
     @Transactional
     public ReviewAddResponse of(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -64,6 +71,25 @@ public class ReviewService {
                         .build()
         ));
 
-        return null;
+        if (images != null && !images.isEmpty()) {
+            return ReviewAddResponse.of(images.stream()
+                    .map(image -> {
+                        // TODO: 파일 포맷, 이름 등을 ENUM에 모아두는 것도 좋아보임
+                        final String fileName = String.format("%s/%s/%s", memberId, REVIEW_IMAGE_PACKAGE, UUID.randomUUID() + image);
+
+                        reviewImageRepository.save(
+                                ReviewImage.builder()
+                                        .image(fileName)
+                                        .reviewId(review.getId())
+                                        .build()
+                        );
+
+                        return memberDataS3Client.putPresignedUrl(fileName);
+                    })
+                    .toList()
+            );
+        }
+
+        return ReviewAddResponse.of(null);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -2,7 +2,9 @@ package com.cocos.cocos.api.review.service;
 
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.db.review.db.Review;
+import com.cocos.cocos.db.review.db.ReviewSummary;
 import com.cocos.cocos.db.review.repository.ReviewRepository;
+import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
 import com.cocos.cocos.enums.pet.Gender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import java.util.List;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewSummaryRepository reviewSummaryRepository;
 
     @Transactional
     public ReviewAddResponse of(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -32,6 +35,22 @@ public class ReviewService {
                 .visitedAt(visitedAt)
                 .diseaseId(diseaseId)
                 .build());
+
+        goodReviewIds.forEach(goodReviewId -> reviewSummaryRepository.save(
+                        ReviewSummary.builder()
+                                .reviewId(review.getId())
+                                .reviewSummaryOptionId(goodReviewId)
+                                .build()
+                )
+        );
+
+        badReviewIds.forEach(badReviewId -> reviewSummaryRepository.save(
+                        ReviewSummary.builder()
+                                .reviewId(review.getId())
+                                .reviewSummaryOptionId(badReviewId)
+                                .build()
+                )
+        );
 
 
         return null;

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.cocos.cocos.api.review.service;
 
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.db.review.db.Review;
+import com.cocos.cocos.db.review.repository.ReviewRepository;
 import com.cocos.cocos.enums.pet.Gender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,11 +14,23 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReviewService {
 
+    private final ReviewRepository reviewRepository;
+
     @Transactional
-    public ReviewAddResponse of(final Long memberId, final Long breedId, final Gender gender,
+    public ReviewAddResponse of(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
                                 final Integer weight, final String visitedAt, final String content,
                                 final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
                                 final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+        final Review review = reviewRepository.save(Review.builder()
+                .breedId(breedId)
+                .gender(gender)
+                .weight(weight)
+                .purposeId(purposeId)
+                .content(content)
+                .hospitalId(hospitalId)
+                .memberId(memberId)
+                .visitedAt(visitedAt)
+                .build());
 
         return null;
     }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,7 +1,6 @@
 package com.cocos.cocos.api.review.service;
 
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
-import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.review.db.Review;
 import com.cocos.cocos.db.review.db.ReviewImage;
 import com.cocos.cocos.db.review.db.ReviewSummary;
@@ -33,9 +32,9 @@ public class ReviewService {
 
     @Transactional
     public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
-                                final Integer weight, final String visitedAt, final String content,
-                                final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
-                                final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+                                       final Integer weight, final String visitedAt, final String content,
+                                       final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
+                                       final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
         final Review review = reviewRepository.save(Review.builder()
                 .breedId(breedId)
                 .gender(gender)
@@ -48,21 +47,8 @@ public class ReviewService {
                 .diseaseId(diseaseId)
                 .build());
 
-        goodReviewIds.forEach(goodReviewId -> reviewSummaryRepository.save(
-                        ReviewSummary.builder()
-                                .reviewId(review.getId())
-                                .reviewSummaryOptionId(goodReviewId)
-                                .build()
-                )
-        );
-
-        badReviewIds.forEach(badReviewId -> reviewSummaryRepository.save(
-                        ReviewSummary.builder()
-                                .reviewId(review.getId())
-                                .reviewSummaryOptionId(badReviewId)
-                                .build()
-                )
-        );
+        addReviewSummary(review.getId(), goodReviewIds);
+        addReviewSummary(review.getId(), badReviewIds);
 
         symptomIds.forEach(symptomId -> reviewSymptomRepository.save(
                 ReviewSymptom.builder()
@@ -91,5 +77,15 @@ public class ReviewService {
         }
 
         return ReviewAddResponse.of(null);
+    }
+
+    private void addReviewSummary(final Long reviewId, final List<Long> reviewSummaryIds) {
+        reviewSummaryIds.forEach(reviewSummaryId -> reviewSummaryRepository.save(
+                        ReviewSummary.builder()
+                                .reviewId(reviewId)
+                                .reviewSummaryOptionId(reviewSummaryId)
+                                .build()
+                )
+        );
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -28,7 +28,7 @@ public class ReviewService {
     private final ReviewImageRepository reviewImageRepository;
     private final MemberDataS3Client memberDataS3Client;
 
-    private static final String REVIEW_IMAGE_PACKAGE = "reviewImage";
+    private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
 
     @Transactional
     public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -62,7 +62,7 @@ public class ReviewService {
             return ReviewAddResponse.of(images.stream()
                     .map(image -> {
                         // TODO: 파일 포맷, 이름 등을 ENUM에 모아두는 것도 좋아보임
-                        final String fileName = String.format("%s/%s/%s", memberId, REVIEW_IMAGE_PACKAGE, UUID.randomUUID() + image);
+                        final String fileName = String.format("%s/%s/%s", memberId, REVIEW_IMAGE_S3_PREFIX, UUID.randomUUID() + image);
 
                         reviewImageRepository.save(
                                 ReviewImage.builder()

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -30,7 +30,9 @@ public class ReviewService {
                 .hospitalId(hospitalId)
                 .memberId(memberId)
                 .visitedAt(visitedAt)
+                .diseaseId(diseaseId)
                 .build());
+
 
         return null;
     }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,0 +1,23 @@
+package com.cocos.cocos.api.review.service;
+
+import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.enums.pet.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    @Transactional
+    public ReviewAddResponse of(final Long memberId, final Long breedId, final Gender gender,
+                                final Integer weight, final String visitedAt, final String content,
+                                final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
+                                final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+
+        return null;
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -35,6 +35,7 @@ public class ReviewService {
                                        final Integer weight, final String visitedAt, final String content,
                                        final Long purposeId, final Long diseaseId, final List<Long> symptomIds,
                                        final List<Long> goodReviewIds, final List<Long> badReviewIds, final List<String> images) {
+        //ToDo: id 검증 로직 필요
         final Review review = reviewRepository.save(Review.builder()
                 .breedId(breedId)
                 .gender(gender)

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -3,8 +3,10 @@ package com.cocos.cocos.api.review.service;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.db.review.db.Review;
 import com.cocos.cocos.db.review.db.ReviewSummary;
+import com.cocos.cocos.db.review.db.ReviewSymptom;
 import com.cocos.cocos.db.review.repository.ReviewRepository;
 import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
+import com.cocos.cocos.db.review.repository.ReviewSymptomRepository;
 import com.cocos.cocos.enums.pet.Gender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ReviewSummaryRepository reviewSummaryRepository;
+    private final ReviewSymptomRepository reviewSymptomRepository;
 
     @Transactional
     public ReviewAddResponse of(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -51,6 +54,13 @@ public class ReviewService {
                                 .build()
                 )
         );
+
+        symptomIds.forEach(symptomId -> reviewSymptomRepository.save(
+                ReviewSymptom.builder()
+                        .reviewId(review.getId())
+                        .symptomId(symptomId)
+                        .build()
+        ));
 
         return null;
     }

--- a/src/main/java/com/cocos/cocos/db/review/db/Review.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/Review.java
@@ -43,8 +43,11 @@ public class Review extends BaseTime {
     @Column(name = "breed_id", nullable = false)
     private Long breedId;
 
+    @Column(name = "disease_id", nullable = false)
+    private Long diseaseId;
+
     @Builder
-    public Review(final String visitedAt, final Gender gender, final int weight, final Long purposeId, final String content, final Long hospitalId, final Long memberId, final Long breedId) {
+    public Review(final String visitedAt, final Gender gender, final int weight, final Long purposeId, final String content, final Long hospitalId, final Long memberId, final Long breedId, final Long diseaseId) {
         this.visitedAt = visitedAt;
         this.gender = gender;
         this.weight = weight;
@@ -53,5 +56,6 @@ public class Review extends BaseTime {
         this.hospitalId = hospitalId;
         this.memberId = memberId;
         this.breedId = breedId;
+        this.diseaseId = diseaseId;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/review/db/Review.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/Review.java
@@ -1,0 +1,57 @@
+package com.cocos.cocos.db.review.db;
+
+import com.cocos.cocos.db.BaseTime;
+import com.cocos.cocos.enums.pet.Gender;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "review")
+public class Review extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "visited_at", nullable = false)
+    private String visitedAt;
+
+    @Column(name = "gender", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(name = "weight", nullable = false)
+    private int weight;
+
+    @Column(name = "purpose_id", nullable = false)
+    private Long purposeId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "hospital_id", nullable = false)
+    private Long hospitalId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "breed_id", nullable = false)
+    private Long breedId;
+
+    @Builder
+    public Review(final String visitedAt, final Gender gender, final int weight, final Long purposeId, final String content, final Long hospitalId, final Long memberId, final Long breedId) {
+        this.visitedAt = visitedAt;
+        this.gender = gender;
+        this.weight = weight;
+        this.purposeId = purposeId;
+        this.content = content;
+        this.hospitalId = hospitalId;
+        this.memberId = memberId;
+        this.breedId = breedId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/review/db/ReviewImage.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/ReviewImage.java
@@ -1,0 +1,31 @@
+package com.cocos.cocos.db.review.db;
+
+import com.cocos.cocos.db.BaseTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "review_image")
+public class ReviewImage extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "image", nullable = false)
+    private String image;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Builder
+    public ReviewImage(final String image, final Long reviewId) {
+        this.image = image;
+        this.reviewId = reviewId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/review/db/ReviewSummary.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/ReviewSummary.java
@@ -1,0 +1,31 @@
+package com.cocos.cocos.db.review.db;
+
+import com.cocos.cocos.db.BaseTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "review_summary")
+public class ReviewSummary extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Column(name = "review_summary_option_id", nullable = false)
+    private Long reviewSummaryOptionId;
+
+    @Builder
+    public ReviewSummary(final Long reviewId, final Long reviewSummaryOptionId) {
+        this.reviewId = reviewId;
+        this.reviewSummaryOptionId = reviewSummaryOptionId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/review/db/ReviewSummaryOption.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/ReviewSummaryOption.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.db.review.db;
+
+import com.cocos.cocos.db.BaseTime;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "review")
+public class ReviewSummaryOption extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "is_good", nullable = false)
+    private Boolean isGood;
+
+    @Column(name = "label", nullable = false)
+    private String label;
+}

--- a/src/main/java/com/cocos/cocos/db/review/db/ReviewSummaryOption.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/ReviewSummaryOption.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "review")
+@Table(name = "review_summary_option")
 public class ReviewSummaryOption extends BaseTime {
 
     @Id

--- a/src/main/java/com/cocos/cocos/db/review/db/ReviewSymptom.java
+++ b/src/main/java/com/cocos/cocos/db/review/db/ReviewSymptom.java
@@ -1,0 +1,31 @@
+package com.cocos.cocos.db.review.db;
+
+import com.cocos.cocos.db.BaseTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "review_symptom")
+public class ReviewSymptom extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Column(name = "symptom_id", nullable = false)
+    private Long symptomId;
+
+    @Builder
+    public ReviewSymptom(final Long reviewId, final Long symptomId) {
+        this.reviewId = reviewId;
+        this.symptomId = symptomId;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.review.repository;
+
+import com.cocos.cocos.db.review.db.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.review.repository;
+
+import com.cocos.cocos.db.review.db.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryOptionRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryOptionRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.review.repository;
+
+import com.cocos.cocos.db.review.db.ReviewSummaryOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewSummaryOptionRepository extends JpaRepository<ReviewSummaryOption, Long> {
+}

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.review.repository;
+
+import com.cocos.cocos.db.review.db.ReviewSummary;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewSummaryRepository extends CrudRepository<ReviewSummary, Long> {
+}

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.db.review.repository;
+
+import com.cocos.cocos.db.review.db.ReviewSymptom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewSymptomRepository extends JpaRepository<ReviewSymptom, Long> {
+}

--- a/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
+++ b/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
@@ -63,7 +63,7 @@ public class HospitalServiceTest {
                 .latitude(35.0)
                 .longitude(128.0)
                 .reviewCount(0)
-                .townId(1L)
+                .districtId(1L)
                 .build();
 
         final HospitalTag hospitalTag1 = HospitalTag.builder()
@@ -120,7 +120,7 @@ public class HospitalServiceTest {
                 .latitude(35.0)
                 .longitude(128.0)
                 .reviewCount(0)
-                .townId(1L)
+                .districtId(1L)
                 .build();
 
         final HospitalTag hospitalTag1 = HospitalTag.builder()

--- a/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
+++ b/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
@@ -1,0 +1,113 @@
+package com.cocos.cocos.review;
+
+import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.api.review.service.ReviewService;
+import com.cocos.cocos.db.review.db.Review;
+import com.cocos.cocos.db.review.db.ReviewImage;
+import com.cocos.cocos.db.review.db.ReviewSummary;
+import com.cocos.cocos.db.review.db.ReviewSymptom;
+import com.cocos.cocos.db.review.repository.ReviewImageRepository;
+import com.cocos.cocos.db.review.repository.ReviewRepository;
+import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
+import com.cocos.cocos.db.review.repository.ReviewSymptomRepository;
+import com.cocos.cocos.enums.pet.Gender;
+import com.cocos.cocos.external.MemberDataS3Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("리뷰 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ReviewServiceTest {
+
+    @InjectMocks
+    ReviewService reviewService;
+
+    @Mock
+    ReviewRepository reviewRepository;
+
+    @Mock
+    ReviewSummaryRepository reviewSummaryRepository;
+
+    @Mock
+    ReviewSymptomRepository reviewSymptomRepository;
+
+    @Mock
+    ReviewImageRepository reviewImageRepository;
+
+    @Mock
+    MemberDataS3Client memberDataS3Client;
+
+    @Test
+    @DisplayName("리뷰를 작성할 수 있다.")
+    void addReview() {
+        //given
+        final Long memberId = 1L;
+        final Long hospitalId = 2L;
+        final Long breedId = 1L;
+        final Gender gender = Gender.F;
+        final Integer weight = 7;
+        final String visitedAt = "2025.04.22";
+        final String content = "내용";
+        final Long purposeId = 2L;
+        final Long diseaseId = 3L;
+        final List<Long> symptomIds = new ArrayList<>(List.of(1L, 2L));
+        final List<Long> goodReviewIds = new ArrayList<>(List.of(4L, 5L, 6L, 10L));
+        final List<Long> badReviewIds = new ArrayList<>(List.of(7L, 8L, 9L));
+        final String image1 = "image1";
+        final String image2 = "image2";
+        final List<String> images = new ArrayList<>(List.of(image1, image2));
+        final String presignedUrl = "presignedUrl";
+        final List<String> presignedUrls = new ArrayList<>(List.of(presignedUrl, presignedUrl));
+
+        final Review review = Review.builder()
+                .breedId(breedId)
+                .gender(gender)
+                .weight(weight)
+                .purposeId(purposeId)
+                .content(content)
+                .hospitalId(hospitalId)
+                .memberId(memberId)
+                .visitedAt(visitedAt)
+                .diseaseId(diseaseId)
+                .build();
+
+        ReflectionTestUtils.setField(review, "id", 123L);
+
+        BDDMockito.given(memberDataS3Client.putPresignedUrl(any())).willReturn(presignedUrl);
+        BDDMockito.given(reviewRepository.save(any(Review.class)))
+                .willReturn(review);
+
+
+        final ReviewAddResponse expected = ReviewAddResponse.of(
+                presignedUrls
+        );
+
+        //when
+        final ReviewAddResponse actual = reviewService.addReview(memberId, hospitalId, breedId, gender, weight, visitedAt
+                , content, purposeId, diseaseId, symptomIds, goodReviewIds, badReviewIds, images);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveAssertion().isEqualTo(expected);
+        BDDMockito.verify(reviewRepository, times(1)).save(any(Review.class));
+        BDDMockito.verify(reviewSummaryRepository, times(7)).save(any(ReviewSummary.class));
+        BDDMockito.verify(reviewSymptomRepository, times(2)).save(any(ReviewSymptom.class));
+        BDDMockito.verify(reviewImageRepository, times(2)).save(any(ReviewImage.class));
+
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #172 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 리뷰, 리뷰 요약, 리뷰 요약 옵션 엔티티를 생성했습니다.
* 리뷰 작성시 리뷰, 리뷰 요약, 리뷰 증상, 리뷰 이미지를 저장하도록 했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 질병은 하나만 가질 수 있고, 증상은 여러 개를 가질 수 있다는 점이 API 명세서에는 반영이 안 되어 있어서 질병은 단일 아이디만 받도록 수정했습니다.

* review를 도메인으로 쓰다 보니 controller도 따로 만들게 되어서 url을 /review/{hospitalId}로 만들었는데 이 부분에 대한 의견이 궁금합니다!

* 필드 수정이 있거나 할 때 테스트를 한 번 돌려보는 것도 좋은 것 같습니다! townId를 수정해서 테스트가 깨지는 경우가 있었는데 테스트 성공 여부 까지 확인하면 좋지만, 여유있지 못할 때는 컴파일은 되도록 수정하면 좋을 것 같습니다 : )