### PR TITLE
Fix: 리뷰 리스트 반환 응답에 방문 목적 필드 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/HospitalReviewResponse.java
@@ -42,16 +42,18 @@ public record HospitalReviewResponse(
         @Schema(description = "종 이름", example = "말티즈")
         String breed,
         @Schema(description = "몸무게", example = "2.7")
-        double weight
+        double weight,
+        @Schema(description = "방문 목적", example = "수술")
+        String visitPurpose
 ) {
     public static HospitalReviewResponse of(
             final Long id, final Long memberId, final String nickname, final String memberBreed, final int age, final Long hospitalId, final String hospitalName, final String visitedAt, final String hospitalAddress,
             final String content, final ReviewSummaryOptionListResponse reviewSummary,
             final List<String> images, final List<String> symptoms, final String disease,
-            final String animal, final Gender gender, final String breed, final double weight
+            final String animal, final Gender gender, final String breed, final double weight, final String visitPurpose
     ) {
         return new HospitalReviewResponse(id, memberId, nickname, memberBreed, age, hospitalId, hospitalName, visitedAt, hospitalAddress,
                 content, reviewSummary, images, symptoms,
-                disease, animal, gender, breed, weight);
+                disease, animal, gender, breed, weight, visitPurpose);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewResponse.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/response/MemberHospitalReviewResponse.java
@@ -34,16 +34,18 @@ public record MemberHospitalReviewResponse(
         @Schema(description = "종 이름", example = "말티즈")
         String breed,
         @Schema(description = "몸무게", example = "2.7")
-        double weight
+        double weight,
+        @Schema(description = "방문 목적", example = "수술")
+        String visitPurpose
 ) {
     public static MemberHospitalReviewResponse of(
             final Long id, final Long hospitalId, final String hospitalName, final String visitedAt, final String hospitalAddress,
             final String content, final ReviewSummaryOptionListResponse reviewSummary,
             final List<String> images, final List<String> symptoms, final String disease,
-            final String animal, final Gender gender, final String breed, final double weight
+            final String animal, final Gender gender, final String breed, final double weight, final String visitPurpose
     ) {
         return new MemberHospitalReviewResponse(id, hospitalId, hospitalName, visitedAt, hospitalAddress,
                 content, reviewSummary, images, symptoms,
-                disease, animal, gender, breed, weight);
+                disease, animal, gender, breed, weight, visitPurpose);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -167,8 +167,7 @@ public class ReviewService {
         final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
         final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
         final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
-        final Map<Long, VisitPurpose> visitPurposeMap = hospitalVisitPurposeRepository.findAll().stream()
-                .collect(Collectors.toMap(VisitPurpose::getId, Function.identity()));
+        final Map<Long, VisitPurpose> visitPurposeMap = getVisitPurposeMap();
 
         final List<MemberHospitalReviewResponse> reviewResponses = reviews.stream()
                 .map(review -> {
@@ -235,8 +234,7 @@ public class ReviewService {
         final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
         final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
         final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
-        final Map<Long, VisitPurpose> visitPurposeMap = hospitalVisitPurposeRepository.findAll().stream()
-                .collect(Collectors.toMap(VisitPurpose::getId, Function.identity()));
+        final Map<Long, VisitPurpose> visitPurposeMap = getVisitPurposeMap();
 
         final Integer reviewCount = getReviewCountByHospitalId(hospitalId);
 
@@ -290,6 +288,11 @@ public class ReviewService {
                 reviews.isEmpty() ? null : reviews.getLast().getId(),
                 reviewResponses
         );
+    }
+
+    private Map<Long, VisitPurpose> getVisitPurposeMap() {
+        return hospitalVisitPurposeRepository.findAll().stream()
+                .collect(Collectors.toMap(VisitPurpose::getId, Function.identity()));
     }
 
     private List<Review> getReviews(final Long locationId, final LocationType locationType, final Long hospitalId, final Long summaryOptionId, final Long cursorId, final Long bodyId, final Pageable pageable) {

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -13,7 +13,9 @@ import com.cocos.cocos.db.disease.repository.DiseaseRepository;
 import com.cocos.cocos.db.district.entity.District;
 import com.cocos.cocos.db.district.repository.DistrictRepository;
 import com.cocos.cocos.db.hospital.entity.Hospital;
+import com.cocos.cocos.db.hospital.entity.VisitPurpose;
 import com.cocos.cocos.db.hospital.repository.HospitalRepository;
+import com.cocos.cocos.db.hospital.repository.HospitalVisitPurposeRepository;
 import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.db.member.repository.MemberRepository;
@@ -57,6 +59,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
     private final DistrictRepository districtRepository;
+    private final HospitalVisitPurposeRepository hospitalVisitPurposeRepository;
 
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
@@ -164,6 +167,8 @@ public class ReviewService {
         final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
         final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
         final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
+        final Map<Long, VisitPurpose> visitPurposeMap = hospitalVisitPurposeRepository.findAll().stream()
+                .collect(Collectors.toMap(VisitPurpose::getId, Function.identity()));
 
         final List<MemberHospitalReviewResponse> reviewResponses = reviews.stream()
                 .map(review -> {
@@ -181,6 +186,7 @@ public class ReviewService {
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
                             goodReviewSummaries, badReviewSummaries
                     );
+                    final String visitPurpose = visitPurposeMap.get(review.getPurposeId()).getName();
 
                     return MemberHospitalReviewResponse.of(
                             review.getId(),
@@ -196,7 +202,8 @@ public class ReviewService {
                             animal.getName(),
                             review.getGender(),
                             breed.getName(),
-                            review.getWeight()
+                            review.getWeight(),
+                            visitPurpose
                     );
                 })
                 .toList();
@@ -228,6 +235,8 @@ public class ReviewService {
         final Map<Long, Disease> diseaseMap = getDiseaseMap(reviews);
         final Map<Long, List<String>> symptomMap = getReviewIdToSymptoms(reviewIds);
         final Map<Long, List<ReviewSummaryOption>> reviewSummaryOptionsMap = getReviewSummaryOptionsMap(reviewIds);
+        final Map<Long, VisitPurpose> visitPurposeMap = hospitalVisitPurposeRepository.findAll().stream()
+                .collect(Collectors.toMap(VisitPurpose::getId, Function.identity()));
 
         final Integer reviewCount = getReviewCountByHospitalId(hospitalId);
 
@@ -250,6 +259,7 @@ public class ReviewService {
                     final ReviewSummaryOptionListResponse summaryOptionList = ReviewSummaryOptionListResponse.of(
                             goodReviewSummaries, badReviewSummaries
                     );
+                    final String visitPurpose = visitPurposeMap.get(review.getPurposeId()).getName();
 
                     return HospitalReviewResponse.of(
                             review.getId(),
@@ -269,7 +279,8 @@ public class ReviewService {
                             animal.getName(),
                             review.getGender(),
                             breed.getName(),
-                            review.getWeight()
+                            review.getWeight(),
+                            visitPurpose
                     );
                 })
                 .toList();
@@ -309,7 +320,8 @@ public class ReviewService {
         if (hospitalId == null) {
             return null;
         } else {
-            return hospitalRepository.findById(hospitalId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)).getReviewCount();        }
+            return hospitalRepository.findById(hospitalId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL)).getReviewCount();
+        }
     }
 
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #201 

## 👷 **작업한 내용**
- 사용자 리뷰 리스트 반환과 병원 리뷰 리스트 반환 응답에 방문 목적 (visitPurpose)필드를 추가했습니다.

## 🚨 **참고 사항**
- 필드명 (visitPurpose) 의미적으로 헷갈리지 않을지 의견 주시면 감사하겠습니다
