### PR TITLE
Feat: 사용자 리뷰 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -167,7 +167,7 @@ public class MemberService {
         member.updateMyHospitalId(hospitalId);
     }
 
-    public Member findMember(final String nickname, final Long memberId) {
+    private Member findMember(final String nickname, final Long memberId) {
         if (nickname != null) {
             return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }

--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -167,7 +167,7 @@ public class MemberService {
         member.updateMyHospitalId(hospitalId);
     }
 
-    private Member findMember(final String nickname, final Long memberId) {
+    public Member findMember(final String nickname, final Long memberId) {
         if (nickname != null) {
             return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.review.dto.response.MemberHospitalReviewListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryOptionListResponse;
+import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.api.review.service.ReviewService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.review.controller;
 
 import com.cocos.cocos.api.review.dto.request.ReviewAddRequest;
+import com.cocos.cocos.api.review.dto.response.MemberHospitalReviewListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryOptionListResponse;
@@ -10,13 +11,17 @@ import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("${api.prefix}")
 @RequiredArgsConstructor
+@Validated
 public class ReviewController implements ReviewControllerSwagger {
 
     private final ReviewService reviewService;
@@ -44,5 +49,14 @@ public class ReviewController implements ReviewControllerSwagger {
     @GetMapping("/hospitals/reviews/summary/option")
     public ResponseEntity<BaseResponse<ReviewSummaryOptionListResponse>> getReviewSummaryOptionList() {
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getReviewSummaryOptionList());
+    }
+
+    @GetMapping("/hospitals/reviews/members")
+    public ResponseEntity<BaseResponse<MemberHospitalReviewListResponse>> getMemberHospitalReviewList(
+            @RequestParam(name = "nickname", required = false) final String nickname,
+            @RequestParam(name = "cursorId", required = false) final Long cursorId,
+            @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, reviewService.getMemberHospitalReviewList(nickname, cursorId, size, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
@@ -1,19 +1,24 @@
 package com.cocos.cocos.api.review.controller;
 
 import com.cocos.cocos.api.review.dto.request.ReviewAddRequest;
+import com.cocos.cocos.api.review.dto.response.MemberHospitalReviewListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryOptionListResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Review Controller", description = "리뷰 관련 API")
 public interface ReviewControllerSwagger {
@@ -36,7 +41,7 @@ public interface ReviewControllerSwagger {
     )
     @Parameter(name = "hospitalId", description = "병원 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<ReviewSummaryListResponse>> getReviewSummaryList(
-            @PathVariable(name = "hospitalId") final Long hospitalId
+            @PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId
     );
 
     @Operation(summary = "리뷰 요약 옵션 리스트 조회 API", description = "병원 리뷰 요약 옵션 리스트를 조회하는 API입니다. ")
@@ -45,4 +50,18 @@ public interface ReviewControllerSwagger {
             description = "요청에 성공했습니다."
     )
     public ResponseEntity<BaseResponse<ReviewSummaryOptionListResponse>> getReviewSummaryOptionList();
+
+    @Operation(summary = "사용자 리뷰 리스트 조회 API", description = "마이페이지 리뷰 리스트 조회 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다."
+    )
+    @Parameter(name = "nickname", description = "사용자 닉네임", required = false)
+    @Parameter(name = "cursorId", description = "페이징용 마지막 리뷰 ID", required = false)
+    @Parameter(name = "size", description = "페이지당 조회할 리뷰 개수 (1~20) 비로그인 시 최대 4개")
+    public ResponseEntity<BaseResponse<MemberHospitalReviewListResponse>> getMemberHospitalReviewList(
+            @RequestParam(name = "nickname", required = false) final String nickname,
+            @RequestParam(name = "cursorId", required = false) final Long cursorId,
+            @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
+    );
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
@@ -1,0 +1,49 @@
+package com.cocos.cocos.api.review.dto.response;
+
+import com.cocos.cocos.enums.pet.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "리뷰 정보")
+public record HospitalReviewResponse(
+        @Schema(description = "리뷰 ID")
+        Long id,
+        @Schema(description = "병원 아이디")
+        Long hospitalId,
+        @Schema(description = "병원 이름")
+        String hospitalName,
+        @Schema(description = "방문 일자")
+        String visitedAt,
+        @Schema(description = "병원 주소")
+        String hospitalAddress,
+        @Schema(description = "리뷰 본문")
+        String content,
+        @Schema(description = "리뷰 요약 옵션 리스트")
+        ReviewSummaryOptionListResponse reviewSummary,
+        @Schema(description = "리뷰 이미지 리스트")
+        List<String> images,
+        @Schema(description = "증상 리스트")
+        List<String> symptoms,
+        @Schema(description = "질병 이름")
+        String disease,
+        @Schema(description = "동물 이름")
+        String animal,
+        @Schema(description = "성별")
+        Gender gender,
+        @Schema(description = "종 이름")
+        String breed,
+        @Schema(description = "몸무게")
+        double weight
+) {
+    public static HospitalReviewResponse of(
+            Long id, Long hospitalId, String hospitalName, String visitedAt, String hospitalAddress,
+            String content, ReviewSummaryOptionListResponse reviewSummary,
+            List<String> images, List<String> symptoms, String disease,
+            String animal, Gender gender, String breed, double weight
+    ) {
+        return new HospitalReviewResponse(id, hospitalId, hospitalName, visitedAt, hospitalAddress,
+                content, reviewSummary, images, symptoms,
+                disease, animal, gender, breed, weight);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
@@ -37,10 +37,10 @@ public record HospitalReviewResponse(
         double weight
 ) {
     public static HospitalReviewResponse of(
-            Long id, Long hospitalId, String hospitalName, String visitedAt, String hospitalAddress,
-            String content, ReviewSummaryOptionListResponse reviewSummary,
-            List<String> images, List<String> symptoms, String disease,
-            String animal, Gender gender, String breed, double weight
+            final Long id, final Long hospitalId, final String hospitalName, final String visitedAt, final String hospitalAddress,
+            final String content, final ReviewSummaryOptionListResponse reviewSummary,
+            final List<String> images, final List<String> symptoms, final String disease,
+            final String animal, final Gender gender, final String breed, final double weight
     ) {
         return new HospitalReviewResponse(id, hospitalId, hospitalName, visitedAt, hospitalAddress,
                 content, reviewSummary, images, symptoms,

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewListResponse.java
@@ -1,0 +1,12 @@
+package com.cocos.cocos.api.review.dto.response;
+
+import java.util.List;
+
+public record MemberHospitalReviewListResponse(
+        Long cursorId,
+        List<HospitalReviewResponse> reviews
+) {
+    public static MemberHospitalReviewListResponse of(final Long cursorId, final List<HospitalReviewResponse> reviewResponses) {
+        return new MemberHospitalReviewListResponse(cursorId, reviewResponses);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewListResponse.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 public record MemberHospitalReviewListResponse(
         Long cursorId,
-        List<HospitalReviewResponse> reviews
+        List<MemberHospitalReviewResponse> reviews
 ) {
-    public static MemberHospitalReviewListResponse of(final Long cursorId, final List<HospitalReviewResponse> reviewResponses) {
+    public static MemberHospitalReviewListResponse of(final Long cursorId, final List<MemberHospitalReviewResponse> reviewResponses) {
         return new MemberHospitalReviewListResponse(cursorId, reviewResponses);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewResponse.java
@@ -6,43 +6,43 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "리뷰 정보")
-public record HospitalReviewResponse(
-        @Schema(description = "리뷰 ID")
+public record MemberHospitalReviewResponse(
+        @Schema(description = "리뷰 ID", example = "1")
         Long id,
-        @Schema(description = "병원 아이디")
+        @Schema(description = "병원 아이디", example = "1")
         Long hospitalId,
-        @Schema(description = "병원 이름")
+        @Schema(description = "병원 이름", example = "코코병원")
         String hospitalName,
-        @Schema(description = "방문 일자")
+        @Schema(description = "방문 일자", example = "2020.02.02")
         String visitedAt,
-        @Schema(description = "병원 주소")
+        @Schema(description = "병원 주소", example = "서울시 강남구")
         String hospitalAddress,
-        @Schema(description = "리뷰 본문")
+        @Schema(description = "리뷰 본문", example = "좋았다.")
         String content,
         @Schema(description = "리뷰 요약 옵션 리스트")
         ReviewSummaryOptionListResponse reviewSummary,
         @Schema(description = "리뷰 이미지 리스트")
         List<String> images,
-        @Schema(description = "증상 리스트")
+        @Schema(description = "증상 리스트", example = "배가 아파요")
         List<String> symptoms,
-        @Schema(description = "질병 이름")
+        @Schema(description = "질병 이름", example = "심장병")
         String disease,
-        @Schema(description = "동물 이름")
+        @Schema(description = "동물 이름", example = "강아지")
         String animal,
-        @Schema(description = "성별")
+        @Schema(description = "성별", example = "F")
         Gender gender,
-        @Schema(description = "종 이름")
+        @Schema(description = "종 이름", example = "말티즈")
         String breed,
-        @Schema(description = "몸무게")
+        @Schema(description = "몸무게", example = "2.7")
         double weight
 ) {
-    public static HospitalReviewResponse of(
+    public static MemberHospitalReviewResponse of(
             final Long id, final Long hospitalId, final String hospitalName, final String visitedAt, final String hospitalAddress,
             final String content, final ReviewSummaryOptionListResponse reviewSummary,
             final List<String> images, final List<String> symptoms, final String disease,
             final String animal, final Gender gender, final String breed, final double weight
     ) {
-        return new HospitalReviewResponse(id, hospitalId, hospitalName, visitedAt, hospitalAddress,
+        return new MemberHospitalReviewResponse(id, hospitalId, hospitalName, visitedAt, hospitalAddress,
                 content, reviewSummary, images, symptoms,
                 disease, animal, gender, breed, weight);
     }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -149,6 +149,7 @@ public class ReviewService {
 
         final List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
 
+        // TODO: 팀 컨벤션 측면에서, Map방식과 filter 방식 중 적절한 방식 논의 필요
         final Map<Long, Hospital> hospitalMap = getHospitalMap(reviews);
         final Map<Long, List<String>> reviewIdToImageUrls = getReviewIdToImageUrls(reviewIds);
         final Map<Long, Breed> breedMap = getBreedMap(reviews);

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -215,13 +215,13 @@ public class ReviewService {
                             .toList();
 
                     final List<ReviewSummaryOptionResponse> goodReviewSummaries = summaryOptions.stream()
-                            .filter(opt -> Boolean.TRUE.equals(opt.getIsGood()))
-                            .map(opt -> ReviewSummaryOptionResponse.of(opt.getId(), opt.getLabel()))
+                            .filter(option -> Boolean.TRUE.equals(option.getIsGood()))
+                            .map(option -> ReviewSummaryOptionResponse.of(option.getId(), option.getLabel()))
                             .toList();
 
                     final List<ReviewSummaryOptionResponse> badReviewSummaries = summaryOptions.stream()
-                            .filter(opt -> Boolean.FALSE.equals(opt.getIsGood()))
-                            .map(opt -> ReviewSummaryOptionResponse.of(opt.getId(), opt.getLabel()))
+                            .filter(option -> Boolean.FALSE.equals(option.getIsGood()))
+                            .map(option -> ReviewSummaryOptionResponse.of(option.getId(), option.getLabel()))
                             .toList();
 
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,16 +1,38 @@
 package com.cocos.cocos.api.review.service;
 
+import com.cocos.cocos.api.member.service.MemberService;
+import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
+import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
+import com.cocos.cocos.api.review.dto.response.ReviewSummaryResponse;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.animal.entity.Animal;
+import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.db.breed.entity.Breed;
+import com.cocos.cocos.db.breed.repository.BreedRepository;
+import com.cocos.cocos.db.disease.entity.Disease;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.db.hospital.entity.Hospital;
+import com.cocos.cocos.db.hospital.repository.HospitalRepository;
+import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.db.review.db.*;
 import com.cocos.cocos.db.review.repository.*;
+import com.cocos.cocos.db.symptom.entity.Symptom;
+import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.external.MemberDataS3Client;
+import com.cocos.cocos.util.SortConstants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,9 +44,17 @@ public class ReviewService {
     private final ReviewImageRepository reviewImageRepository;
     private final ReviewSummaryOptionRepository reviewSummaryOptionRepository;
     private final MemberDataS3Client memberDataS3Client;
+    private final HospitalRepository hospitalRepository;
+    private final BreedRepository breedRepository;
+    private final AnimalRepository animalRepository;
+    private final DiseaseRepository diseaseRepository;
+    private final SymptomRepository symptomRepository;
+
+    private final MemberService memberService;
 
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
+    private static final int DEFAULT_PAGE_SIZE = 4;
 
     @Transactional
     public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -103,6 +133,133 @@ public class ReviewService {
                 getReviewSummaryAndCount(reviewSummaryOptions, reviewIds, IS_GOOD_REVIEW),
                 getReviewSummaryAndCount(reviewSummaryOptions, reviewIds, !IS_GOOD_REVIEW)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public MemberHospitalReviewListResponse getMemberHospitalReviewList(final String nickname, final Long cursorId, final int size, final Long memberId) {
+        if (memberId == null && nickname == null) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_QUERY);
+        }
+        final Member member = memberService.findMember(nickname, memberId);
+        final int searchSize = memberId == null ? DEFAULT_PAGE_SIZE : size;
+        final Pageable pageable = PageRequest.of(0, searchSize, Sort.by(
+                SortConstants.ID_DESC
+        ));
+
+        final List<Review> reviews = (cursorId == null)
+                ? reviewRepository.findAllByMemberId(member.getId(), pageable)
+                : reviewRepository.findAllByMemberIdAndIdLessThan(member.getId(), cursorId, pageable);
+
+        final Set<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toSet());
+
+        final Set<Long> hospitalIds = reviews.stream().map(Review::getHospitalId).collect(Collectors.toSet());
+        final Map<Long, Hospital> hospitalMap = hospitalRepository.findAllById(hospitalIds).stream()
+                .collect(Collectors.toMap(Hospital::getId, Function.identity()));
+
+        final List<ReviewImage> reviewImages = reviewImageRepository.findAllByReviewIdIn(reviewIds);
+        final Map<Long, List<String>> reviewIdToImageUrls = reviewImages.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewImage::getReviewId,
+                        Collectors.mapping(img -> memberDataS3Client.getPresignedUrl(img.getImage()), Collectors.toList())
+                ));
+
+        final Set<Long> breedIds = reviews.stream().map(Review::getBreedId).collect(Collectors.toSet());
+        final Map<Long, Breed> breedMap = breedRepository.findAllById(breedIds).stream()
+                .collect(Collectors.toMap(Breed::getId, Function.identity()));
+        final Set<Long> animalIds = breedMap.values().stream()
+                .map(Breed::getAnimalId)
+                .collect(Collectors.toSet());
+        final Map<Long, Animal> animalMap = animalRepository.findAllById(animalIds).stream()
+                .collect(Collectors.toMap(Animal::getId, Function.identity()));
+
+        final Set<Long> diseaseIds = reviews.stream().map(Review::getDiseaseId).collect(Collectors.toSet());
+        final Map<Long, Disease> diseaseMap = diseaseRepository.findAllById(diseaseIds).stream()
+                .collect(Collectors.toMap(Disease::getId, Function.identity()));
+
+        final List<ReviewSymptom> reviewSymptoms = reviewSymptomRepository.findByReviewIdIn(reviewIds);
+        final Map<Long, List<Long>> reviewIdToSymptomIds = reviewSymptoms.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewSymptom::getReviewId,
+                        Collectors.mapping(ReviewSymptom::getSymptomId, Collectors.toList())
+                ));
+        final Set<Long> symptomIds = reviewSymptoms.stream().map(ReviewSymptom::getSymptomId).collect(Collectors.toSet());
+        final Map<Long, Symptom> symptomMap = symptomRepository.findAllById(symptomIds).stream()
+                .collect(Collectors.toMap(Symptom::getId, Function.identity()));
+
+        final List<ReviewSummary> reviewSummaries = reviewSummaryRepository.findByReviewIdIn(reviewIds);
+        final Map<Long, List<Long>> reviewIdToSummaryIds = reviewSummaries.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewSummary::getReviewId,
+                        Collectors.mapping(ReviewSummary::getReviewSummaryOptionId, Collectors.toList())
+                ));
+        final Set<Long> reviewSummaryOptionIds = reviewSummaries.stream().map(ReviewSummary::getReviewSummaryOptionId).collect(Collectors.toSet());
+        final Map<Long, ReviewSummaryOption> reviewSummaryOptionMap = reviewSummaryOptionRepository.findAllById(reviewSummaryOptionIds).stream()
+                .collect(Collectors.toMap(ReviewSummaryOption::getId, Function.identity()));
+
+        final List<HospitalReviewResponse> reviewResponses = reviews.stream()
+                .map(review -> {
+                    final Hospital hospital = requireEntity(hospitalMap.get(review.getHospitalId()), FailMessage.NOT_FOUND_HOSPITAL);
+                    final Breed breed = requireEntity(breedMap.get(review.getBreedId()), FailMessage.NOT_FOUND_BREED);
+                    final Animal animal = requireEntity(animalMap.get(breed.getAnimalId()), FailMessage.NOT_FOUND_ANIMAL);
+                    final Disease disease = requireEntity(diseaseMap.get(review.getDiseaseId()), FailMessage.NOT_FOUND_DISEASE);
+
+                    final List<String> imageUrls = reviewIdToImageUrls.getOrDefault(review.getId(), List.of());
+
+                    final List<String> symptomResponses = reviewIdToSymptomIds.getOrDefault(review.getId(), List.of()).stream()
+                            .map(symptomId -> {
+                                final Symptom symptom = requireEntity(symptomMap.get(symptomId), FailMessage.NOT_FOUND_SYMPTOM);
+                                return symptom.getName();
+                            })
+                            .toList();
+
+                    final List<Long> summaryOptionIds = reviewIdToSummaryIds.getOrDefault(review.getId(), List.of());
+                    final List<ReviewSummaryOption> summaryOptions = summaryOptionIds.stream()
+                            .map(optionId -> requireEntity(reviewSummaryOptionMap.get(optionId), FailMessage.NOT_FOUND_SUMMARY_OPTION))
+                            .toList();
+
+                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = summaryOptions.stream()
+                            .filter(opt -> Boolean.TRUE.equals(opt.getIsGood()))
+                            .map(opt -> ReviewSummaryOptionResponse.of(opt.getId(), opt.getLabel()))
+                            .toList();
+
+                    final List<ReviewSummaryOptionResponse> badReviewSummaries = summaryOptions.stream()
+                            .filter(opt -> Boolean.FALSE.equals(opt.getIsGood()))
+                            .map(opt -> ReviewSummaryOptionResponse.of(opt.getId(), opt.getLabel()))
+                            .toList();
+
+                    final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
+                            goodReviewSummaries, badReviewSummaries
+                    );
+
+
+                    return HospitalReviewResponse.of(
+                            review.getId(),
+                            hospital.getId(),
+                            hospital.getName(),
+                            review.getVisitedAt(),
+                            hospital.getDisplayAddress(),
+                            review.getContent(),
+                            summaryOptionList,
+                            imageUrls,
+                            symptomResponses,
+                            disease.getName(),
+                            animal.getName(),
+                            review.getGender(),
+                            breed.getName(),
+                            review.getWeight()
+                    );
+                })
+                .toList();
+
+        return MemberHospitalReviewListResponse.of(
+                reviews.isEmpty() ? null : reviews.getLast().getId(),
+                reviewResponses
+        );
+    }
+
+    private <T> T requireEntity(final T entity, final FailMessage message) {
+        if (entity == null) throw new CocosException(message);
+        return entity;
     }
 
     private List<ReviewSummaryResponse> getReviewSummaryAndCount(final List<ReviewSummaryOption> reviewSummaryOptions, final List<Long> reviewIds, final boolean isGood) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -1,6 +1,5 @@
 package com.cocos.cocos.api.review.service;
 
-import com.cocos.cocos.api.member.service.MemberService;
 import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryResponse;
@@ -15,6 +14,7 @@ import com.cocos.cocos.db.hospital.entity.Hospital;
 import com.cocos.cocos.db.hospital.repository.HospitalRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.api.review.dto.response.*;
+import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.review.db.*;
 import com.cocos.cocos.db.review.repository.*;
 import com.cocos.cocos.db.symptom.entity.Symptom;
@@ -49,8 +49,7 @@ public class ReviewService {
     private final AnimalRepository animalRepository;
     private final DiseaseRepository diseaseRepository;
     private final SymptomRepository symptomRepository;
-
-    private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
@@ -137,10 +136,8 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public MemberHospitalReviewListResponse getMemberHospitalReviewList(final String nickname, final Long cursorId, final int size, final Long memberId) {
-        if (memberId == null && nickname == null) {
-            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_QUERY);
-        }
-        final Member member = memberService.findMember(nickname, memberId);
+        final Member member = findMember(nickname, memberId);
+
         final int searchSize = memberId == null ? DEFAULT_PAGE_SIZE : size;
         final Pageable pageable = PageRequest.of(0, searchSize, Sort.by(
                 SortConstants.ID_DESC
@@ -260,6 +257,17 @@ public class ReviewService {
     private <T> T requireEntity(final T entity, final FailMessage message) {
         if (entity == null) throw new CocosException(message);
         return entity;
+    }
+
+    private Member findMember(final String nickname, final Long memberId) {
+        if (memberId == null && nickname == null) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_QUERY);
+        }
+
+        if (nickname != null) {
+            return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+        }
+        return memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
     }
 
     private List<ReviewSummaryResponse> getReviewSummaryAndCount(final List<ReviewSummaryOption> reviewSummaryOptions, final List<Long> reviewIds, final boolean isGood) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -255,14 +255,11 @@ public class ReviewService {
     }
 
     private Map<Long, List<String>> getReviewIdToSymptoms(final List<Long> reviewIds) {
-
-        List<ReviewSymptom> reviewSymptoms = reviewSymptomRepository.findByReviewIdIn(reviewIds);
-
-        Set<Long> symptomIds = reviewSymptoms.stream()
+        final List<ReviewSymptom> reviewSymptoms = reviewSymptomRepository.findByReviewIdIn(reviewIds);
+        final Set<Long> symptomIds = reviewSymptoms.stream()
                 .map(ReviewSymptom::getSymptomId)
                 .collect(Collectors.toSet());
-
-        Map<Long, Symptom> symptomMap = symptomRepository.findAllById(symptomIds).stream()
+        final Map<Long, Symptom> symptomMap = symptomRepository.findAllById(symptomIds).stream()
                 .collect(Collectors.toMap(Symptom::getId, Function.identity()));
 
         return reviewSymptoms.stream()

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -149,87 +149,32 @@ public class ReviewService {
 
         final List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
 
-        final Set<Long> hospitalIds = reviews.stream().map(Review::getHospitalId).collect(Collectors.toSet());
-        final Map<Long, Hospital> hospitalMap = hospitalRepository.findAllById(hospitalIds).stream()
-                .collect(Collectors.toMap(Hospital::getId, Function.identity()));
+        final Map<Long, Hospital> hospitalMap = getHospitalMap(reviews);
+        final Map<Long, List<String>> reviewIdToImageUrls = getReviewIdToImageUrls(reviewIds);
+        final Map<Long, Breed> breedMap = getBreedMap(reviews);
+        final Map<Long, Animal> animalMap = getAnimalMap(breedMap);
+        final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
+        final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
+        final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
 
-        final List<ReviewImage> reviewImages = reviewImageRepository.findAllByReviewIdIn(reviewIds);
-        final Map<Long, List<String>> reviewIdToImageUrls = reviewImages.stream()
-                .collect(Collectors.groupingBy(
-                        ReviewImage::getReviewId,
-                        Collectors.mapping(img -> memberDataS3Client.getPresignedUrl(img.getImage()), Collectors.toList())
-                ));
-
-        final Set<Long> breedIds = reviews.stream().map(Review::getBreedId).collect(Collectors.toSet());
-        final Map<Long, Breed> breedMap = breedRepository.findAllById(breedIds).stream()
-                .collect(Collectors.toMap(Breed::getId, Function.identity()));
-        final Set<Long> animalIds = breedMap.values().stream()
-                .map(Breed::getAnimalId)
-                .collect(Collectors.toSet());
-        final Map<Long, Animal> animalMap = animalRepository.findAllById(animalIds).stream()
-                .collect(Collectors.toMap(Animal::getId, Function.identity()));
-
-        final Set<Long> diseaseIds = reviews.stream().map(Review::getDiseaseId).collect(Collectors.toSet());
-        final Map<Long, Disease> diseaseMap = diseaseRepository.findAllById(diseaseIds).stream()
-                .collect(Collectors.toMap(Disease::getId, Function.identity()));
-
-        final List<ReviewSymptom> reviewSymptoms = reviewSymptomRepository.findByReviewIdIn(reviewIds);
-        final Map<Long, List<Long>> reviewIdToSymptomIds = reviewSymptoms.stream()
-                .collect(Collectors.groupingBy(
-                        ReviewSymptom::getReviewId,
-                        Collectors.mapping(ReviewSymptom::getSymptomId, Collectors.toList())
-                ));
-        final Set<Long> symptomIds = reviewSymptoms.stream().map(ReviewSymptom::getSymptomId).collect(Collectors.toSet());
-        final Map<Long, Symptom> symptomMap = symptomRepository.findAllById(symptomIds).stream()
-                .collect(Collectors.toMap(Symptom::getId, Function.identity()));
-
-        final List<ReviewSummary> reviewSummaries = reviewSummaryRepository.findByReviewIdIn(reviewIds);
-        final Map<Long, List<Long>> reviewIdToSummaryIds = reviewSummaries.stream()
-                .collect(Collectors.groupingBy(
-                        ReviewSummary::getReviewId,
-                        Collectors.mapping(ReviewSummary::getReviewSummaryOptionId, Collectors.toList())
-                ));
-        final Set<Long> reviewSummaryOptionIds = reviewSummaries.stream().map(ReviewSummary::getReviewSummaryOptionId).collect(Collectors.toSet());
-        final Map<Long, ReviewSummaryOption> reviewSummaryOptionMap = reviewSummaryOptionRepository.findAllById(reviewSummaryOptionIds).stream()
-                .collect(Collectors.toMap(ReviewSummaryOption::getId, Function.identity()));
-
-        final List<HospitalReviewResponse> reviewResponses = reviews.stream()
+        final List<MemberHospitalReviewResponse> reviewResponses = reviews.stream()
                 .map(review -> {
-                    final Hospital hospital = requireEntity(hospitalMap.get(review.getHospitalId()), FailMessage.NOT_FOUND_HOSPITAL);
-                    final Breed breed = requireEntity(breedMap.get(review.getBreedId()), FailMessage.NOT_FOUND_BREED);
-                    final Animal animal = requireEntity(animalMap.get(breed.getAnimalId()), FailMessage.NOT_FOUND_ANIMAL);
-                    final Disease disease = requireEntity(diseaseMap.get(review.getDiseaseId()), FailMessage.NOT_FOUND_DISEASE);
-
+                    final Hospital hospital = hospitalMap.get(review.getHospitalId());
+                    final Breed breed = breedMap.get(review.getBreedId());
+                    final Animal animal = animalMap.get(breed.getAnimalId());
+                    final Disease disease = diseaseMap.get(review.getDiseaseId());
                     final List<String> imageUrls = reviewIdToImageUrls.getOrDefault(review.getId(), List.of());
+                    final List<String> symptoms = symptomMap.getOrDefault(review.getId(), List.of());
 
-                    final List<String> symptomResponses = reviewIdToSymptomIds.getOrDefault(review.getId(), List.of()).stream()
-                            .map(symptomId -> {
-                                final Symptom symptom = requireEntity(symptomMap.get(symptomId), FailMessage.NOT_FOUND_SYMPTOM);
-                                return symptom.getName();
-                            })
-                            .toList();
+                    final List<ReviewSummaryOption> summaryOptions = reviewSummaryOptionsMap.getOrDefault(review.getId(), List.of());
 
-                    final List<Long> summaryOptionIds = reviewIdToSummaryIds.getOrDefault(review.getId(), List.of());
-                    final List<ReviewSummaryOption> summaryOptions = summaryOptionIds.stream()
-                            .map(optionId -> requireEntity(reviewSummaryOptionMap.get(optionId), FailMessage.NOT_FOUND_SUMMARY_OPTION))
-                            .toList();
-
-                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = summaryOptions.stream()
-                            .filter(option -> Boolean.TRUE.equals(option.getIsGood()))
-                            .map(option -> ReviewSummaryOptionResponse.of(option.getId(), option.getLabel()))
-                            .toList();
-
-                    final List<ReviewSummaryOptionResponse> badReviewSummaries = summaryOptions.stream()
-                            .filter(option -> Boolean.FALSE.equals(option.getIsGood()))
-                            .map(option -> ReviewSummaryOptionResponse.of(option.getId(), option.getLabel()))
-                            .toList();
-
+                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, true);
+                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, false);
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
                             goodReviewSummaries, badReviewSummaries
                     );
 
-
-                    return HospitalReviewResponse.of(
+                    return MemberHospitalReviewResponse.of(
                             review.getId(),
                             hospital.getId(),
                             hospital.getName(),
@@ -238,7 +183,7 @@ public class ReviewService {
                             review.getContent(),
                             summaryOptionList,
                             imageUrls,
-                            symptomResponses,
+                            symptoms,
                             disease.getName(),
                             animal.getName(),
                             review.getGender(),
@@ -254,10 +199,112 @@ public class ReviewService {
         );
     }
 
-    private <T> T requireEntity(final T entity, final FailMessage message) {
-        if (entity == null) throw new CocosException(message);
-        return entity;
+    private Map<Long, Disease> getDiseaseMap(final List<Review> reviews) {
+        final Set<Long> diseaseIds = reviews.stream().map(Review::getDiseaseId).collect(Collectors.toSet());
+        final Map<Long, Disease> diseaseMap = diseaseRepository.findAllById(diseaseIds).stream()
+                .collect(Collectors.toMap(Disease::getId, Function.identity()));
+
+        if (diseaseMap.size() != diseaseIds.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_DISEASE);
+        }
+        return diseaseMap;
     }
+
+    private Map<Long, Animal> getAnimalMap(final Map<Long, Breed> breedMap) {
+        final Set<Long> animalIds = breedMap.values().stream()
+                .map(Breed::getAnimalId)
+                .collect(Collectors.toSet());
+        final Map<Long, Animal> animalMap = animalRepository.findAllById(animalIds).stream()
+                .collect(Collectors.toMap(Animal::getId, Function.identity()));
+
+        if (animalMap.size() != animalIds.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_ANIMAL);
+        }
+        return animalMap;
+    }
+
+    private Map<Long, Breed> getBreedMap(final List<Review> reviews) {
+        final Set<Long> breedIds = reviews.stream().map(Review::getBreedId).collect(Collectors.toSet());
+        final Map<Long, Breed> breedMap = breedRepository.findAllById(breedIds).stream()
+                .collect(Collectors.toMap(Breed::getId, Function.identity()));
+
+        if (breedMap.size() != breedIds.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_BREED);
+        }
+        return breedMap;
+    }
+
+    private Map<Long, Hospital> getHospitalMap(final List<Review> reviews) {
+        final Set<Long> hospitalIds = reviews.stream().map(Review::getHospitalId).collect(Collectors.toSet());
+        final Map<Long, Hospital> hospitalMap = hospitalRepository.findAllById(hospitalIds).stream()
+                .collect(Collectors.toMap(Hospital::getId, Function.identity()));
+
+        if (hospitalMap.size() != hospitalIds.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_HOSPITAL);
+        }
+        return hospitalMap;
+    }
+
+    private Map<Long, List<String>> getReviewIdToImageUrls(final List<Long> reviewIds) {
+        final List<ReviewImage> reviewImages = reviewImageRepository.findAllByReviewIdIn(reviewIds);
+        return reviewImages.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewImage::getReviewId,
+                        Collectors.mapping(img -> memberDataS3Client.getPresignedUrl(img.getImage()), Collectors.toList())
+                ));
+    }
+
+    private Map<Long, List<String>> getReviewIdToSymptoms(final List<Long> reviewIds) {
+
+        List<ReviewSymptom> reviewSymptoms = reviewSymptomRepository.findByReviewIdIn(reviewIds);
+
+        Set<Long> symptomIds = reviewSymptoms.stream()
+                .map(ReviewSymptom::getSymptomId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Symptom> symptomMap = symptomRepository.findAllById(symptomIds).stream()
+                .collect(Collectors.toMap(Symptom::getId, Function.identity()));
+
+        return reviewSymptoms.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewSymptom::getReviewId,
+                        Collectors.mapping(
+                                reviewSymptom -> {
+                                    final Symptom symptom = symptomMap.get(reviewSymptom.getSymptomId());
+                                    if (symptom == null) {
+                                        throw new CocosException(FailMessage.NOT_FOUND_SYMPTOM);
+                                    }
+                                    return symptom.getName();
+                                },
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    private Map<Long, List<ReviewSummaryOption>> getReviewSummaryOptionsMap(final List<Long> reviewIds) {
+
+        final List<ReviewSummary> reviewSummaries = reviewSummaryRepository.findByReviewIdIn(reviewIds);
+        final Set<Long> reviewSummaryOptionIds = reviewSummaries.stream().map(ReviewSummary::getReviewSummaryOptionId).collect(Collectors.toSet());
+
+        final Map<Long, ReviewSummaryOption> reviewSummaryOptionMap = reviewSummaryOptionRepository.findAllById(reviewSummaryOptionIds).stream()
+                .collect(Collectors.toMap(ReviewSummaryOption::getId, Function.identity()));
+
+        return reviewSummaries.stream()
+                .collect(Collectors.groupingBy(
+                        ReviewSummary::getReviewId,
+                        Collectors.mapping(
+                                reviewSummary -> {
+                                    final ReviewSummaryOption reviewSummaryOption = reviewSummaryOptionMap.get(reviewSummary.getReviewSummaryOptionId());
+                                    if (reviewSummaryOption == null) {
+                                        throw new CocosException(FailMessage.NOT_FOUND_SUMMARY_OPTION);
+                                    }
+                                    return reviewSummaryOption;
+                                },
+                                Collectors.toList()
+                        )
+                ));
+    }
+
 
     private Member findMember(final String nickname, final Long memberId) {
         if (memberId == null && nickname == null) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -147,7 +147,7 @@ public class ReviewService {
                 ? reviewRepository.findAllByMemberId(member.getId(), pageable)
                 : reviewRepository.findAllByMemberIdAndIdLessThan(member.getId(), cursorId, pageable);
 
-        final Set<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toSet());
+        final List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
 
         final Set<Long> hospitalIds = reviews.stream().map(Review::getHospitalId).collect(Collectors.toSet());
         final Map<Long, Hospital> hospitalMap = hospitalRepository.findAllById(hospitalIds).stream()

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
-    List<ReviewImage> findAllByReviewIdIn(final Set<Long> reviewId);
+    List<ReviewImage> findAllByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewImageRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.review.db.ReviewImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Set;
+
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    List<ReviewImage> findAllByReviewIdIn(final Set<Long> reviewId);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.db.review.repository;
 
 import com.cocos.cocos.db.review.db.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,8 @@ import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByHospitalId(final Long hospitalId);
+
+    List<Review> findAllByMemberIdAndIdLessThan(final Long memberId, final Long cursorId, final Pageable pageable);
+
+    List<Review> findAllByMemberId(final Long memberId, final Pageable pageable);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
@@ -5,11 +5,10 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 
 @Repository
 public interface ReviewSummaryRepository extends CrudRepository<ReviewSummary, Long> {
     int countByReviewIdInAndReviewSummaryOptionId(final List<Long> reviewIds, final Long reviewSummaryOptionId);
 
-    List<ReviewSummary> findByReviewIdIn(final Set<Long> reviewIds);
+    List<ReviewSummary> findByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface ReviewSummaryRepository extends CrudRepository<ReviewSummary, Long> {
     int countByReviewIdInAndReviewSummaryOptionId(final List<Long> reviewIds, final Long reviewSummaryOptionId);
+
+    List<ReviewSummary> findByReviewIdIn(final Set<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.review.db.ReviewSymptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Set;
+
 @Repository
 public interface ReviewSymptomRepository extends JpaRepository<ReviewSymptom, Long> {
+    List<ReviewSymptom> findByReviewIdIn(final Set<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 
 @Repository
 public interface ReviewSymptomRepository extends JpaRepository<ReviewSymptom, Long> {
-    List<ReviewSymptom> findByReviewIdIn(final Set<Long> reviewIds);
+    List<ReviewSymptom> findByReviewIdIn(final List<Long> reviewIds);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -22,7 +22,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_HOSPITAL_ID(HttpStatus.BAD_REQUEST, 40008, "유효하지 않은 병원 아이디입니다."),
     BAD_REQUEST_INVALID_BREED_ID(HttpStatus.BAD_REQUEST, 40009, "유효하지 않은 품종 아이디입니다."),
     BAD_REQUEST_INVALID_DISEASE_ID(HttpStatus.BAD_REQUEST, 40010, "유효하지 않은 질병 아이디입니다."),
-
+    BAD_REQUEST_INVALID_MEMBER_QUERY(HttpStatus.BAD_REQUEST, 40011, "회원 식별자 (id 또는 nickname)를 제공해야 합니다."),
     /**
      * 401
      */
@@ -62,6 +62,7 @@ public enum FailMessage {
     NOT_FOUND_CITY(HttpStatus.NOT_FOUND, 40419, "시/도를 찾을 수 없습니다."),
     NOT_FOUND_DISTRICT(HttpStatus.NOT_FOUND, 40420, "시/군/구를 찾을 수 없습니다."),
     NOT_FOUND_HOSPITAL(HttpStatus.NOT_FOUND, 40421, "병원을 찾을 수 없습니다."),
+    NOT_FOUND_SUMMARY_OPTION(HttpStatus.NOT_FOUND, 40422, "리뷰 요약 옵션을 찾을 수 없습니다."),
 
     /**
      * 405


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #186 

## 👷 **작업한 내용**
- 사용자 리뷰 리스트 조회 API 구현
- 비로그인 사용자의 경우 4개의 review만 가져올 수 있도록 구현하였습니다.
- 로그인 사용자의 경우 최대 20개의 review를 가져올 수 있습니다. (default = 10)
- MemberService의 findMember 메서드 접근제어자 public으로 변경
- 리뷰마다 루프를 돌면서 해당하는 동물, 종, 리뷰 요약 등을 가져오면 리뷰10개를 가져온다고 할 때 약 90개 정도의 쿼리가 발생하여 이를 최소화하기 위해 미리 Map 형식으로 정의해두고 10개로 쿼리 개수를 줄였습니다. 

## 🚨 **참고 사항**
- Map 데이터가 많아져서 메모리를 많이 사용할 것을 우려하여 페이지네이션의 최대값을 20으로 지정하였습니다. 임시로 설정해둔 값이라 변경될 가능성 있습니다. 
- MemberService의 메서드를 public으로 변경하여 외부 Service에서도 사용할 수 있도록 변경하였는데, 해당 구조에 대한 의견이 궁금합니다! 
