### PR TITLE
Fix: locationType, locationId 없이도 오류 없이 hospital list 조회할 수 있도록 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -86,6 +86,7 @@ public class HospitalService {
     }
 
     private List<Hospital> getHospitalsBySortAndCursor(int size, List<Long> districtIds, Long cursorId, Integer cursorReviewCount, HospitalSortCriteria hospitalSortCriteria) {
+        // TODO: 유효한 정렬 기준 확인하는 로직으로 따로 분리 (정렬 기준 늘어날 경우)
         Pageable pageable = PageRequest.of(0, size, Sort.by(
                 Sort.Order.desc(hospitalSortCriteria.getFieldName()),
                 SortConstants.ID_DESC

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -87,14 +87,15 @@ public class HospitalService {
 
     private List<Hospital> getHospitalsBySortAndCursor(int size, List<Long> districtIds, Long cursorId, Integer cursorReviewCount, HospitalSortCriteria hospitalSortCriteria) {
         // TODO: 유효한 정렬 기준 확인하는 로직으로 따로 분리 (정렬 기준 늘어날 경우)
+        if (hospitalSortCriteria != HospitalSortCriteria.REVIEW) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SORT_CRITERIA);
+        }
+
         Pageable pageable = PageRequest.of(0, size, Sort.by(
                 Sort.Order.desc(hospitalSortCriteria.getFieldName()),
                 SortConstants.ID_DESC
         ));
 
-        if (hospitalSortCriteria != HospitalSortCriteria.REVIEW) {
-            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SORT_CRITERIA);
-        }
 
         if (cursorId == null) {
             if (districtIds.isEmpty()) {

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -65,31 +65,68 @@ public class HospitalService {
     }
 
     private List<Long> getDistrictIds(final Long locationId, final LocationType locationType) {
-        if (locationType == LocationType.CITY) {
-            return districtRepository.findByCityId(locationId).stream().map(District::getId).toList();
+        if (locationType == null) {
+            return List.of();
         }
-        return List.of(locationId);
+
+        return switch (locationType) {
+            case LocationType.CITY ->
+                    districtRepository.findByCityId(locationId).stream().map(District::getId).toList();
+            case LocationType.DISTRICT -> List.of(locationId);
+            default -> List.of();
+        };
     }
 
     private List<Hospital> getHospitalsByKeywordAndCursor(final int size, final List<Long> districtIds, final String keyword, final Long cursorId, final Integer cursorReviewCount, final HospitalSortCriteria hospitalSortCriteria) {
         if (keyword != null && !keyword.isBlank()) {
-            Pageable pageable = PageRequest.of(0, size, Sort.by(
-                    SortConstants.ID_DESC
-            ));
-            return (cursorId != null) ? hospitalRepository.findAllByNameContainingAndDistrictIdInAndIdLessThan(keyword, districtIds, cursorId, pageable) : hospitalRepository.findAllByNameContainingAndDistrictIdIn(keyword, districtIds, pageable);
+            return getHospitalsByKeyword(size, districtIds, keyword, cursorId);
         } else {
-            Pageable pageable = PageRequest.of(0, size, Sort.by(
-                    Sort.Order.desc(hospitalSortCriteria.getFieldName()),
-                    SortConstants.ID_DESC
-            ));
-            if (hospitalSortCriteria == HospitalSortCriteria.REVIEW) {
-                if (cursorId == null) {
-                    return hospitalRepository.findAllByDistrictIdIn(districtIds, pageable);
-                } else {
-                    return hospitalRepository.findAllByDistrictIdInWithCursor(districtIds, cursorId, cursorReviewCount, pageable);
-                }
-            }
+            return getHospitalsBySortAndCursor(size, districtIds, cursorId, cursorReviewCount, hospitalSortCriteria);
+        }
+    }
+
+    private List<Hospital> getHospitalsBySortAndCursor(int size, List<Long> districtIds, Long cursorId, Integer cursorReviewCount, HospitalSortCriteria hospitalSortCriteria) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(
+                Sort.Order.desc(hospitalSortCriteria.getFieldName()),
+                SortConstants.ID_DESC
+        ));
+
+        if (hospitalSortCriteria != HospitalSortCriteria.REVIEW) {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SORT_CRITERIA);
+        }
+
+        if (cursorId == null) {
+            if (districtIds.isEmpty()) {
+                return hospitalRepository.findAll(pageable).getContent();
+            } else {
+                return hospitalRepository.findAllByDistrictIdIn(districtIds, pageable);
+            }
+        } else {
+            if (districtIds.isEmpty()) {
+                return hospitalRepository.findAllWithCursor(cursorId, cursorReviewCount, pageable);
+            } else {
+                return hospitalRepository.findAllByDistrictIdInWithCursor(districtIds, cursorId, cursorReviewCount, pageable);
+            }
+        }
+
+    }
+
+    private List<Hospital> getHospitalsByKeyword(int size, List<Long> districtIds, String keyword, Long cursorId) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(
+                SortConstants.ID_DESC
+        ));
+        if (cursorId == null) {
+            if (districtIds.isEmpty()) {
+                return hospitalRepository.findAllByNameContaining(keyword, pageable);
+            } else {
+                return hospitalRepository.findAllByNameContainingAndDistrictIdIn(keyword, districtIds, pageable);
+            }
+        } else {
+            if (districtIds.isEmpty()) {
+                return hospitalRepository.findAllByNameContainingAndIdLessThan(keyword, cursorId, pageable);
+            } else {
+                return hospitalRepository.findAllByNameContainingAndDistrictIdInAndIdLessThan(keyword, districtIds, cursorId, pageable);
+            }
         }
     }
 

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -85,7 +85,7 @@ public class HospitalService {
         }
     }
 
-    private List<Hospital> getHospitalsBySortAndCursor(int size, List<Long> districtIds, Long cursorId, Integer cursorReviewCount, HospitalSortCriteria hospitalSortCriteria) {
+    private List<Hospital> getHospitalsBySortAndCursor(final int size, final List<Long> districtIds, final Long cursorId, final Integer cursorReviewCount, final HospitalSortCriteria hospitalSortCriteria) {
         // TODO: 유효한 정렬 기준 확인하는 로직으로 따로 분리 (정렬 기준 늘어날 경우)
         if (hospitalSortCriteria != HospitalSortCriteria.REVIEW) {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SORT_CRITERIA);
@@ -113,7 +113,7 @@ public class HospitalService {
 
     }
 
-    private List<Hospital> getHospitalsByKeyword(int size, List<Long> districtIds, String keyword, Long cursorId) {
+    private List<Hospital> getHospitalsByKeyword(final int size, final List<Long> districtIds, final String keyword, final Long cursorId) {
         Pageable pageable = PageRequest.of(0, size, Sort.by(
                 SortConstants.ID_DESC
         ));

--- a/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/repository/HospitalRepository.java
@@ -14,7 +14,11 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
 
     List<Hospital> findAllByNameContainingAndDistrictIdInAndIdLessThan(final String name, final List<Long> districtIds, final Long id, final Pageable pageable);
 
+    List<Hospital> findAllByNameContainingAndIdLessThan(final String name, final Long cursorId, final Pageable pageable);
+
     List<Hospital> findAllByNameContainingAndDistrictIdIn(final String name, final List<Long> districtIds, final Pageable pageable);
+
+    List<Hospital> findAllByNameContaining(final String name, final Pageable pageable);
 
     //TODO: 추후 queryDSL 도입 고민 필요
     @Query("""
@@ -26,6 +30,15 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
               )
             """)
     List<Hospital> findAllByDistrictIdInWithCursor(@Param("districtIds") final List<Long> districtIds, @Param("cursorId") final Long cursorId, @Param("reviewCount") final Integer reviewCount, final Pageable pageable);
+
+    @Query("""
+            SELECT h FROM Hospital h
+            WHERE (
+                h.reviewCount < :reviewCount
+                OR (h.reviewCount = :reviewCount AND h.id < :cursorId)
+              )
+            """)
+    List<Hospital> findAllWithCursor(final Long cursorId, final Integer reviewCount, final Pageable pageable);
 
     List<Hospital> findAllByDistrictIdIn(final List<Long> districtIds, final Pageable pageable);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #198 

## 👷 **작업한 내용**
- 현재 병원 조회할 때 locationId와 locationType이 없으면 오류가 발생합니다.
- 리뷰 추가 시 병원 검색할 때는 해당 필드가 넘어오지 않아서, 해당 필드가 없을 때도 결과값을 return해야 합니다.
- locationId, locationType이 request body에 없을 때에도 요청을 처리할 수 있도록 예외처리를 추가했습니다.

## 🚨 **참고 사항**
