### PR TITLE
Feat: 후기 작성 약관 동의 API 및 약관 동의 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -89,4 +89,15 @@ public class MemberController implements MemberControllerSwagger {
         memberService.updateMemberHospital(hospitalId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }
+
+    @PatchMapping("/reviews/agree")
+    public ResponseEntity<BaseResponse<Void>> updateMemberReviewTerms() {
+        memberService.updateReviewTermsAgree(PrincipalHandler.getMemberIdFromPrincipal());
+        return SuccessResponse.success(SuccessMessage.OK, null);
+    }
+
+    @GetMapping("/reviews/agree")
+    public ResponseEntity<BaseResponse<MemberReviewTermsAgreeResponse>> getMemberReviewTerms() {
+        return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberReviewTermsAgree(PrincipalHandler.getMemberIdFromPrincipal()));
+    }
 }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -77,4 +77,18 @@ public interface MemberControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> updateMemberHospital(
             @PathVariable(name = "hospitalId") final Long hospitalId
     );
+
+    @Operation(summary = "리뷰 약관 동의 업데이트 API", description = "리뷰 약관 동의 여부를 업데이트하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다."
+    )
+    public ResponseEntity<BaseResponse<Void>> updateMemberReviewTerms();
+
+    @Operation(summary = "리뷰 약관 동의 여부 조회 API", description = "리뷰 약관 동의 여부를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다."
+    )
+    public ResponseEntity<BaseResponse<MemberReviewTermsAgreeResponse>> getMemberReviewTerms();
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberReviewTermsAgreeResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberReviewTermsAgreeResponse.java
@@ -1,6 +1,9 @@
 package com.cocos.cocos.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MemberReviewTermsAgreeResponse(
+        @Schema(description = "리뷰 약관 동의 여부", example = "true")
         boolean isReviewTermsAgree
 ) {
     public static MemberReviewTermsAgreeResponse of(final boolean reviewTermsAgree) {

--- a/src/main/java/com/cocos/cocos/api/member/dto/response/MemberReviewTermsAgreeResponse.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/response/MemberReviewTermsAgreeResponse.java
@@ -1,0 +1,9 @@
+package com.cocos.cocos.api.member.dto.response;
+
+public record MemberReviewTermsAgreeResponse(
+        boolean isReviewTermsAgree
+) {
+    public static MemberReviewTermsAgreeResponse of(final boolean reviewTermsAgree) {
+        return new MemberReviewTermsAgreeResponse(reviewTermsAgree);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -191,4 +191,13 @@ public class MemberService {
 
         member.updateReviewTermsAgree();
     }
+
+    @Transactional(readOnly = true)
+    public MemberReviewTermsAgreeResponse getMemberReviewTermsAgree(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+
+        return MemberReviewTermsAgreeResponse.of(member.isReviewTermsAgree());
+    }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -182,4 +182,13 @@ public class MemberService {
         );
         memberAddress.updateAddress(address, roadAddress, locationId, latitude, longitude, locationType);
     }
+
+    @Transactional
+    public void updateReviewTermsAgree(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+
+        member.updateReviewTermsAgree();
+    }
 }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
@@ -52,8 +51,7 @@ public class Member extends BaseTime {
     @ColumnDefault("false")
     private boolean isReviewTermsAgree;
 
-    @Column(name = "review_terms_agree_at", nullable = false)
-    @CreationTimestamp
+    @Column(name = "review_terms_agree_at", nullable = true)
     private LocalDateTime reviewTermsAgreeAt;
 
     @Builder

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -7,7 +7,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -45,6 +48,13 @@ public class Member extends BaseTime {
     @Column(name = "my_hospital_id")
     private Long myHospitalId;
 
+    @Column(name = "is_review_terms_agree", nullable = false)
+    @ColumnDefault("false")
+    private boolean isReviewTermsAgree;
+
+    @Column(name = "review_terms_agree_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime reviewTermsAgreeAt;
 
     @Builder
     public Member(final String nickname, final String email, final String image, final Platform platform, final String sub, final boolean isAdmin, final Long myHospitalId) {
@@ -68,7 +78,7 @@ public class Member extends BaseTime {
         if (nickname != null) this.nickname = nickname;
     }
 
-    public  void updateMyHospitalId(final Long myHospitalId) {
+    public void updateMyHospitalId(final Long myHospitalId) {
         if (myHospitalId != null) {
             this.myHospitalId = myHospitalId;
         }

--- a/src/main/java/com/cocos/cocos/db/member/entity/Member.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/Member.java
@@ -83,4 +83,9 @@ public class Member extends BaseTime {
             this.myHospitalId = myHospitalId;
         }
     }
+
+    public void updateReviewTermsAgree() {
+        this.isReviewTermsAgree = true;
+        this.reviewTermsAgreeAt = LocalDateTime.now();
+    }
 }

--- a/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
+++ b/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.member;
 
+import com.cocos.cocos.api.member.dto.response.MemberReviewTermsAgreeResponse;
 import com.cocos.cocos.api.member.service.MemberService;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
@@ -41,5 +42,26 @@ public class MemberServiceTest {
 
         //then
         Assertions.assertThat(member.getIsReviewTermsAgree()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("리뷰 약관 동의 여부를 조회 할 수 있다.")
+    void getReviewAgree() {
+        //given
+        final Member member = Member.builder()
+                .build();
+        final Long memberId = 1L;
+
+        ReflectionTestUtils.setField(member, "isReviewTermsAgree", true);
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        final MemberReviewTermsAgreeResponse expected = MemberReviewTermsAgreeResponse.of(member.getIsReviewTermsAgree());
+
+        //when
+        final MemberReviewTermsAgreeResponse actual = memberService.getReviewTermsAgree();
+
+        //then
+        Assertions.assertThat(expected).usingRecursiveAssertion().isEqualTo(actual);
+
     }
 }

--- a/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
+++ b/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
@@ -1,0 +1,45 @@
+package com.cocos.cocos.member;
+
+import com.cocos.cocos.api.member.service.MemberService;
+import com.cocos.cocos.db.member.entity.Member;
+import com.cocos.cocos.db.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("지역 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("리뷰 약관 동의를 할 수 있다.")
+    void addReviewAgree() {
+        //given
+        final Member member = Member.builder()
+                .build();
+        final Long memberId = 1L;
+
+        ReflectionTestUtils.setField(member, "isReviewTermsAgree", false);
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        //when
+        memberService.updateReviewTermsAgree(memberId);
+
+        //then
+        Assertions.assertThat(member.getIsReviewTermsAgree()).isEqualTo(true);
+    }
+}

--- a/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
+++ b/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
@@ -55,7 +55,7 @@ public class MemberServiceTest {
         ReflectionTestUtils.setField(member, "isReviewTermsAgree", true);
         ReflectionTestUtils.setField(member, "id", memberId);
 
-        final MemberReviewTermsAgreeResponse expected = MemberReviewTermsAgreeResponse.of(member.getIsReviewTermsAgree());
+        final MemberReviewTermsAgreeResponse expected = MemberReviewTermsAgreeResponse.of(member.isReviewTermsAgree());
 
         //when
         final MemberReviewTermsAgreeResponse actual = memberService.getReviewTermsAgree();

--- a/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
+++ b/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
@@ -63,7 +63,7 @@ public class MemberServiceTest {
         BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 
         //when
-        final MemberReviewTermsAgreeResponse actual = memberService.getReviewTermsAgree();
+        final MemberReviewTermsAgreeResponse actual = memberService.getMemberReviewTermsAgree(memberId);
 
         //then
         Assertions.assertThat(expected).usingRecursiveAssertion().isEqualTo(actual);

--- a/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
+++ b/src/test/java/com/cocos/cocos/member/MemberServiceTest.java
@@ -10,10 +10,13 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("지역 서비스 테스트")
@@ -36,12 +39,13 @@ public class MemberServiceTest {
 
         ReflectionTestUtils.setField(member, "isReviewTermsAgree", false);
         ReflectionTestUtils.setField(member, "id", memberId);
+        BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 
         //when
         memberService.updateReviewTermsAgree(memberId);
 
         //then
-        Assertions.assertThat(member.getIsReviewTermsAgree()).isEqualTo(true);
+        Assertions.assertThat(member.isReviewTermsAgree()).isEqualTo(true);
     }
 
     @Test
@@ -56,6 +60,7 @@ public class MemberServiceTest {
         ReflectionTestUtils.setField(member, "id", memberId);
 
         final MemberReviewTermsAgreeResponse expected = MemberReviewTermsAgreeResponse.of(member.isReviewTermsAgree());
+        BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 
         //when
         final MemberReviewTermsAgreeResponse actual = memberService.getReviewTermsAgree();


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #179 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 후기 작성 약관 동의 API 및 약관 동의 여부 조회 API를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 리뷰 약관 동의 필드가 멤버 엔티티안에 필드로 있어서 기본값을 false로 하고 업데이트하는 방식을 택했습니다. 이에 따라 기존 명세서에는 post로 되어 있었지만 patch메소드로 수정했는데 이에 대한 의견이 궁금합니다!
