### PR TITLE
Feat: 리뷰 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -66,7 +66,7 @@ public class HospitalService {
 
     private List<Long> getDistrictIds(final Long locationId, final LocationType locationType) {
         if (locationType == LocationType.CITY) {
-            return districtRepository.findByCityId(locationId).stream().map(District::getId).toList();
+            return districtRepository.findAllByCityId(locationId).stream().map(District::getId).toList();
         }
         return List.of(locationId);
     }

--- a/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
+++ b/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
@@ -26,7 +26,7 @@ public class LocationService {
         return LocationResponse.of(
                 cities.stream()
                         .map(city -> {
-                            final List<District> districts = districtRepository.findByCityId(city.getId());
+                            final List<District> districts = districtRepository.findAllByCityId(city.getId());
                             return CityResponse.of(
                                     city.getId(),
                                     city.getName(),

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -6,6 +6,8 @@ import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewImageDeleteListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
 import com.cocos.cocos.api.review.dto.response.ReviewSummaryOptionListResponse;
+import com.cocos.cocos.api.review.dto.request.ReviewListRequest;
+import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.api.review.service.ReviewService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
@@ -60,6 +62,13 @@ public class ReviewController implements ReviewControllerSwagger {
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
     ) {
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getMemberHospitalReviewList(nickname, cursorId, size, PrincipalHandler.getMemberIdFromPrincipal()));
+    }
+
+    @PostMapping("/hospitals/reviews/filter")
+    public ResponseEntity<BaseResponse<HospitalReviewListResponse>> getHospitalReviewList(
+            @RequestBody final ReviewListRequest reviewListRequest
+    ) {
+        return SuccessResponse.success(SuccessMessage.OK, reviewService.getHospitalReviewList(reviewListRequest.hospitalId(), reviewListRequest.summaryOptionId(), reviewListRequest.cursorId(), reviewListRequest.size(), reviewListRequest.bodyId(), reviewListRequest.locationId(), reviewListRequest.locationType(), PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
     @DeleteMapping("/hospitals/reviews/{reviewId}")

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
@@ -1,11 +1,8 @@
 package com.cocos.cocos.api.review.controller;
 
 import com.cocos.cocos.api.review.dto.request.ReviewAddRequest;
-import com.cocos.cocos.api.review.dto.response.MemberHospitalReviewListResponse;
-import com.cocos.cocos.api.review.dto.response.ReviewAddResponse;
-import com.cocos.cocos.api.review.dto.response.ReviewImageDeleteListResponse;
-import com.cocos.cocos.api.review.dto.response.ReviewSummaryListResponse;
-import com.cocos.cocos.api.review.dto.response.ReviewSummaryOptionListResponse;
+import com.cocos.cocos.api.review.dto.request.ReviewListRequest;
+import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
 import com.cocos.cocos.validation.review.ReviewIdConstraint;
@@ -75,5 +72,14 @@ public interface ReviewControllerSwagger {
             @RequestParam(name = "nickname", required = false) final String nickname,
             @RequestParam(name = "cursorId", required = false) final Long cursorId,
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
+    );
+
+    @Operation(summary = "리뷰 리스트 조회 API", description = "메인페이지 리뷰 리스트 조회 & 병원 리뷰 리스트 조회 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공했습니다."
+    )
+    public ResponseEntity<BaseResponse<HospitalReviewListResponse>> getHospitalReviewList(
+            @RequestBody final ReviewListRequest reviewListRequest
     );
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
@@ -1,0 +1,32 @@
+package com.cocos.cocos.api.review.dto.request;
+
+import com.cocos.cocos.enums.location.LocationType;
+import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record ReviewListRequest(
+        @Schema(description = "리뷰 요약 아이디", example = "1", nullable = true)
+        Long summaryOptionId, // TODO: 검증 로직 필요
+        @Schema(description = "커서 아이디 (마지막으로 전달받은 리뷰 아이디", example = "1", nullable = true)
+        Long cursorId, // TODO: 검증 로직 필요
+        @Schema(description = "병원 아이디", nullable = true, example = "1")
+        @HospitalIdConstraint
+        Long hospitalId,
+        @Schema(description = "신체 아이디", nullable = true, example = "1")
+        Long bodyId, // TODO: 검증 로직 필요
+        @Schema(description = "지역 아이디", nullable = true, example = "1")
+        Long locationId, // TODO: 검증 로직 필요
+        @Schema(description = "지역 타입", nullable = true, example = "DISTRICT")
+        LocationType locationType,
+        @Schema(description = "페이지네이션 크기 ", example = "10", defaultValue = "10")
+        @Min(value = 1, message = "size는 1이상입니다.")
+        @Max(value = 20, message = "size는 20이하입니다.")
+        int size
+) {
+    public ReviewListRequest(final Long summaryReviewId, final Long cursorId, final Long hospitalId, final Long bodyId, final Long locationId, final LocationType locationType) {
+        this(summaryReviewId, cursorId, hospitalId, bodyId, locationId, locationType, 10);
+    }
+
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewListResponse.java
@@ -1,0 +1,17 @@
+package com.cocos.cocos.api.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record HospitalReviewListResponse(
+        @Schema(description = "리뷰수", example = "111", nullable = true)
+        Integer reviewCount,
+        @Schema(description = "커서 아이디 (마지막으로 전달받은 리뷰 아이디)", example = "12")
+        Long cursorId,
+        List<HospitalReviewResponse> reviews
+) {
+    public static HospitalReviewListResponse of(final Integer reviewCount, final Long cursorId, final List<HospitalReviewResponse> reviews) {
+        return new HospitalReviewListResponse(reviewCount, cursorId, reviews);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewListResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewListResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 public record HospitalReviewListResponse(
         @Schema(description = "리뷰수", example = "111", nullable = true)
         Integer reviewCount,
-        @Schema(description = "커서 아이디 (마지막으로 전달받은 리뷰 아이디)", example = "12")
+        @Schema(description = "커서 아이디 (현재 응답 값의 마지막 리뷰 아이디)", example = "12")
         Long cursorId,
         List<HospitalReviewResponse> reviews
 ) {

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
@@ -1,0 +1,57 @@
+package com.cocos.cocos.api.review.dto.response;
+
+import com.cocos.cocos.enums.pet.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "리뷰 정보")
+public record HospitalReviewResponse(
+        @Schema(description = "리뷰 ID", example = "1")
+        Long id,
+        @Schema(description = "작성자 아이디", example = "1")
+        Long memberId,
+        @Schema(description = "작성자 닉네임", example = "냥냥")
+        String nickname,
+        @Schema(description = "종 이름", example = "말티즈")
+        String memberBreed,
+        @Schema(description = "펫 나이", example = "1")
+        int age,
+        @Schema(description = "병원 아이디", example = "1")
+        Long hospitalId,
+        @Schema(description = "병원 이름", example = "코코병원")
+        String hospitalName,
+        @Schema(description = "방문 일자", example = "2020.02.02")
+        String visitedAt,
+        @Schema(description = "병원 주소", example = "서울시 강남구")
+        String hospitalAddress,
+        @Schema(description = "리뷰 본문", example = "좋았다.")
+        String content,
+        @Schema(description = "리뷰 요약 옵션 리스트")
+        ReviewSummaryOptionListResponse reviewSummary,
+        @Schema(description = "리뷰 이미지 리스트")
+        List<String> images,
+        @Schema(description = "증상 리스트", example = "배가 아파요")
+        List<String> symptoms,
+        @Schema(description = "질병 이름", example = "심장병")
+        String disease,
+        @Schema(description = "동물 이름", example = "강아지")
+        String animal,
+        @Schema(description = "성별", example = "F")
+        Gender gender,
+        @Schema(description = "종 이름", example = "말티즈")
+        String breed,
+        @Schema(description = "몸무게", example = "2.7")
+        double weight
+) {
+    public static HospitalReviewResponse of(
+            final Long id, final Long memberId, final String nickname, final String memberBreed, final int age, final Long hospitalId, final String hospitalName, final String visitedAt, final String hospitalAddress,
+            final String content, final ReviewSummaryOptionListResponse reviewSummary,
+            final List<String> images, final List<String> symptoms, final String disease,
+            final String animal, final Gender gender, final String breed, final double weight
+    ) {
+        return new HospitalReviewResponse(id, memberId, nickname, memberBreed, age, hospitalId, hospitalName, visitedAt, hospitalAddress,
+                content, reviewSummary, images, symptoms,
+                disease, animal, gender, breed, weight);
+    }
+}

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -10,16 +10,21 @@ import com.cocos.cocos.db.breed.entity.Breed;
 import com.cocos.cocos.db.breed.repository.BreedRepository;
 import com.cocos.cocos.db.disease.entity.Disease;
 import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.db.district.entity.District;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.hospital.entity.Hospital;
 import com.cocos.cocos.db.hospital.repository.HospitalRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.db.pet.entity.Pet;
+import com.cocos.cocos.db.pet.repository.PetRepository;
 import com.cocos.cocos.db.review.db.*;
 import com.cocos.cocos.db.review.repository.*;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.external.MemberDataS3Client;
 import com.cocos.cocos.util.SortConstants;
@@ -50,6 +55,8 @@ public class ReviewService {
     private final DiseaseRepository diseaseRepository;
     private final SymptomRepository symptomRepository;
     private final MemberRepository memberRepository;
+    private final PetRepository petRepository;
+    private final DistrictRepository districtRepository;
 
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
@@ -152,7 +159,7 @@ public class ReviewService {
         // TODO: 팀 컨벤션 측면에서, Map방식과 filter 방식 중 적절한 방식 논의 필요
         final Map<Long, Hospital> hospitalMap = getHospitalMap(reviews);
         final Map<Long, List<String>> reviewIdToImageUrls = getReviewIdToImageUrls(reviewIds);
-        final Map<Long, Breed> breedMap = getBreedMap(reviews);
+        final Map<Long, Breed> breedMap = getBreedMapFromReviews(reviews);
         final Map<Long, Animal> animalMap = getAnimalMap(breedMap);
         final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
         final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
@@ -200,6 +207,131 @@ public class ReviewService {
         );
     }
 
+    public HospitalReviewListResponse getHospitalReviewList(final Long hospitalId, final Long summaryOptionId, final Long cursorId, final int size, final Long bodyId, final Long locationId, final LocationType locationType, final Long memberId) {
+        final int searchSize = memberId == null ? DEFAULT_PAGE_SIZE : size;
+        final Pageable pageable = PageRequest.of(0, searchSize, Sort.by(
+                SortConstants.ID_DESC
+        ));
+
+        final List<Review> reviews = getReviews(locationId, locationType, hospitalId, summaryOptionId, cursorId, bodyId, pageable);
+
+        final Map<Long, Hospital> hospitalMap = getHospitalMap(reviews);
+        final List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
+        final Set<Long> memberIds = reviews.stream().map(Review::getMemberId).collect(Collectors.toSet());
+
+        final Map<Long, List<String>> reviewIdToImageUrls = getReviewIdToImageUrls(reviewIds);
+        final Map<Long, Member> memberMap = getMemberMap(memberIds);
+        final Map<Long, Pet> petMap = getPetMap(memberIds);
+        final Map<Long, Breed> breedMap = getBreedMapFromReviewsAndPets(reviews, petMap);
+        final Map<Long, Animal> animalMap = getAnimalMap(breedMap);
+        final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
+        final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
+        final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
+
+        final Integer reviewCount = getReviewCountByHospitalId(hospitalId);
+
+        final List<HospitalReviewResponse> reviewResponses = reviews.stream()
+                .map(review -> {
+                    final Hospital hospital = hospitalMap.get(review.getHospitalId());
+                    final Breed breed = breedMap.get(review.getBreedId());
+                    final Member member = memberMap.get(review.getMemberId());
+                    final Pet pet = petMap.get(review.getMemberId());
+                    final Breed memberBreed = breedMap.get(pet.getBreedId());
+                    final Animal animal = animalMap.get(breed.getAnimalId());
+                    final Disease disease = diseaseMap.get(review.getDiseaseId());
+                    final List<String> imageUrls = reviewIdToImageUrls.getOrDefault(review.getId(), List.of());
+                    final List<String> symptoms = symptomMap.getOrDefault(review.getId(), List.of());
+
+                    final List<ReviewSummaryOption> summaryOptions = reviewSummaryOptionsMap.getOrDefault(review.getId(), List.of());
+
+                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, true);
+                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, false);
+                    final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
+                            goodReviewSummaries, badReviewSummaries
+                    );
+
+                    return HospitalReviewResponse.of(
+                            review.getId(),
+                            member.getId(),
+                            member.getNickname(),
+                            memberBreed.getName(),
+                            pet.getAge(),
+                            hospital.getId(),
+                            hospital.getName(),
+                            review.getVisitedAt(),
+                            hospital.getDisplayAddress(),
+                            review.getContent(),
+                            summaryOptionList,
+                            imageUrls,
+                            symptoms,
+                            disease.getName(),
+                            animal.getName(),
+                            review.getGender(),
+                            breed.getName(),
+                            review.getWeight()
+                    );
+                })
+                .toList();
+
+        return HospitalReviewListResponse.of(
+                reviewCount,
+                reviews.isEmpty() ? null : reviews.getLast().getId(),
+                reviewResponses
+        );
+    }
+
+    private List<Review> getReviews(final Long locationId, final LocationType locationType, final Long hospitalId, final Long summaryOptionId, final Long cursorId, final Long bodyId, final Pageable pageable) {
+
+        if (bodyId != null && locationId != null && locationType != null) {
+            final List<Long> symptomIds = symptomRepository.findAllByBodyId(bodyId).stream()
+                    .map(Symptom::getId)
+                    .toList();
+
+            final List<Long> districtIds = getDistrictIds(locationId, locationType);
+            final List<Long> hospitalIds = hospitalRepository.findAllByDistrictIdIn(districtIds).stream()
+                    .map(Hospital::getId)
+                    .toList();
+
+            final List<Long> reviewIds = reviewSymptomRepository.findBySymptomIdIn(symptomIds).stream()
+                    .map(ReviewSymptom::getReviewId)
+                    .toList();
+
+            return reviewRepository.findByBodyAndLocationAndSummaryOptionIdAndCursorId(reviewIds, hospitalIds, summaryOptionId, cursorId, pageable);
+        } else if (hospitalId != null) {
+            return reviewRepository.findByHospitalIdAndSummaryOptionIdAndCursorId(hospitalId, summaryOptionId, cursorId, pageable);
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_MISSING_BODY);
+        }
+    }
+
+    private Integer getReviewCountByHospitalId(final Long hospitalId) {
+        if (hospitalId == null) {
+            return null;
+        } else {
+            return hospitalRepository.findById(hospitalId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)).getReviewCount();        }
+    }
+
+
+    private Map<Long, Member> getMemberMap(final Set<Long> memberIds) {
+        final Map<Long, Member> membermap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        if (membermap.size() != memberIds.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_MEMBER);
+        }
+        return membermap;
+    }
+
+    private Map<Long, Pet> getPetMap(final Set<Long> memberIds) {
+        final Map<Long, Pet> petMap = petRepository.findAllByMemberIdIn(memberIds).stream()
+                .collect(Collectors.toMap(Pet::getMemberId, Function.identity()));
+
+        if (memberIds.size() != petMap.size()) {
+            throw new CocosException(FailMessage.NOT_FOUND_PET);
+        }
+        return petMap;
+    }
+
     private Map<Long, Disease> getDiseaseMap(final List<Review> reviews) {
         final Set<Long> diseaseIds = reviews.stream().map(Review::getDiseaseId).collect(Collectors.toSet());
         final Map<Long, Disease> diseaseMap = diseaseRepository.findAllById(diseaseIds).stream()
@@ -224,8 +356,30 @@ public class ReviewService {
         return animalMap;
     }
 
-    private Map<Long, Breed> getBreedMap(final List<Review> reviews) {
-        final Set<Long> breedIds = reviews.stream().map(Review::getBreedId).collect(Collectors.toSet());
+    private Map<Long, Breed> getBreedMapFromReviewsAndPets(final List<Review> reviews, final Map<Long, Pet> pets) {
+        final Set<Long> breedIdsFromReviews = reviews.stream()
+                .map(Review::getBreedId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> breedIdsFromPets = pets.values().stream()
+                .map(Pet::getBreedId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> allBreedIds = new HashSet<>();
+        allBreedIds.addAll(breedIdsFromReviews);
+        allBreedIds.addAll(breedIdsFromPets);
+
+        return fetchBreedMap(allBreedIds);
+    }
+
+    private Map<Long, Breed> getBreedMapFromReviews(final List<Review> reviews) {
+        final Set<Long> breedIds = reviews.stream()
+                .map(Review::getBreedId)
+                .collect(Collectors.toSet());
+        return fetchBreedMap(breedIds);
+    }
+
+    private Map<Long, Breed> fetchBreedMap(final Set<Long> breedIds) {
         final Map<Long, Breed> breedMap = breedRepository.findAllById(breedIds).stream()
                 .collect(Collectors.toMap(Breed::getId, Function.identity()));
 
@@ -375,5 +529,16 @@ public class ReviewService {
         reviewRepository.deleteById(reviewId);
 
         return ReviewImageDeleteListResponse.of(reviewImages);
+    }
+
+    // TODO: hospitalService와 중복. 공용으로 관리하도록 리팩 필요
+    private List<Long> getDistrictIds(final Long locationId, final LocationType locationType) {
+        if (locationType == LocationType.CITY) {
+            return districtRepository.findByCityId(locationId).stream().map(District::getId).toList();
+        }
+        if (locationType == LocationType.DISTRICT) {
+            return List.of(locationId);
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_LOCATION_TYPE);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -207,6 +207,7 @@ public class ReviewService {
         );
     }
 
+    @Transactional(readOnly = true)
     public HospitalReviewListResponse getHospitalReviewList(final Long hospitalId, final Long summaryOptionId, final Long cursorId, final int size, final Long bodyId, final Long locationId, final LocationType locationType, final Long memberId) {
         final int searchSize = memberId == null ? DEFAULT_PAGE_SIZE : size;
         final Pageable pageable = PageRequest.of(0, searchSize, Sort.by(

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -176,8 +176,8 @@ public class ReviewService {
 
                     final List<ReviewSummaryOption> summaryOptions = reviewSummaryOptionsMap.getOrDefault(review.getId(), List.of());
 
-                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, true);
-                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, false);
+                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, IS_GOOD_REVIEW);
+                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, !IS_GOOD_REVIEW);
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
                             goodReviewSummaries, badReviewSummaries
                     );
@@ -245,8 +245,8 @@ public class ReviewService {
 
                     final List<ReviewSummaryOption> summaryOptions = reviewSummaryOptionsMap.getOrDefault(review.getId(), List.of());
 
-                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, true);
-                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, false);
+                    final List<ReviewSummaryOptionResponse> goodReviewSummaries = getReviewSummaryOptionList(summaryOptions, IS_GOOD_REVIEW);
+                    final List<ReviewSummaryOptionResponse> badReviewSummaries = getReviewSummaryOptionList(summaryOptions, !IS_GOOD_REVIEW);
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
                             goodReviewSummaries, badReviewSummaries
                     );

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -534,7 +534,7 @@ public class ReviewService {
     // TODO: hospitalService와 중복. 공용으로 관리하도록 리팩 필요
     private List<Long> getDistrictIds(final Long locationId, final LocationType locationType) {
         if (locationType == LocationType.CITY) {
-            return districtRepository.findByCityId(locationId).stream().map(District::getId).toList();
+            return districtRepository.findAllByCityId(locationId).stream().map(District::getId).toList();
         }
         if (locationType == LocationType.DISTRICT) {
             return List.of(locationId);

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -29,11 +29,13 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/api/dev/test/**",
             "/api/dev/locations",
-            "/api/local/hospitals/**",
-            "/api/dev/hospitals/**",
+            "/api/local/hospitals/*",
+            "/api/dev/hospitals/*",
             "/api/local/members/login",
             "/api/local/hospitals/reviews/member",
-            "/api/dev/hospitals/reviews/member"
+            "/api/dev/hospitals/reviews/member",
+            "/api/local/hospitals/reviews/filter",
+            "/api/dev/hospitals/reviews/filter"
     };
 
     @Bean

--- a/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
+++ b/src/main/java/com/cocos/cocos/db/district/repository/DistrictRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Repository
 public interface DistrictRepository extends JpaRepository<District, Long> {
 
-    List<District> findByCityId(final Long cityId);
+    List<District> findAllByCityId(final Long cityId);
 
     District findByNameAndCityId(final String name, final Long cityId);
 }

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
@@ -28,4 +28,8 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     List<Hospital> findAllByDistrictIdInWithCursor(@Param("districtIds") final List<Long> districtIds, @Param("cursorId") final Long cursorId, @Param("reviewCount") final Integer reviewCount, final Pageable pageable);
 
     List<Hospital> findAllByDistrictIdIn(final List<Long> districtIds, final Pageable pageable);
+
+    List<Hospital> findAllByDistrictIdIn(final List<Long> districtIds);
+
+
 }

--- a/src/main/java/com/cocos/cocos/db/pet/repository/PetRepository.java
+++ b/src/main/java/com/cocos/cocos/db/pet/repository/PetRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface PetRepository extends JpaRepository<Pet, Long> {
@@ -13,6 +14,8 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     Pet findByMemberId(final Long memberId);
 
     List<Pet> findAllByMemberIdIn(@Param("memberIds") List<Long> memberIds);
+
+    List<Pet> findAllByMemberIdIn(Set<Long> memberIds);
 
     boolean existsByMemberId(final Long memberId);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.db.review.repository;
 import com.cocos.cocos.db.review.db.Review;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,4 +19,27 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByMemberIdAndIdLessThan(final Long memberId, final Long cursorId, final Pageable pageable);
 
     List<Review> findAllByMemberId(final Long memberId, final Pageable pageable);
+
+    @Query("""
+                SELECT r FROM Review r
+                JOIN ReviewSummary s ON r.id = s.reviewId
+                WHERE r.hospitalId = :hospitalId
+                AND (:summaryOptionId IS NULL OR s.reviewSummaryOptionId = :summaryOptionId)
+                AND (:cursorId IS NULL OR r.id < :cursorId)
+            """)
+    List<Review> findByHospitalIdAndSummaryOptionIdAndCursorId(
+            final Long hospitalId, final Long summaryOptionId, final Long cursorId, final Pageable pageable
+    );
+
+    @Query("""
+                SELECT r FROM Review r
+                JOIN ReviewSummary s ON r.id = s.reviewId
+                WHERE (:reviewIds IS NULL OR r.id IN :reviewIds)
+                AND (:summaryOptionId IS NULL OR s.reviewSummaryOptionId = :summaryOptionId)
+                AND (:cursorId IS NULL OR r.id < :cursorId)
+                AND (r.hospitalId IN :hospitalIds)
+            """)
+    List<Review> findByBodyAndLocationAndSummaryOptionIdAndCursorId(
+            final List<Long> reviewIds, final List<Long> hospitalIds, final Long summaryOptionId, final Long cursorId, final Pageable pageable
+    );
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSymptomRepository.java
@@ -14,4 +14,6 @@ public interface ReviewSymptomRepository extends JpaRepository<ReviewSymptom, Lo
     void deleteAllByReviewIdIn(final List<Long> reviewIds);
 
     List<ReviewSymptom> findByReviewIdIn(final List<Long> reviewIds);
+
+    List<ReviewSymptom> findBySymptomIdIn(final List<Long> symptomIds);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -22,8 +22,9 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_HOSPITAL_ID(HttpStatus.BAD_REQUEST, 40008, "유효하지 않은 병원 아이디입니다."),
     BAD_REQUEST_INVALID_BREED_ID(HttpStatus.BAD_REQUEST, 40009, "유효하지 않은 품종 아이디입니다."),
     BAD_REQUEST_INVALID_DISEASE_ID(HttpStatus.BAD_REQUEST, 40010, "유효하지 않은 질병 아이디입니다."),
-    BAD_REQUEST_INVALID_REVIEW_ID(HttpStatus.BAD_REQUEST, 40011, "유효하지 않은 리뷰 아이디입니다."),
-    BAD_REQUEST_INVALID_MEMBER_QUERY(HttpStatus.BAD_REQUEST, 40012, "회원 식별자 (id 또는 nickname)를 제공해야 합니다."),
+    BAD_REQUEST_INVALID_MEMBER_QUERY(HttpStatus.BAD_REQUEST, 40011, "회원 식별자 (id 또는 nickname)를 제공해야 합니다."),
+    BAD_REQUEST_MISSING_BODY(HttpStatus.BAD_REQUEST, 40012, "필수 body가 누락되었습니다."),
+    BAD_REQUEST_INVALID_REVIEW_ID(HttpStatus.BAD_REQUEST, 40013, "유효하지 않은 리뷰 아이디입니다."),
     /**
      * 401
      */

--- a/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
+++ b/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
@@ -60,7 +60,7 @@ public class LocationServiceTest {
         final List<District> districts = new ArrayList<>(List.of(district1, district2));
 
         BDDMockito.given(cityRepository.findAll()).willReturn(cities);
-        BDDMockito.given(districtRepository.findByCityId(any())).willReturn(districts);
+        BDDMockito.given(districtRepository.findAllByCityId(any())).willReturn(districts);
 
         final DistrictResponse districtResponse1 = DistrictResponse.of(district1.getId(), district1.getName());
         final DistrictResponse districtResponse2 = DistrictResponse.of(district2.getId(), district2.getName());


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #197 
- 
## 👷 **작업한 내용**
- 리뷰 리스트 조회 API를 구현했습니다. 
- 메인화면에서 사용할 때 -> bodyId, locationId, locationType 필수 (리뷰 요약 필터 옵셔널)
- 병원상세페이지에서 사용할 때 -> hospitalId 필수 (리뷰 요약 필터 옵셔널)
- 페이지네이션을 적용했습니다. (cursorId ==> reviewId 기준)

## 🚨 **참고 사항**
- validator 부분은 한번에 추가하면 좋을 것 같아서 todo로 남겨두었습니다!
- 예외처리 시에  bodyId, locationId, locationType 와 hospitalId 기준으로 응답을 나눕니다. 현재 예외처리에는 한계가 있어서, bodyId, locationId, locationType 와 hospitalId  모두 request에 존재할 경우 hospitalId가 무시됩니다. (현재 비즈니스 로직 상 올 수 없는 요청)
- endpoint를 기존 GET 'hospitals/reviews' 에서 POST 'hospital/reviews/filter'로 변경하였습니다. 메서드를 변경한 것은, query로 받는 필드가 많아져 이를 body로 변경함에 따른 것입니다. URL endpoint를 변경한 것은 post 필터링 API(posts/filter)와 일관성을 유지하기 위함입니다! 
