### PR TITLE
Fix: 카카오 로그인 시 토큰 및 사용자 정보 조회 시 Null 값 확인 후 예외처리

### DIFF
--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -96,6 +96,8 @@ public enum FailMessage {
     INTERNAL_SERVER_ERROR_PET_AGE(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "서버에 유효하지 않은 petAge가 존재합니다. "),
     INTERNAL_SERVER_ERROR_UNSUPPORTED_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, 50004, "유틸 클래스입니다. "),
     INTERNAL_SERVER_ERROR_KAKAO_UNLINK(HttpStatus.INTERNAL_SERVER_ERROR, 50005, "카카오 회원탈퇴에 실패했습니다."),
+    INTERNAL_SERVER_ERROR_KAKAO_ACCESS_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, 50006, "카카오 어세스 토큰 발급에 실패했습니다."),
+    INTERNAL_SERVER_ERROR_KAKAO_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, 50007, "카카오 사용자 정보 조회에 실패했습니다."),
 
     /**
      * 503

--- a/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
+++ b/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
@@ -63,7 +63,7 @@ public class KakaoLoginClient {
         return kakaoInfoResponse.id();
     }
 
-    final public void unlink(final Long id) {
+    public void unlink(final Long id) {
         final RestClient restClient = RestClient.create();
         final URI uri = UriComponentsBuilder
                 .fromUriString("https://kapi.kakao.com/v1/user/unlink")

--- a/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
+++ b/src/main/java/com/cocos/cocos/external/KakaoLoginClient.java
@@ -5,7 +5,6 @@ import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.login.dto.KakaoAccessTokenResponse;
 import com.cocos.cocos.external.login.dto.KakaoInfoResponse;
 import com.cocos.cocos.external.login.dto.KakaoUnlinkResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -14,10 +13,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
-@Slf4j
 @Component
 public class KakaoLoginClient {
-    //ToDo: log제거 및 final 키워드 및 설명 주석 추가 및 final 키워드 추가 필요
 
     @Value("${kakao.client-id}")
     private String kakaoClientId;
@@ -30,8 +27,8 @@ public class KakaoLoginClient {
 
     public String login(final String code) {
 
-        RestClient restClient = RestClient.create();
-        URI uri = UriComponentsBuilder
+        final RestClient restClient = RestClient.create();
+        final URI uri = UriComponentsBuilder
                 .fromUriString("https://kauth.kakao.com/oauth/token")
                 .queryParam("code", "{code}")
                 .queryParam("client_id", "{client_id}")
@@ -41,16 +38,17 @@ public class KakaoLoginClient {
                 .buildAndExpand(code, kakaoClientId, kakaoRedirectUrl, "authorization_code")
                 .toUri();
 
-        KakaoAccessTokenResponse kakaoAccessTokenResponse = restClient.post()
+        final KakaoAccessTokenResponse kakaoAccessTokenResponse = restClient.post()
                 .uri(uri)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
                 .body(KakaoAccessTokenResponse.class);
 
+        if (kakaoAccessTokenResponse == null || kakaoAccessTokenResponse.accessToken() == null) {
+            throw new CocosException(FailMessage.INTERNAL_SERVER_ERROR_KAKAO_ACCESS_TOKEN);
+        }
 
-        log.info(kakaoAccessTokenResponse.accessToken());
-
-        KakaoInfoResponse kakaoInfoResponse = restClient.get()
+        final KakaoInfoResponse kakaoInfoResponse = restClient.get()
                 //ToDo: uri같은 거 yml에 적용 필요
                 .uri("https://kapi.kakao.com/v2/user/me")
                 .header("Authorization", "Bearer " + kakaoAccessTokenResponse.accessToken())
@@ -58,12 +56,16 @@ public class KakaoLoginClient {
                 .retrieve()
                 .body(KakaoInfoResponse.class);
 
+        if (kakaoInfoResponse == null) {
+            throw new CocosException(FailMessage.INTERNAL_SERVER_ERROR_KAKAO_USER_INFO);
+        }
+
         return kakaoInfoResponse.id();
     }
 
-    public void unlink(final Long id) {
-        RestClient restClient = RestClient.create();
-        URI uri = UriComponentsBuilder
+    final public void unlink(final Long id) {
+        final RestClient restClient = RestClient.create();
+        final URI uri = UriComponentsBuilder
                 .fromUriString("https://kapi.kakao.com/v1/user/unlink")
                 .queryParam("target_id_type", "{targetIdType}")
                 .queryParam("target_id", "{targetId}")
@@ -71,14 +73,14 @@ public class KakaoLoginClient {
                 .buildAndExpand("user_id", id)
                 .toUri();
 
-        KakaoUnlinkResponse kakaoUnlinkResponse = restClient.post()
+        final KakaoUnlinkResponse kakaoUnlinkResponse = restClient.post()
                 .uri(uri)
                 .header("Authorization", ADMIN_KEY_TYPE + kakaoAdminKey)
                 .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
                 .retrieve()
                 .body(KakaoUnlinkResponse.class);
 
-        if (kakaoUnlinkResponse.id() == null) {
+        if (kakaoUnlinkResponse == null) {
             throw new CocosException(FailMessage.INTERNAL_SERVER_ERROR_KAKAO_UNLINK);
         }
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #141 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 카카오 로그인 및 회원탈퇴 시 null 여부를 체크하였습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
