### PR TITLE
Feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -100,4 +100,10 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<BaseResponse<MemberReviewTermsAgreeResponse>> getMemberReviewTerms() {
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberReviewTermsAgree(PrincipalHandler.getMemberIdFromPrincipal()));
     }
+
+    @DeleteMapping("/deactivate")
+    public ResponseEntity<BaseResponse<Void>> deactivateMember() {
+        memberService.deactivateMember(PrincipalHandler.getMemberIdFromPrincipal());
+        return SuccessResponse.success(SuccessMessage.OK, null);
+    }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -31,6 +31,7 @@ import com.cocos.cocos.db.review.db.Review;
 import com.cocos.cocos.db.review.repository.ReviewImageRepository;
 import com.cocos.cocos.db.review.repository.ReviewRepository;
 import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
+import com.cocos.cocos.db.review.repository.ReviewSymptomRepository;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
@@ -69,6 +70,7 @@ public class MemberService {
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
     private final ReviewSummaryRepository reviewSummaryRepository;
+    private final ReviewSymptomRepository reviewSymptomRepository;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
@@ -305,6 +307,7 @@ public class MemberService {
 
         reviewImageRepository.deleteAllByReviewIdIn(memberWriteReviewIds);
         reviewSummaryRepository.deleteAllByReviewIdIn(memberWriteReviewIds);
+        reviewSymptomRepository.deleteAllByReviewIdIn(memberWriteReviewIds);
 
         deleteAboutHospital(memberWriteReviews);
 

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -5,6 +5,9 @@ import com.cocos.cocos.auth.JwtProvider;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.city.entity.City;
 import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.comment.entity.Comment;
+import com.cocos.cocos.db.comment.repository.CommentRepository;
+import com.cocos.cocos.db.comment.repository.SubCommentRepository;
 import com.cocos.cocos.db.district.entity.District;
 import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.hospital.entity.Hospital;
@@ -15,6 +18,20 @@ import com.cocos.cocos.db.member.entity.MemberToken;
 import com.cocos.cocos.db.member.repository.MemberAddressRepository;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.member.repository.MemberTokenRepository;
+import com.cocos.cocos.db.pet.entity.Pet;
+import com.cocos.cocos.db.pet.repository.PetDiseaseRepository;
+import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
+import com.cocos.cocos.db.post.entity.Post;
+import com.cocos.cocos.db.post.repository.PostImageRepository;
+import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import com.cocos.cocos.db.post.repository.PostTagRepository;
+import com.cocos.cocos.db.review.db.Review;
+import com.cocos.cocos.db.review.repository.ReviewImageRepository;
+import com.cocos.cocos.db.review.repository.ReviewRepository;
+import com.cocos.cocos.db.review.repository.ReviewSummaryRepository;
+import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.message.FailMessage;
@@ -23,6 +40,8 @@ import com.cocos.cocos.external.MemberDataS3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +56,19 @@ public class MemberService {
     private final CityRepository cityRepository;
     private final DistrictRepository districtRepository;
     private final HospitalRepository hospitalRepository;
+    private final PetRepository petRepository;
+    private final PetSymptomRepository petSymptomRepository;
+    private final PetDiseaseRepository petDiseaseRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final SubCommentRepository subCommentRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostTagRepository postTagRepository;
+    private final SearchRepository searchRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final ReviewSummaryRepository reviewSummaryRepository;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMemberProfile(final String nickname, final Long memberId) {
@@ -199,5 +231,63 @@ public class MemberService {
         );
 
         return MemberReviewTermsAgreeResponse.of(member.isReviewTermsAgree());
+    }
+
+    @Transactional
+    public void deactivateMember(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
+        );
+
+        final Pet pet = petRepository.findByMemberId(memberId);
+
+        final List<Long> memberWritePostIds = postRepository.findAllByMemberId(memberId).stream()
+                .map(Post::getId)
+                .toList();
+
+        final List<Long> commentIds = commentRepository.findAllByPostIdIn(memberWritePostIds).stream()
+                .map(Comment::getId)
+                .toList();
+
+
+        final List<Post> memberLikePosts = postLikeRepository.findAllByMemberId(memberId).stream()
+                .map(postLike -> postRepository.findById(postLike.getPostId()).orElseThrow(
+                        () -> new CocosException(FailMessage.NOT_FOUND_POST)
+                ))
+                .toList();
+
+        final List<Long> reviewIds = reviewRepository.findAllByMemberId(memberId).stream()
+                .map(Review::getId)
+                .toList();
+
+        final List<Hospital> hospitals = reviewRepository.findAllByMemberId(memberId).stream()
+                .map(review -> hospitalRepository.findById(review.getId()).orElseThrow(
+                        () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
+                )).toList();
+
+        hospitals.forEach(Hospital::deleteReview);
+        reviewRepository.deleteAllByIdIn(reviewIds);
+
+        reviewImageRepository.deleteAllByReviewIdIn(reviewIds);
+        reviewSummaryRepository.deleteAllByReviewIdIn(reviewIds);
+
+        memberLikePosts.forEach(Post::deleteLike);
+        postTagRepository.deleteAllByPostIdIn(memberWritePostIds);
+        postRepository.deleteAllByMemberId(memberId);
+        searchRepository.deleteAllByMemberId(memberId);
+
+        subCommentRepository.deleteAllByCommentIdInOrMemberId(commentIds, memberId);
+        commentRepository.deleteAllByPostIdInOrMemberId(memberWritePostIds, memberId);
+        postImageRepository.deleteAllByPostIdIn(memberWritePostIds);
+
+        petSymptomRepository.deleteAllByPetId(pet.getId());
+        petDiseaseRepository.deleteAllByPetId(pet.getId());
+        petRepository.deleteById(pet.getId());
+
+        memberAddressRepository.deleteByMemberId(memberId);
+        memberTokenRepository.deleteByMemberId(memberId);
+
+        kakaoLoginClient.unlink(Long.parseLong(member.getSub()));
+        memberRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -239,55 +239,84 @@ public class MemberService {
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
         );
 
+        deleteAboutPet(memberId);
+        deleteAboutPost(memberId);
+        deleteAboutReview(memberId);
+
+        searchRepository.deleteAllByMemberId(memberId);
+
+        memberAddressRepository.deleteByMemberId(memberId);
+        memberTokenRepository.deleteByMemberId(memberId);
+        kakaoLoginClient.unlink(Long.parseLong(member.getSub()));
+        memberRepository.deleteById(memberId);
+    }
+
+    private void deleteAboutPet(final Long memberId) {
         final Pet pet = petRepository.findByMemberId(memberId);
 
-        final List<Long> memberWritePostIds = postRepository.findAllByMemberId(memberId).stream()
-                .map(Post::getId)
-                .toList();
+        petSymptomRepository.deleteAllByPetId(pet.getId());
+        petDiseaseRepository.deleteAllByPetId(pet.getId());
+        petRepository.deleteById(pet.getId());
+    }
 
-        final List<Long> commentIds = commentRepository.findAllByPostIdIn(memberWritePostIds).stream()
-                .map(Comment::getId)
-                .toList();
-
-
+    private void deleteAboutPost(final Long memberId) {
         final List<Post> memberLikePosts = postLikeRepository.findAllByMemberId(memberId).stream()
                 .map(postLike -> postRepository.findById(postLike.getPostId()).orElseThrow(
                         () -> new CocosException(FailMessage.NOT_FOUND_POST)
                 ))
                 .toList();
 
-        final List<Long> reviewIds = reviewRepository.findAllByMemberId(memberId).stream()
+        memberLikePosts.forEach(Post::deleteLike);
+        postLikeRepository.deleteAllByMemberId(memberId);
+
+        final List<Post> memberWritePosts = postRepository.findAllByMemberId(memberId);
+        final List<Long> memberWritePostIds = memberWritePosts.stream()
+                .map(Post::getId)
+                .toList();
+
+        postImageRepository.deleteAllByPostIdIn(memberWritePostIds);
+        postTagRepository.deleteAllByPostIdIn(memberWritePostIds);
+
+        deleteAboutComment(memberWritePostIds, memberId);
+
+        postRepository.deleteAllByMemberId(memberId);
+    }
+
+    private void deleteAboutComment(final List<Long> memberWritePostIds, final Long memberId) {
+        final List<Comment> memberWriteOrDeleteTargetComments = commentRepository.findAllByPostIdInOrMemberId(memberWritePostIds, memberId);
+        final List<Long> memberWriteOrDeleteTargetCommentsIds = memberWriteOrDeleteTargetComments.stream()
+                .map(Comment::getId)
+                .toList();
+
+        deleteAboutSubComment(memberWriteOrDeleteTargetCommentsIds, memberId);
+
+        commentRepository.deleteAllByPostIdInOrMemberId(memberWritePostIds, memberId);
+    }
+
+    private void deleteAboutSubComment(final List<Long> memberWriteOrDeleteTargetCommentsIds, final Long memberId) {
+        subCommentRepository.deleteAllByCommentIdInOrMemberId(memberWriteOrDeleteTargetCommentsIds, memberId);
+    }
+
+    private void deleteAboutReview(final Long memberId) {
+        final List<Review> memberWriteReviews = reviewRepository.findAllByMemberId(memberId);
+        final List<Long> memberWriteReviewIds = memberWriteReviews.stream()
                 .map(Review::getId)
                 .toList();
 
-        final List<Hospital> hospitals = reviewRepository.findAllByMemberId(memberId).stream()
+        reviewImageRepository.deleteAllByReviewIdIn(memberWriteReviewIds);
+        reviewSummaryRepository.deleteAllByReviewIdIn(memberWriteReviewIds);
+
+        deleteAboutHospital(memberWriteReviews);
+
+        reviewRepository.deleteAllByIdIn(memberWriteReviewIds);
+    }
+
+    private void deleteAboutHospital(final List<Review> memberWriteReviews) {
+        final List<Hospital> hospitals = memberWriteReviews.stream()
                 .map(review -> hospitalRepository.findById(review.getId()).orElseThrow(
                         () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
                 )).toList();
 
         hospitals.forEach(Hospital::deleteReview);
-        reviewRepository.deleteAllByIdIn(reviewIds);
-
-        reviewImageRepository.deleteAllByReviewIdIn(reviewIds);
-        reviewSummaryRepository.deleteAllByReviewIdIn(reviewIds);
-
-        memberLikePosts.forEach(Post::deleteLike);
-        postTagRepository.deleteAllByPostIdIn(memberWritePostIds);
-        postRepository.deleteAllByMemberId(memberId);
-        searchRepository.deleteAllByMemberId(memberId);
-
-        subCommentRepository.deleteAllByCommentIdInOrMemberId(commentIds, memberId);
-        commentRepository.deleteAllByPostIdInOrMemberId(memberWritePostIds, memberId);
-        postImageRepository.deleteAllByPostIdIn(memberWritePostIds);
-
-        petSymptomRepository.deleteAllByPetId(pet.getId());
-        petDiseaseRepository.deleteAllByPetId(pet.getId());
-        petRepository.deleteById(pet.getId());
-
-        memberAddressRepository.deleteByMemberId(memberId);
-        memberTokenRepository.deleteByMemberId(memberId);
-
-        kakaoLoginClient.unlink(Long.parseLong(member.getSub()));
-        memberRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -316,7 +316,7 @@ public class MemberService {
 
     private void deleteAboutHospital(final List<Review> memberWriteReviews) {
         final List<Hospital> hospitals = memberWriteReviews.stream()
-                .map(review -> hospitalRepository.findById(review.getId()).orElseThrow(
+                .map(review -> hospitalRepository.findById(review.getHospitalId()).orElseThrow(
                         () -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)
                 )).toList();
 

--- a/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
@@ -23,4 +23,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByPostIdIn(final List<Long> postIds);
 
     void deleteAllByPostIdInOrMemberId(final List<Long> postIds, final Long memberId);
+
+    List<Comment> findAllByPostIdInOrMemberId(final List<Long> postIds, final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/CommentRepository.java
@@ -19,4 +19,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
 
     List<Comment> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
+
+    List<Comment> findAllByPostIdIn(final List<Long> postIds);
+
+    void deleteAllByPostIdInOrMemberId(final List<Long> postIds, final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/comment/repository/SubCommentRepository.java
+++ b/src/main/java/com/cocos/cocos/db/comment/repository/SubCommentRepository.java
@@ -17,4 +17,6 @@ public interface SubCommentRepository extends JpaRepository<SubComment, Long> {
     List<SubComment> findByCommentIdInOrderByCreatedAtAsc(@Param("commentId") List<Long> commentId);
 
     List<SubComment> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
+
+    void deleteAllByCommentIdInOrMemberId(final List<Long> commentId, final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
@@ -28,4 +28,6 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     List<Hospital> findAllByDistrictIdInWithCursor(@Param("districtIds") final List<Long> districtIds, @Param("cursorId") final Long cursorId, @Param("reviewCount") final Integer reviewCount, final Pageable pageable);
 
     List<Hospital> findAllByDistrictIdIn(final List<Long> districtIds, final Pageable pageable);
+
+    List<Hospital> findAllByIdIn(final List<Long> hospitalIds)
 }

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
@@ -28,6 +28,4 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     List<Hospital> findAllByDistrictIdInWithCursor(@Param("districtIds") final List<Long> districtIds, @Param("cursorId") final Long cursorId, @Param("reviewCount") final Integer reviewCount, final Pageable pageable);
 
     List<Hospital> findAllByDistrictIdIn(final List<Long> districtIds, final Pageable pageable);
-
-    List<Hospital> findAllByIdIn(final List<Long> hospitalIds)
 }

--- a/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/cocos/cocos/db/member/repository/MemberAddressRepository.java
@@ -11,4 +11,6 @@ public interface MemberAddressRepository extends JpaRepository<MemberAddress, Lo
     Optional<MemberAddress> findByMemberId(final Long memberId);
 
     boolean existsByMemberId(final Long memberId);
+
+    void deleteByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostImageRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostImageRepository.java
@@ -12,4 +12,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     List<PostImage> findAllByPostId(final Long postId);
 
     void deleteAllByPostId(final Long postId);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
@@ -18,4 +18,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     void deleteAllByPostId(final Long postId);
 
     List<PostLike> findAllByMemberId(final Long memberId);
+
+    void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostLikeRepository.java
@@ -4,6 +4,8 @@ import com.cocos.cocos.db.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
@@ -14,4 +16,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     int countByPostId(final Long postId);
 
     void deleteAllByPostId(final Long postId);
+
+    List<PostLike> findAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
@@ -20,4 +20,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     List<Post> findTopPostsByPostIds(@Param("postIds") List<Long> postIds, Pageable pageable);
 
     List<Post> findAllByMemberId(final Long memberId);
+
+    void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostTagRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostTagRepository.java
@@ -18,4 +18,6 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
     @Query("SELECT pt FROM PostTag pt WHERE pt.tagId IN :tagIds AND pt.tagType = :tagType")
     List<PostTag> findAllByTagIdAndTagType(@Param("tagIds") List<Long> tagIds, @Param("tagType") TagType tagType);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
@@ -4,6 +4,9 @@ import com.cocos.cocos.db.review.db.ReviewImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    void deleteAllByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
@@ -9,4 +9,8 @@ import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByHospitalId(final Long hospitalId);
+
+    List<Review> findAllByMemberId(final Long memberId);
+
+    void deleteAllByIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface ReviewSummaryRepository extends CrudRepository<ReviewSummary, Long> {
     int countByReviewIdInAndReviewSummaryOptionId(final List<Long> reviewIds, final Long reviewSummaryOptionId);
+
+    void deleteAllByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
@@ -4,6 +4,9 @@ import com.cocos.cocos.db.review.db.ReviewSymptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReviewSymptomRepository extends JpaRepository<ReviewSymptom, Long> {
+    void deleteAllByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -19,4 +19,6 @@ public interface SearchRepository extends JpaRepository<Search, Long> {
     List<Search> findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(final Long memberId, final SearchType searchType);
 
     List<Search> findAllByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
+
+    void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -90,6 +90,8 @@ public enum FailMessage {
     INTERNAL_SERVER_ERROR_PET_ID_FOR_MEMBER(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "서버에 유효하지 않은 petId가 존재합니다. "),
     INTERNAL_SERVER_ERROR_PET_AGE(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "서버에 유효하지 않은 petAge가 존재합니다. "),
     INTERNAL_SERVER_ERROR_UNSUPPORTED_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, 50004, "유틸 클래스입니다. "),
+    INTERNAL_SERVER_ERROR_KAKAO_UNLINK(HttpStatus.INTERNAL_SERVER_ERROR, 50005, "카카오 회원탈퇴에 실패했습니다."),
+
     /**
      * 503
      */

--- a/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
+++ b/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
@@ -1,7 +1,10 @@
 package com.cocos.cocos.external;
 
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.login.dto.KakaoAccessTokenResponse;
 import com.cocos.cocos.external.login.dto.KakaoInfoResponse;
+import com.cocos.cocos.external.login.dto.KakaoUnlinkResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -20,6 +23,10 @@ public class KakaoLoginClient {
     private String kakaoClientId;
     @Value("${kakao.redirect-url}")
     private String kakaoRedirectUrl;
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    private static final String ADMIN_KEY_TYPE = "KakaoAK ";
 
     public String login(final String code) {
 
@@ -52,5 +59,27 @@ public class KakaoLoginClient {
                 .body(KakaoInfoResponse.class);
 
         return kakaoInfoResponse.id();
+    }
+
+    public void unlink(final Long id) {
+        RestClient restClient = RestClient.create();
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com/v1/user/unlink")
+                .queryParam("target_id_type", "{targetIdType}")
+                .queryParam("target_id", "{targetId}")
+                .encode()
+                .buildAndExpand("user_id", id)
+                .toUri();
+
+        KakaoUnlinkResponse kakaoUnlinkResponse = restClient.post()
+                .uri(uri)
+                .header("Authorization", ADMIN_KEY_TYPE + kakaoAdminKey)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .body(KakaoUnlinkResponse.class);
+
+        if (kakaoUnlinkResponse.id() == null) {
+            throw new CocosException(FailMessage.INTERNAL_SERVER_ERROR_KAKAO_UNLINK);
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/external/login/dto/KakaoUnlinkRequest.java
+++ b/src/main/java/com/cocos/cocos/external/login/dto/KakaoUnlinkRequest.java
@@ -1,0 +1,14 @@
+package com.cocos.cocos.external.login.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUnlinkRequest(
+        String targetIdType,
+        Long targetId
+) {
+    public static KakaoUnlinkRequest of(final String targetIdType, final Long targetId) {
+        return new KakaoUnlinkRequest(targetIdType, targetId);
+    }
+}

--- a/src/main/java/com/cocos/cocos/external/login/dto/KakaoUnlinkResponse.java
+++ b/src/main/java/com/cocos/cocos/external/login/dto/KakaoUnlinkResponse.java
@@ -1,0 +1,6 @@
+package com.cocos.cocos.external.login.dto;
+
+public record KakaoUnlinkResponse(
+        Long id
+) {
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #187 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 회원탈퇴를 구현했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 우선 기획의도에 따라 hard delete로 구현했습니다.
* 멤버가 삭제되는 만큼 관련되어있는 것들은 모두 삭제했는데, 혹시 빠진 부분이 있으면 검토해 주시면 감사하겠습니다!
1. `펫`, `펫증상`, `펫질병` 삭제
2. `작성한 댓글` , `작성한 대댓글` , `작성한 게시물` ,`작성한 게시물의 댓글` , `작성한 게시물의 대댓글` 삭제
3. `좋아요 수` 감소 , `좋아요 여부` 삭제 
4. `게시물 태그`, `게시물 이미지` 삭제
5. `리뷰` , `리뷰 이미지` , `리뷰 요약` 삭제
6. `병원 리뷰 수` 감소
7. `주소` ,`토큰` , `카카오 회원탈퇴` , `사용자` 삭제

* 카카오 회원탈퇴에 따른 yml 업데이트가 있습니다(admin-key 추가). 따라서 secret 업데이트가 필요합니다! approve되면 notion에 업데이트하겠습니다 : ) 