### PR TITLE
Fix: 유효성 검사 로직 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -58,7 +58,6 @@ public class CommentController implements CommentControllerSwagger {
     public ResponseEntity<BaseResponse<Void>> deletePostSubComment(
             @PathVariable(name = "subCommentId") @SubCommentIdConstraint final Long subCommentId
     ) {
-        entityExistsValidator.validateSubCommentBySubCommentId(subCommentId);
         commentService.deletePostSubComment(subCommentId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -10,6 +10,7 @@ import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
 import com.cocos.cocos.util.validation.EntityExistsValidator;
+import com.cocos.cocos.validation.comment.CommentIdConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,19 +36,17 @@ public class CommentController implements CommentControllerSwagger {
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<BaseResponse<Void>> deletePostComment(
-            @PathVariable(name = "commentId") final Long commentId
+            @PathVariable(name = "commentId") @CommentIdConstraint final Long commentId
     ) {
-        entityExistsValidator.validateCommentByCommentId(commentId);
         commentService.deletePostComment(commentId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }
 
     @PostMapping("/sub/{commentId}")
     public ResponseEntity<BaseResponse<Void>> addPostSubComment(
-            @PathVariable(name = "commentId") final Long commentId,
+            @PathVariable(name = "commentId") @CommentIdConstraint final Long commentId,
             @RequestBody final SubCommentContentRequest subCommentContentRequest
     ) {
-        entityExistsValidator.validateCommentByCommentId(commentId);
         entityExistsValidator.validateMemberByNickname(subCommentContentRequest.nickname());
         entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         commentService.addPostSubComment(commentId, subCommentContentRequest.nickname(), subCommentContentRequest.content(), PrincipalHandler.getMemberIdFromPrincipal());
@@ -65,7 +64,7 @@ public class CommentController implements CommentControllerSwagger {
 
     @GetMapping("/{postId}")
     public ResponseEntity<BaseResponse<CommentsAndSubCommentsResponse>> getPostComments(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId
     ) {
         return SuccessResponse.success(SuccessMessage.OK, commentService.getPostComments(postId, PrincipalHandler.getMemberIdFromPrincipal()));
     }

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
 import com.cocos.cocos.util.validation.EntityExistsValidator;
 import com.cocos.cocos.validation.comment.CommentIdConstraint;
+import com.cocos.cocos.validation.comment.SubCommentIdConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -55,7 +56,7 @@ public class CommentController implements CommentControllerSwagger {
 
     @DeleteMapping("/sub/{subCommentId}")
     public ResponseEntity<BaseResponse<Void>> deletePostSubComment(
-            @PathVariable(name = "subCommentId") final Long subCommentId
+            @PathVariable(name = "subCommentId") @SubCommentIdConstraint final Long subCommentId
     ) {
         entityExistsValidator.validateSubCommentBySubCommentId(subCommentId);
         commentService.deletePostSubComment(subCommentId, PrincipalHandler.getMemberIdFromPrincipal());

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -10,6 +10,7 @@ import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
 import com.cocos.cocos.util.validation.EntityExistsValidator;
+import com.cocos.cocos.validation.post.PostIdConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,10 +25,9 @@ public class CommentController implements CommentControllerSwagger {
 
     @PostMapping("/{postId}")
     public ResponseEntity<BaseResponse<Void>> addPostComment(
-            @PathVariable(name = "postId") final Long postId,
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId,
             @RequestBody final CommentContentRequest commentContentRequest
     ) {
-        entityExistsValidator.validatePostByPostId(postId);
         entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         commentService.addPostComment(postId, commentContentRequest.content(), PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, null);

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentController.java
@@ -13,6 +13,7 @@ import com.cocos.cocos.util.validation.EntityExistsValidator;
 import com.cocos.cocos.validation.comment.CommentIdConstraint;
 import com.cocos.cocos.validation.comment.SubCommentIdConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -46,9 +47,8 @@ public class CommentController implements CommentControllerSwagger {
     @PostMapping("/sub/{commentId}")
     public ResponseEntity<BaseResponse<Void>> addPostSubComment(
             @PathVariable(name = "commentId") @CommentIdConstraint final Long commentId,
-            @RequestBody final SubCommentContentRequest subCommentContentRequest
+            @RequestBody @Valid final SubCommentContentRequest subCommentContentRequest
     ) {
-        entityExistsValidator.validateMemberByNickname(subCommentContentRequest.nickname());
         entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         commentService.addPostSubComment(commentId, subCommentContentRequest.nickname(), subCommentContentRequest.content(), PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, null);

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.comment.dto.request.SubCommentContentRequest;
 import com.cocos.cocos.api.comment.dto.response.CommentsAndSubCommentsResponse;
 import com.cocos.cocos.api.comment.dto.response.MyAllCommentsResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.post.PostIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -23,7 +24,7 @@ public interface CommentControllerSwagger {
             responseCode = "201",
             description = "요청에 성공했습니다.")
     public ResponseEntity<BaseResponse<Void>> addPostComment(
-            @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) final Long postId,
+            @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @PostIdConstraint final Long postId,
             @RequestBody final CommentContentRequest content
     );
 

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.comment.dto.request.SubCommentContentRequest;
 import com.cocos.cocos.api.comment.dto.response.CommentsAndSubCommentsResponse;
 import com.cocos.cocos.api.comment.dto.response.MyAllCommentsResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.comment.CommentIdConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,7 +35,7 @@ public interface CommentControllerSwagger {
             description = "요청이 성공했습니다. ")
     @Parameter(name = "commentId", description = "댓글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<Void>> deletePostComment(
-            final Long commentId
+            @CommentIdConstraint final Long commentId
     );
 
     @Operation(summary = "게시글 대댓글 추가 API", description = "게시글에 대댓글을 추가하는 API 입니다.")
@@ -42,7 +43,7 @@ public interface CommentControllerSwagger {
             responseCode = "201",
             description = "요청에 성공했습니다.")
     public ResponseEntity<BaseResponse<Void>> addPostSubComment(
-            @Parameter(name = "commentId", description = "댓글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) final Long commentId,
+            @Parameter(name = "commentId", description = "댓글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @CommentIdConstraint final Long commentId,
             @RequestBody final SubCommentContentRequest content
     );
 
@@ -60,7 +61,7 @@ public interface CommentControllerSwagger {
             responseCode = "200",
             description = "요청에 성공했습니다.")
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
-    public ResponseEntity<BaseResponse<CommentsAndSubCommentsResponse>> getPostComments(final Long postId);
+    public ResponseEntity<BaseResponse<CommentsAndSubCommentsResponse>> getPostComments(@PostIdConstraint final Long postId);
 
     @Operation(summary = "사용자 댓글 & 대댓글 조회 API", description = "사용자의 댓글과 대댓글을 조회하는 API입니다. ")
     @ApiResponse(

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,7 +46,7 @@ public interface CommentControllerSwagger {
             description = "요청에 성공했습니다.")
     public ResponseEntity<BaseResponse<Void>> addPostSubComment(
             @Parameter(name = "commentId", description = "댓글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @CommentIdConstraint final Long commentId,
-            @RequestBody final SubCommentContentRequest content
+            @RequestBody @Valid final SubCommentContentRequest content
     );
 
     @Operation(summary = "게시글 대댓글 삭제 API", description = "게시글의 대댓글을 삭제하는 API 입니다.")

--- a/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/comment/controller/CommentControllerSwagger.java
@@ -6,6 +6,7 @@ import com.cocos.cocos.api.comment.dto.response.CommentsAndSubCommentsResponse;
 import com.cocos.cocos.api.comment.dto.response.MyAllCommentsResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.validation.comment.CommentIdConstraint;
+import com.cocos.cocos.validation.comment.SubCommentIdConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -53,7 +54,7 @@ public interface CommentControllerSwagger {
             description = "요청이 성공했습니다. ")
     @Parameter(name = "subCommentId", description = "대댓글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<Void>> deletePostSubComment(
-            final Long subCommentId
+            @SubCommentIdConstraint final Long subCommentId
     );
 
     @Operation(summary = "게시글 댓글&대댓글 조회 API", description = "게시글에 달린 댓글과 대댓글을 조회하는 API입니다. ")

--- a/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/request/SubCommentContentRequest.java
@@ -1,9 +1,11 @@
 package com.cocos.cocos.api.comment.dto.request;
 
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SubCommentContentRequest(
         @Schema(description = "언급된 멤버의 닉네임 정보입니다. ", example = "nickname")
+        @MemberNicknameConstraint
         String nickname,
         @Schema(description = "댓글 내용", example = "댓글의 내용입니다. ")
         String content

--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.disease.service.DiseaseService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.validation.body.BodyIdsConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,7 @@ public class DiseaseController implements DiseaseControllerSwagger{
 
     @GetMapping
     public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(
-            @RequestParam(name = "bodyIds") final List<Long> bodyIds
+            @RequestParam(name = "bodyIds") @BodyIdsConstraint final List<Long> bodyIds
     ) {
         return SuccessResponse.success(SuccessMessage.OK, diseaseService.getDiseases(bodyIds));
     }

--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
@@ -2,6 +2,7 @@ package com.cocos.cocos.api.disease.controller;
 
 import com.cocos.cocos.api.disease.dto.response.DiseasesOfBodiesResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.body.BodyIdsConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -20,5 +21,5 @@ public interface DiseaseControllerSwagger {
             responseCode = "200",
             description = "질병 리스트 조회 성공")
     @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
-    public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(final List<Long> bodyIds);
+    public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(@BodyIdsConstraint final List<Long> bodyIds);
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
@@ -2,6 +2,7 @@ package com.cocos.cocos.api.hospital.dto.request;
 
 import com.cocos.cocos.enums.hospital.HospitalSortCriteria;
 import com.cocos.cocos.enums.location.LocationType;
+import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -18,6 +19,7 @@ public record HospitalListRequest(
         Long locationId,
 
         @Schema(description = "마지막으로 조회된 병원 아이디 (첫 요청을 제외하고 필수로 보내야 합니다.)", nullable = true, example = "1")
+        @HospitalIdConstraint
         Long cursorId,
 
         @Schema(description = "마지막으로 조회된 병원 리뷰수 (정렬 기준이 REVIEW일 때는 첫 요청을 제외하고 필수로 보내야 합니다.)", nullable = true, example = "1")

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
@@ -16,7 +16,7 @@ public record HospitalListRequest(
         LocationType locationType,
 
         @Schema(description = "지역 아이디", nullable = true, example = "1")
-        Long locationId,
+        Long locationId, // TODO: 유효성 검증 로직 추가
 
         @Schema(description = "마지막으로 조회된 병원 아이디 (첫 요청을 제외하고 필수로 보내야 합니다.)", nullable = true, example = "1")
         @HospitalIdConstraint

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -8,6 +8,8 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +27,7 @@ public class MemberController implements MemberControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
@@ -79,13 +81,13 @@ public class MemberController implements MemberControllerSwagger {
 
     @GetMapping("/hospitals")
     public ResponseEntity<BaseResponse<MemberHospitalResponse>> getMemberHospital(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberHospital(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
     @PatchMapping("/hospitals/{hospitalId}")
-    public ResponseEntity<BaseResponse<Void>> updateMemberHospital(@PathVariable(name = "hospitalId") final Long hospitalId) {
+    public ResponseEntity<BaseResponse<Void>> updateMemberHospital(@PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId) {
         memberService.updateMemberHospital(hospitalId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberControllerSwagger.java
@@ -4,6 +4,8 @@ import com.cocos.cocos.api.member.dto.request.LoginRequest;
 import com.cocos.cocos.api.member.dto.request.ProfileUpdateRequest;
 import com.cocos.cocos.api.member.dto.response.*;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,7 +22,7 @@ public interface MemberControllerSwagger {
             responseCode = "200",
             description = "사용자 조회에 성공했습니다.")
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     );
 
     @Operation(summary = "로그인 API", description = "로그인 API 입니다.")
@@ -66,7 +68,7 @@ public interface MemberControllerSwagger {
             description = "요청에 성공했습니다."
     )
     public ResponseEntity<BaseResponse<MemberHospitalResponse>> getMemberHospital(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     );
 
     @Operation(summary = "사용자 즐겨찾는 병원 추가&수정 API", description = "사용자의 즐겨찾는 병원을 수정합니다. 이전에 등록된 병원이 없는 경우 추가합니다. ")
@@ -75,7 +77,7 @@ public interface MemberControllerSwagger {
             description = "요청에 성공했습니다."
     )
     public ResponseEntity<BaseResponse<Void>> updateMemberHospital(
-            @PathVariable(name = "hospitalId") final Long hospitalId
+            @PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId
     );
 
     @Operation(summary = "리뷰 약관 동의 업데이트 API", description = "리뷰 약관 동의 여부를 업데이트하는 API입니다.")

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
@@ -21,7 +21,7 @@ public record ProfileUpdateRequest(
         @Schema(description = "경도", example = "128.xxx")
         Double longitude,
         @Schema(description = "위치 아이디", example = "1")
-        Long locationId,
+        Long locationId,  // TODO: 유효성 검증 로직 추가
         @Schema(description = "위치 종류", example = "CITY | DISTRICT")
         LocationType locationType
 ) {

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
@@ -8,6 +8,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.validation.pet.PetIdConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,7 @@ public class PetController implements PetControllerSwagger {
 
     @PatchMapping("/{petId}")
     public ResponseEntity<BaseResponse<Void>> updatePet(
-            @PathVariable(name = "petId") final Long petId,
+            @PathVariable(name = "petId") @PetIdConstraint final Long petId,
             @RequestBody final PetUpdateRequest petUpdateRequest
     ) {
         //ToDo: 넘길 때 DTO 자체 보단, 값을 넘기는 것이 Controller에서 사용하는 DTO의 역할을 잘 지키는 것이라고 생각함

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
@@ -1,6 +1,6 @@
 package com.cocos.cocos.api.pet.controller;
 
-import com.cocos.cocos.api.pet.dto.reponse.PetResponse;
+import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.api.pet.service.PetService;

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetController.java
@@ -8,7 +8,9 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import com.cocos.cocos.validation.pet.PetIdConstraint;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +24,7 @@ public class PetController implements PetControllerSwagger {
 
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> addPet(
-            @RequestBody final PetCreateRequest petCreateRequest
+            @RequestBody @Valid final PetCreateRequest petCreateRequest
     ) {
         //ToDo: 넘길 때 DTO 자체 보단, 값을 넘기는 것이 Controller에서 사용하는 DTO의 역할을 잘 지키는 것이라고 생각함
         petService.addPet(petCreateRequest, PrincipalHandler.getMemberIdFromPrincipal());
@@ -32,7 +34,7 @@ public class PetController implements PetControllerSwagger {
     @PatchMapping("/{petId}")
     public ResponseEntity<BaseResponse<Void>> updatePet(
             @PathVariable(name = "petId") @PetIdConstraint final Long petId,
-            @RequestBody final PetUpdateRequest petUpdateRequest
+            @RequestBody @Valid final PetUpdateRequest petUpdateRequest
     ) {
         //ToDo: 넘길 때 DTO 자체 보단, 값을 넘기는 것이 Controller에서 사용하는 DTO의 역할을 잘 지키는 것이라고 생각함
         petService.updatePet(petUpdateRequest, petId, PrincipalHandler.getMemberIdFromPrincipal());
@@ -41,7 +43,7 @@ public class PetController implements PetControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<PetResponse>> getPet(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
         return SuccessResponse.success(SuccessMessage.OK, petService.getPet(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
@@ -4,6 +4,8 @@ import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
+import com.cocos.cocos.validation.pet.PetIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -30,7 +32,7 @@ public interface PetControllerSwagger {
             responseCode = "200",
             description = "요청이 성공했습니다. ")
     public ResponseEntity<BaseResponse<Void>> updatePet(
-            @Parameter(name = "petId", description = "애완동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) final Long petId,
+            @Parameter(name = "petId", description = "애완동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @PetIdConstraint final Long petId,
             @RequestBody final PetUpdateRequest petUpdateRequest
     );
 
@@ -39,6 +41,6 @@ public interface PetControllerSwagger {
             responseCode = "200",
             description = "요청이 성공했습니다.")
     public ResponseEntity<BaseResponse<PetResponse>> getPet(
-            @RequestParam final String nickname
+            @RequestParam @MemberNicknameConstraint final String nickname
     );
 }

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
@@ -1,6 +1,6 @@
 package com.cocos.cocos.api.pet.controller;
 
-import com.cocos.cocos.api.pet.dto.reponse.PetResponse;
+import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.common.response.BaseResponse;

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
@@ -12,31 +12,32 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "Pet Controller", description = "애완동물 관련 API")
+@Tag(name = "Pet Controller", description = "반려동물 관련 API")
 public interface PetControllerSwagger {
 
-    @Operation(summary = "사용자 애완동물 추가 API", description = "사용자 애완동물 추가 API입니다. ")
+    @Operation(summary = "사용자 반려동물 추가 API", description = "사용자 반려동물 추가 API입니다. ")
     @ApiResponse(
             responseCode = "201",
             description = "요청이 성공했습니다. ")
     public ResponseEntity<BaseResponse<Void>> addPet(
-            @RequestBody final PetCreateRequest petCreateRequest
+            @RequestBody @Valid final PetCreateRequest petCreateRequest
     );
 
-    @Operation(summary = "사용자 애완동물 수정 API", description = "사용자 애완동물 수정 API입니다. ")
+    @Operation(summary = "사용자 반려동물 수정 API", description = "사용자 반려동물 수정 API입니다. ")
     @ApiResponse(
             responseCode = "200",
             description = "요청이 성공했습니다. ")
     public ResponseEntity<BaseResponse<Void>> updatePet(
             @Parameter(name = "petId", description = "애완동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @PetIdConstraint final Long petId,
-            @RequestBody final PetUpdateRequest petUpdateRequest
+            @RequestBody @Valid final PetUpdateRequest petUpdateRequest
     );
 
-    @Operation(summary = "사용자 애완동물 조회 API", description = "사용자 애완동물 조회 API입니다. ")
+    @Operation(summary = "사용자 반려동물 조회 API", description = "사용자 반려동물 조회 API입니다. ")
     @ApiResponse(
             responseCode = "200",
             description = "요청이 성공했습니다.")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -1,6 +1,8 @@
 package com.cocos.cocos.api.pet.dto.request;
 
 import com.cocos.cocos.enums.pet.Gender;
+import com.cocos.cocos.validation.breed.BreedIdConstraint;
+import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -8,6 +10,7 @@ import java.util.List;
 @Schema(description = "애완동물 생성 형식")
 public record PetCreateRequest(
         @Schema(description = "동물 종 아이디", example = "1")
+        @BreedIdConstraint
         Long breedId,
 
         @Schema(description = "반려동물 이름", example = "포리")
@@ -20,6 +23,7 @@ public record PetCreateRequest(
         int age,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")
+        @DiseaseIdsConstraint
         List<Long> diseaseIds,
 
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -25,8 +25,4 @@ public record PetCreateRequest(
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")
         List<Long> symptomIds
 ) {
-    //ToDo: RequestDTO에는 of 제거해도 될 듯
-    public static PetCreateRequest of(final Long breedId, final String name, final Gender gender, final int age, final List<Long> diseaseIds, final List<Long> symptomIds) {
-        return new PetCreateRequest(breedId, name, gender, age, diseaseIds, symptomIds);
-    }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.api.pet.dto.request;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
+import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public record PetCreateRequest(
         List<Long> diseaseIds,
 
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")
+        @SymptomIdsConstraint
         List<Long> symptomIds
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 @Schema(description = "애완동물 수정 형식")
 public record PetUpdateRequest(
-        //ToDo: 간격 맞추기 필요
         @Schema(description = "동물 종 아이디", example = "1")
         Long breedId,
 
@@ -27,8 +26,4 @@ public record PetUpdateRequest(
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")
         List<Long> symptomIds
 ) {
-    //ToDo: RequestDTO에는 of 제거해도 될 듯
-    public static PetUpdateRequest of(final Long breedId, final String name, final Gender gender, final Integer age, final List<Long> diseaseIds, final List<Long> symptomIds) {
-        return new PetUpdateRequest(breedId, name, gender, age, diseaseIds, symptomIds);
-    }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.cocos.cocos.api.pet.dto.request;
 
 import com.cocos.cocos.enums.pet.Gender;
+import com.cocos.cocos.validation.breed.BreedIdConstraint;
+import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -9,6 +11,7 @@ import java.util.List;
 @Schema(description = "애완동물 수정 형식")
 public record PetUpdateRequest(
         @Schema(description = "동물 종 아이디", example = "1")
+        @BreedIdConstraint
         Long breedId,
 
         @Schema(description = "반려동물 이름", example = "포리")
@@ -21,6 +24,7 @@ public record PetUpdateRequest(
         Integer age,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")
+        @DiseaseIdsConstraint
         List<Long> diseaseIds,
 
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.api.pet.dto.request;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
+import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -28,6 +29,7 @@ public record PetUpdateRequest(
         List<Long> diseaseIds,
 
         @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")
+        @SymptomIdsConstraint
         List<Long> symptomIds
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetDiseaseResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetDiseaseResponse.java
@@ -1,4 +1,4 @@
-package com.cocos.cocos.api.pet.dto.reponse;
+package com.cocos.cocos.api.pet.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
@@ -1,4 +1,4 @@
-package com.cocos.cocos.api.pet.dto.reponse;
+package com.cocos.cocos.api.pet.dto.response;
 
 import com.cocos.cocos.enums.pet.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetSymptomResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetSymptomResponse.java
@@ -1,4 +1,4 @@
-package com.cocos.cocos.api.pet.dto.reponse;
+package com.cocos.cocos.api.pet.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -1,8 +1,8 @@
 package com.cocos.cocos.api.pet.service;
 
-import com.cocos.cocos.api.pet.dto.reponse.PetDiseaseResponse;
-import com.cocos.cocos.api.pet.dto.reponse.PetResponse;
-import com.cocos.cocos.api.pet.dto.reponse.PetSymptomResponse;
+import com.cocos.cocos.api.pet.dto.response.PetDiseaseResponse;
+import com.cocos.cocos.api.pet.dto.response.PetResponse;
+import com.cocos.cocos.api.pet.dto.response.PetSymptomResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.common.exception.CocosException;
@@ -109,6 +109,7 @@ public class PetService {
             throw new CocosException(FailMessage.FORBIDDEN_PET_UPDATE);
         }
         if (petUpdateRequest.breedId() != null) {
+            //TODO: 리팩 필요 (if문 제거)
             if (!breedRepository.existsById(petUpdateRequest.breedId())) {
                 throw new CocosException(FailMessage.NOT_FOUND_BREED);
             }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -8,6 +8,9 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
+import com.cocos.cocos.validation.post.PostIdConstraint;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,14 +24,14 @@ public class PostController implements PostControllerSwagger {
 
     @GetMapping("/{postId}")
     public ResponseEntity<BaseResponse<PostDetailResponse>> getPostDetail(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId
     ) {
         return SuccessResponse.success(SuccessMessage.OK, postService.getPostDetail(postId, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<BaseResponse<Void>> deletePost(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId
     ) {
         postService.deletePost(postId);
         return SuccessResponse.success(SuccessMessage.OK, null);
@@ -41,7 +44,7 @@ public class PostController implements PostControllerSwagger {
 
     @PostMapping
     public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(
-            @RequestBody final PostRequest postRequest
+            @RequestBody @Valid final PostRequest postRequest
     ) {
         return SuccessResponse.success(SuccessMessage.OK, postService.addPost(
                 PrincipalHandler.getMemberIdFromPrincipal(), postRequest.categoryId(), postRequest.title(),
@@ -57,7 +60,7 @@ public class PostController implements PostControllerSwagger {
 
     @PostMapping("/filters")
     public ResponseEntity<BaseResponse<PostListResponse>> getPosts(
-            @RequestBody final PostListRequest postListRequest
+            @RequestBody @Valid final PostListRequest postListRequest
     ) {
         return SuccessResponse.success(SuccessMessage.OK, postService.getPosts(PrincipalHandler.getMemberIdFromPrincipal(), postListRequest.keyword(),
                 postListRequest.animalIds(), postListRequest.symptomIds(), postListRequest.diseaseIds(),
@@ -67,7 +70,7 @@ public class PostController implements PostControllerSwagger {
 
     @GetMapping("/members")
     public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(
-            @RequestParam(name = "nickname", required = false) final String nickname
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
         return SuccessResponse.success(SuccessMessage.OK, postService.getMemberPosts(PrincipalHandler.getMemberIdFromPrincipal(), nickname));
     }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
@@ -4,12 +4,15 @@ import com.cocos.cocos.api.post.dto.request.PostListRequest;
 import com.cocos.cocos.api.post.dto.request.PostRequest;
 import com.cocos.cocos.api.post.dto.response.*;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
+import com.cocos.cocos.validation.post.PostIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -21,14 +24,14 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "게시글 상세 조회 성공")
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
-    public ResponseEntity<BaseResponse<PostDetailResponse>> getPostDetail(final Long postId);
+    public ResponseEntity<BaseResponse<PostDetailResponse>> getPostDetail(@PostIdConstraint final Long postId);
 
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제하는 API입니다.")
     @ApiResponse(
             responseCode = "200",
             description = "게시글 삭제 성공")
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
-    public ResponseEntity<BaseResponse<Void>> deletePost(final Long postId);
+    public ResponseEntity<BaseResponse<Void>> deletePost(@PostIdConstraint final Long postId);
 
     @Operation(summary = "게시글 카테고리 리스트 API", description = "게시글 카테고리 리스트를 조회하는 API입니다.")
     @ApiResponse(
@@ -40,7 +43,7 @@ public interface PostControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "게시글 추가 성공")
-    public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(final PostRequest postRequest);
+    public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(@RequestBody @Valid final PostRequest postRequest);
 
     @Operation(summary = "인기 게시글 조회 API", description = "인기 게시글을 조회하는 API입니다.")
     @ApiResponse(
@@ -53,7 +56,7 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "사용자 게시글 조회 성공")
     @Parameter(name = "nickname", description = "모모", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "String"))
-    public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(final String nickname);
+    public ResponseEntity<BaseResponse<MemberPostsResponse>> getMemberPosts(@MemberNicknameConstraint final String nickname);
 
 
     @Operation(summary = "게시글 리스트 조회 API", description = "사용자 게시글을 조회하는 API입니다.")
@@ -61,6 +64,6 @@ public interface PostControllerSwagger {
             responseCode = "200",
             description = "게시글 리스트 조회 성공")
     public ResponseEntity<BaseResponse<PostListResponse>> getPosts(
-            @RequestBody final PostListRequest postListRequest
+            @RequestBody @Valid final PostListRequest postListRequest
     );
 }

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.validation.post.PostIdConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +19,7 @@ public class PostLikeController implements PostLikeControllerSwagger {
 
     @PostMapping("/{postId}")
     public ResponseEntity<BaseResponse<Void>> addPostLike(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId
     ) {
         postLikeService.addPostLike(PrincipalHandler.getMemberIdFromPrincipal(), postId);
         return SuccessResponse.success(SuccessMessage.OK, null);
@@ -26,7 +27,7 @@ public class PostLikeController implements PostLikeControllerSwagger {
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<BaseResponse<Void>> deletePostLike(
-            @PathVariable(name = "postId") final Long postId
+            @PathVariable(name = "postId") @PostIdConstraint final Long postId
     ) {
         postLikeService.deletePostLike(PrincipalHandler.getMemberIdFromPrincipal(), postId);
         return SuccessResponse.success(SuccessMessage.OK, null);

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostLikeControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostLikeControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.api.post.controller;
 
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.post.PostIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -18,7 +19,7 @@ public interface PostLikeControllerSwagger {
             description = "게시글 공감 추가 성공")
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<Void>> addPostLike(
-            final Long postId
+            @PostIdConstraint final Long postId
     );
 
     @Operation(summary = "게시글 공감 삭제 API", description = "게시글 공감을 삭제하는 API입니다.")
@@ -27,6 +28,6 @@ public interface PostLikeControllerSwagger {
             description = "게시글 공감 삭제 성공")
     @Parameter(name = "postId", description = "게시글 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<Void>> deletePostLike(
-            final Long postId
+            @PostIdConstraint final Long postId
     );
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
@@ -1,6 +1,8 @@
 package com.cocos.cocos.api.post.dto.request;
 
 import com.cocos.cocos.enums.post.PostSortCriteria;
+import com.cocos.cocos.validation.animal.AnimalIdsConstraint;
+import com.cocos.cocos.validation.body.BodyIdConstraint;
 import com.cocos.cocos.validation.category.CategoryIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.post.PostIdConstraint;
@@ -14,6 +16,7 @@ public record PostListRequest(
         @Schema(description = "검색 키워드", example = "포메 or null")
         String keyword,
         @Schema(description = "동물 아이디 리스트", example = "[1, 2] or null")
+        @AnimalIdsConstraint
         List<Long> animalIds,
         @Schema(description = "증상 아이디 리스트", example = "[1, 2] or null")
         @SymptomIdsConstraint
@@ -34,6 +37,7 @@ public record PostListRequest(
         @Schema(description = "마지막 게시글 생성일", example = "YYYY-MM-DD~ or null")
         LocalDateTime createdAt,
         @Schema(description = "신체 아이디", example = "1")
+        @BodyIdConstraint
         Long bodyId
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostListRequest.java
@@ -1,6 +1,10 @@
 package com.cocos.cocos.api.post.dto.request;
 
 import com.cocos.cocos.enums.post.PostSortCriteria;
+import com.cocos.cocos.validation.category.CategoryIdConstraint;
+import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
+import com.cocos.cocos.validation.post.PostIdConstraint;
+import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -12,14 +16,18 @@ public record PostListRequest(
         @Schema(description = "동물 아이디 리스트", example = "[1, 2] or null")
         List<Long> animalIds,
         @Schema(description = "증상 아이디 리스트", example = "[1, 2] or null")
+        @SymptomIdsConstraint
         List<Long> symptomIds,
         @Schema(description = "질병 아이디 리스트", example = "[1, 2] or null")
+        @DiseaseIdsConstraint
         List<Long> diseaseIds,
         @Schema(description = "정렬 기준", example = "RECENT or POPULAR")
         PostSortCriteria sortBy,
         @Schema(description = "마지막 게시글 아이디", example = "1 or null")
+        @PostIdConstraint
         Long cursorId,
         @Schema(description = "마지막 게시글 카테고리 아이디", example = "1 or null")
+        @CategoryIdConstraint
         Long categoryId,
         @Schema(description = "마지막 게시글 좋아요 수 아이디", example = "1 or null")
         Long likeCount,

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
@@ -1,11 +1,15 @@
 package com.cocos.cocos.api.post.dto.request;
 
+import com.cocos.cocos.validation.category.CategoryIdConstraint;
+import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
+import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record PostRequest(
         @Schema(description = "게시글 카테고리 아이디", example = "1")
+        @CategoryIdConstraint
         Long categoryId,
         @Schema(description = "게시글 제목", example = "제목")
         String title,
@@ -13,11 +17,13 @@ public record PostRequest(
         String content,
         @Schema(description = "게시글 이미지 리스트", example = "[image1.png, image2.jpg]")
         List<String> images,
-        @Schema(description = "게시글 카테고리 아이디", example = "1")
+        @Schema(description = "게시글 동물 종 아이디", example = "1")
         Long animalId,
-        @Schema(description = "게시글 카테고리 아이디", example = "[1, 2]")
+        @Schema(description = "게시글 증상 아이디 리스트", example = "[1, 2]")
+        @SymptomIdsConstraint
         List<Long> symptomIds,
-        @Schema(description = "게시글 카테고리 아이디", example = "[2, 4]")
+        @Schema(description = "게시글 질병 아이디 리스트", example = "[2, 4]")
+        @DiseaseIdsConstraint
         List<Long> diseaseIds
 ) {
 }

--- a/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
+++ b/src/main/java/com/cocos/cocos/api/post/dto/request/PostRequest.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.api.post.dto.request;
 
+import com.cocos.cocos.validation.animal.AnimalIdConstraint;
 import com.cocos.cocos.validation.category.CategoryIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
@@ -18,6 +19,7 @@ public record PostRequest(
         @Schema(description = "게시글 이미지 리스트", example = "[image1.png, image2.jpg]")
         List<String> images,
         @Schema(description = "게시글 동물 종 아이디", example = "1")
+        @AnimalIdConstraint
         Long animalId,
         @Schema(description = "게시글 증상 아이디 리스트", example = "[1, 2]")
         @SymptomIdsConstraint

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -14,7 +14,9 @@ import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import com.cocos.cocos.validation.review.ReviewIdConstraint;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,7 @@ public class ReviewController implements ReviewControllerSwagger {
     @PostMapping("/hospitals/{hospitalId}/reviews")
     public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
             @PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId,
-            @RequestBody final ReviewAddRequest reviewAddRequest
+            @RequestBody @Valid final ReviewAddRequest reviewAddRequest
     ) {
         return SuccessResponse.success(SuccessMessage.CREATED, reviewService.addReview(
                 PrincipalHandler.getMemberIdFromPrincipal(), hospitalId, reviewAddRequest.breedId(), reviewAddRequest.gender(),
@@ -57,8 +59,8 @@ public class ReviewController implements ReviewControllerSwagger {
 
     @GetMapping("/hospitals/reviews/members")
     public ResponseEntity<BaseResponse<MemberHospitalReviewListResponse>> getMemberHospitalReviewList(
-            @RequestParam(name = "nickname", required = false) final String nickname,
-            @RequestParam(name = "cursorId", required = false) final Long cursorId,
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname,
+            @RequestParam(name = "cursorId", required = false) @ReviewIdConstraint final Long cursorId,
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
     ) {
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getMemberHospitalReviewList(nickname, cursorId, size, PrincipalHandler.getMemberIdFromPrincipal()));
@@ -66,7 +68,7 @@ public class ReviewController implements ReviewControllerSwagger {
 
     @PostMapping("/hospitals/reviews/filter")
     public ResponseEntity<BaseResponse<HospitalReviewListResponse>> getHospitalReviewList(
-            @RequestBody final ReviewListRequest reviewListRequest
+            @RequestBody @Valid final ReviewListRequest reviewListRequest
     ) {
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getHospitalReviewList(reviewListRequest.hospitalId(), reviewListRequest.summaryOptionId(), reviewListRequest.cursorId(), reviewListRequest.size(), reviewListRequest.bodyId(), reviewListRequest.locationId(), reviewListRequest.locationType(), PrincipalHandler.getMemberIdFromPrincipal()));
     }

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewControllerSwagger.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.review.dto.request.ReviewListRequest;
 import com.cocos.cocos.api.review.dto.response.*;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import com.cocos.cocos.validation.review.ReviewIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +32,7 @@ public interface ReviewControllerSwagger {
     @Parameter(name = "hospitalId", description = "병원 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
             @PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId,
-            @RequestBody final ReviewAddRequest reviewAddRequest
+            @RequestBody @Valid final ReviewAddRequest reviewAddRequest
     );
 
     @Operation(summary = "리뷰 요약 조회 API", description = "병원 리뷰 요약 리스트를 조회하는 API입니다. ")
@@ -69,8 +71,8 @@ public interface ReviewControllerSwagger {
     @Parameter(name = "cursorId", description = "페이징용 마지막 리뷰 ID", required = false)
     @Parameter(name = "size", description = "페이지당 조회할 리뷰 개수 (1~20) 비로그인 시 최대 4개")
     public ResponseEntity<BaseResponse<MemberHospitalReviewListResponse>> getMemberHospitalReviewList(
-            @RequestParam(name = "nickname", required = false) final String nickname,
-            @RequestParam(name = "cursorId", required = false) final Long cursorId,
+            @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname,
+            @RequestParam(name = "cursorId", required = false) @ReviewIdConstraint final Long cursorId,
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
     );
 
@@ -80,6 +82,6 @@ public interface ReviewControllerSwagger {
             description = "요청에 성공했습니다."
     )
     public ResponseEntity<BaseResponse<HospitalReviewListResponse>> getHospitalReviewList(
-            @RequestBody final ReviewListRequest reviewListRequest
+            @RequestBody @Valid final ReviewListRequest reviewListRequest
     );
 }

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewAddRequest.java
@@ -3,6 +3,10 @@ package com.cocos.cocos.api.review.dto.request;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdConstraint;
+import com.cocos.cocos.validation.purpose.PurposeIdConstraint;
+import com.cocos.cocos.validation.review.BadReviewIdsConstraint;
+import com.cocos.cocos.validation.review.GoodReviewIdsConstraint;
+import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -20,15 +24,19 @@ public record ReviewAddRequest(
         @Schema(description = "내용", nullable = true, example = "병원 시설이 너무 깔끔해요.")
         String content,
         @Schema(description = "방문 목적 아이디", nullable = true, example = "1")
+        @PurposeIdConstraint
         Long purposeId,
         @Schema(description = "질병 아이디", nullable = true, example = "7")
         @DiseaseIdConstraint
         Long diseaseId,
         @Schema(description = "증상 아이디 리스트", nullable = true, example = "[5,30...]")
+        @SymptomIdsConstraint
         List<Long> symptomIds,
         @Schema(description = "좋은 간단 리뷰 아이디 리스트", nullable = true, example = "[1,2,3...]")
+        @GoodReviewIdsConstraint
         List<Long> goodReviewIds,
         @Schema(description = "나쁜 간단 리뷰 아이디 리스트", nullable = true, example = "[1,2,3...]")
+        @BadReviewIdsConstraint
         List<Long> badReviewIds,
         @Schema(description = "리뷰 이미지 리스트", nullable = true, example = "[image1, image2...]")
         List<String> images

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
@@ -1,23 +1,29 @@
 package com.cocos.cocos.api.review.dto.request;
 
 import com.cocos.cocos.enums.location.LocationType;
+import com.cocos.cocos.validation.body.BodyIdConstraint;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.review.ReviewIdConstraint;
+import com.cocos.cocos.validation.review.SummaryOptionIdConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record ReviewListRequest(
         @Schema(description = "리뷰 요약 아이디", example = "1", nullable = true)
-        Long summaryOptionId, // TODO: 검증 로직 필요
+        @SummaryOptionIdConstraint
+        Long summaryOptionId,
         @Schema(description = "커서 아이디 (마지막으로 전달받은 리뷰 아이디", example = "1", nullable = true)
-        Long cursorId, // TODO: 검증 로직 필요
+        @ReviewIdConstraint
+        Long cursorId,
         @Schema(description = "병원 아이디", nullable = true, example = "1")
         @HospitalIdConstraint
         Long hospitalId,
         @Schema(description = "신체 아이디", nullable = true, example = "1")
-        Long bodyId, // TODO: 검증 로직 필요
+        @BodyIdConstraint
+        Long bodyId,
         @Schema(description = "지역 아이디", nullable = true, example = "1")
-        Long locationId, // TODO: 검증 로직 필요
+        Long locationId,  // TODO: 유효성 검증 로직 추가
         @Schema(description = "지역 타입", nullable = true, example = "DISTRICT")
         LocationType locationType,
         @Schema(description = "페이지네이션 크기 ", example = "10", defaultValue = "10")

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.api.symptom.service.SymptomService;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
+import com.cocos.cocos.validation.body.BodyIdsConstraint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,7 @@ public class SymptomController implements SymptomControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(
-            @RequestParam(name = "bodyIds") final List<Long> bodyIds
+            @RequestParam(name = "bodyIds") @BodyIdsConstraint final List<Long> bodyIds
     ) {
         return SuccessResponse.success(SuccessMessage.OK, symptomService.getSymptoms(bodyIds));
     }

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
@@ -2,6 +2,7 @@ package com.cocos.cocos.api.symptom.controller;
 
 import com.cocos.cocos.api.symptom.dto.response.SymptomsOfBodiesResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.body.BodyIdsConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -20,5 +21,5 @@ public interface SymptomControllerSwagger {
             responseCode = "200",
             description = "증상 리스트 조회 성공")
     @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
-    public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(final List<Long> bodyIds);
+    public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(@BodyIdsConstraint final List<Long> bodyIds);
 }

--- a/src/main/java/com/cocos/cocos/db/animal/repository/AnimalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/animal/repository/AnimalRepository.java
@@ -4,6 +4,9 @@ import com.cocos.cocos.db.animal.entity.Animal;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AnimalRepository extends JpaRepository<Animal, Long> {
+    long countByIdIn(final List<Long> animalIds);
 }

--- a/src/main/java/com/cocos/cocos/db/animal/repository/AnimalRepository.java
+++ b/src/main/java/com/cocos/cocos/db/animal/repository/AnimalRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface AnimalRepository extends JpaRepository<Animal, Long> {
-    long countByIdIn(final List<Long> animalIds);
+    long countByIdIn(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/db/body/repository/BodyRepository.java
+++ b/src/main/java/com/cocos/cocos/db/body/repository/BodyRepository.java
@@ -4,6 +4,9 @@ import com.cocos.cocos.db.body.entity.Body;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface BodyRepository extends JpaRepository<Body, Long> {
+    long countByIdIn(final List<Long> bodyIds);
 }

--- a/src/main/java/com/cocos/cocos/db/body/repository/BodyRepository.java
+++ b/src/main/java/com/cocos/cocos/db/body/repository/BodyRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface BodyRepository extends JpaRepository<Body, Long> {
-    long countByIdIn(final List<Long> bodyIds);
+    long countByIdIn(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryOptionRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewSummaryOptionRepository.java
@@ -4,6 +4,11 @@ import com.cocos.cocos.db.review.db.ReviewSummaryOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReviewSummaryOptionRepository extends JpaRepository<ReviewSummaryOption, Long> {
+    long countByIdInAndIsGoodTrue(final List<Long> ids);
+
+    long countByIdInAndIsGoodFalse(final List<Long> ids);
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -27,6 +27,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_REVIEW_ID(HttpStatus.BAD_REQUEST, 40013, "유효하지 않은 리뷰 아이디입니다."),
     BAD_REQUEST_INVALID_POST_ID(HttpStatus.BAD_REQUEST, 40014, "유효하지 않은 게시글 아이디입니다. "),
     BAD_REQUEST_INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, 40015, "유효하지 않은 댓글 아이디입니다. "),
+    BAD_REQUEST_INVALID_SUB_COMMENT_ID(HttpStatus.BAD_REQUEST, 40016, "유효하지 않은 대댓글 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -31,6 +31,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, 40017, "유효하지 않은 멤버 닉네임입니다. "),
     BAD_REQUEST_INVALID_BODY_ID(HttpStatus.BAD_REQUEST, 40018, "유효하지 않은 신체 아이디입니다. "),
     BAD_REQUEST_INVALID_PET_ID(HttpStatus.BAD_REQUEST, 40019, "유효하지 않은 펫 아이디입니다. "),
+    BAD_REQUEST_INVALID_SYMPTOM_ID(HttpStatus.BAD_REQUEST, 40020, "유효하지 않은 증상 아이디입니다."),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -33,6 +33,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_PET_ID(HttpStatus.BAD_REQUEST, 40019, "유효하지 않은 펫 아이디입니다. "),
     BAD_REQUEST_INVALID_SYMPTOM_ID(HttpStatus.BAD_REQUEST, 40020, "유효하지 않은 증상 아이디입니다."),
     BAD_REQUEST_INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, 40021, "유효하지 않은 카테고리 아이디입니다. "),
+    BAD_REQUEST_INVALID_ANIMAL_ID(HttpStatus.BAD_REQUEST, 40022, "유효하지 않은 동물 아이디 입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -25,6 +25,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_MEMBER_QUERY(HttpStatus.BAD_REQUEST, 40011, "회원 식별자 (id 또는 nickname)를 제공해야 합니다."),
     BAD_REQUEST_MISSING_BODY(HttpStatus.BAD_REQUEST, 40012, "필수 body가 누락되었습니다."),
     BAD_REQUEST_INVALID_REVIEW_ID(HttpStatus.BAD_REQUEST, 40013, "유효하지 않은 리뷰 아이디입니다."),
+    BAD_REQUEST_INVALID_POST_ID(HttpStatus.BAD_REQUEST, 40014, "유효하지 않은 게시글 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -34,6 +34,10 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_SYMPTOM_ID(HttpStatus.BAD_REQUEST, 40020, "유효하지 않은 증상 아이디입니다."),
     BAD_REQUEST_INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, 40021, "유효하지 않은 카테고리 아이디입니다. "),
     BAD_REQUEST_INVALID_ANIMAL_ID(HttpStatus.BAD_REQUEST, 40022, "유효하지 않은 동물 아이디 입니다. "),
+    BAD_REQUEST_INVALID_PURPOSE_ID(HttpStatus.BAD_REQUEST, 40023, "유효하지 않은 방문목적 아이디 입니다. "),
+    BAD_REQUEST_INVALID_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40024, "유효하지 않은 리뷰 요약 아이디입니다. "),
+    BAD_REQUEST_INVALID_GOOD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40025, "유효하지 않은 좋은 리뷰 요약 아이디입니다. "),
+    BAD_REQUEST_INVALID_BAD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 440026, "유효하지 않은 나쁜 리뷰 요약 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -29,6 +29,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, 40015, "유효하지 않은 댓글 아이디입니다. "),
     BAD_REQUEST_INVALID_SUB_COMMENT_ID(HttpStatus.BAD_REQUEST, 40016, "유효하지 않은 대댓글 아이디입니다. "),
     BAD_REQUEST_INVALID_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, 40017, "유효하지 않은 멤버 닉네임입니다. "),
+    BAD_REQUEST_INVALID_BODY_ID(HttpStatus.BAD_REQUEST, 40018, "유효하지 않은 신체 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -30,6 +30,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_SUB_COMMENT_ID(HttpStatus.BAD_REQUEST, 40016, "유효하지 않은 대댓글 아이디입니다. "),
     BAD_REQUEST_INVALID_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, 40017, "유효하지 않은 멤버 닉네임입니다. "),
     BAD_REQUEST_INVALID_BODY_ID(HttpStatus.BAD_REQUEST, 40018, "유효하지 않은 신체 아이디입니다. "),
+    BAD_REQUEST_INVALID_PET_ID(HttpStatus.BAD_REQUEST, 40019, "유효하지 않은 펫 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -26,6 +26,7 @@ public enum FailMessage {
     BAD_REQUEST_MISSING_BODY(HttpStatus.BAD_REQUEST, 40012, "필수 body가 누락되었습니다."),
     BAD_REQUEST_INVALID_REVIEW_ID(HttpStatus.BAD_REQUEST, 40013, "유효하지 않은 리뷰 아이디입니다."),
     BAD_REQUEST_INVALID_POST_ID(HttpStatus.BAD_REQUEST, 40014, "유효하지 않은 게시글 아이디입니다. "),
+    BAD_REQUEST_INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, 40015, "유효하지 않은 댓글 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -32,6 +32,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_BODY_ID(HttpStatus.BAD_REQUEST, 40018, "유효하지 않은 신체 아이디입니다. "),
     BAD_REQUEST_INVALID_PET_ID(HttpStatus.BAD_REQUEST, 40019, "유효하지 않은 펫 아이디입니다. "),
     BAD_REQUEST_INVALID_SYMPTOM_ID(HttpStatus.BAD_REQUEST, 40020, "유효하지 않은 증상 아이디입니다."),
+    BAD_REQUEST_INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, 40021, "유효하지 않은 카테고리 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -28,6 +28,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_POST_ID(HttpStatus.BAD_REQUEST, 40014, "유효하지 않은 게시글 아이디입니다. "),
     BAD_REQUEST_INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, 40015, "유효하지 않은 댓글 아이디입니다. "),
     BAD_REQUEST_INVALID_SUB_COMMENT_ID(HttpStatus.BAD_REQUEST, 40016, "유효하지 않은 대댓글 아이디입니다. "),
+    BAD_REQUEST_INVALID_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, 40017, "유효하지 않은 멤버 닉네임입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/validation/animal/AnimalIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/animal/AnimalIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.animal;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = AnimalIdValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnimalIdConstraint {
+    String message() default "Invalid Animal Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/animal/AnimalIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/animal/AnimalIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.animal;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnimalIdValidator implements ConstraintValidator<AnimalIdConstraint, Long> {
+
+    private final AnimalRepository animalRepository;
+
+    @Override
+    public boolean isValid(final Long animalId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (animalId == null || animalRepository.existsById(animalId)) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_ANIMAL_ID);
+        }
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/animal/AnimalIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/animal/AnimalIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.animal;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = AnimalIdsValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnimalIdsConstraint {
+    String message() default "Invalid Animal Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/animal/AnimalIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/animal/AnimalIdsValidator.java
@@ -1,0 +1,29 @@
+package com.cocos.cocos.validation.animal;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AnimalIdsValidator implements ConstraintValidator<AnimalIdsConstraint, List<Long>> {
+
+    private final AnimalRepository animalRepository;
+
+    @Override
+    public boolean isValid(final List<Long> animalIds, final ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = animalRepository.countByIdIn(animalIds);
+        if (animalIds == null || validCount == animalIds.size()) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_ANIMAL_ID);
+        }
+    }
+
+}

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdConstraint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = BodyIdValidator.class)
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BodyIdConstraint {
     String message() default "Invalid Body Id";

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.body;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = BodyIdValidator.class)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BodyIdConstraint {
+    String message() default "Invalid Body Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.body;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BodyIdValidator implements ConstraintValidator<BodyIdConstraint, Long> {
+
+    private final BodyRepository bodyRepository;
+
+    @Override
+    public boolean isValid(final Long bodyId, final ConstraintValidatorContext constraintValidatorContext) {
+       if (bodyId == null || bodyRepository.existsById(bodyId)) {
+           return true;
+       } else {
+           throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);
+       }
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdValidator.java
@@ -16,10 +16,10 @@ public class BodyIdValidator implements ConstraintValidator<BodyIdConstraint, Lo
 
     @Override
     public boolean isValid(final Long bodyId, final ConstraintValidatorContext constraintValidatorContext) {
-       if (bodyId == null || bodyRepository.existsById(bodyId)) {
-           return true;
-       } else {
-           throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);
-       }
+        if (bodyId == null || bodyRepository.existsById(bodyId)) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.body;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = BodyIdsValidator.class)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BodyIdsConstraint {
+    String message() default "Invalid Body Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdsConstraint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = BodyIdsValidator.class)
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BodyIdsConstraint {
     String message() default "Invalid Body Ids";

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
@@ -19,9 +19,10 @@ public class BodyIdsValidator implements ConstraintValidator<BodyIdsConstraint, 
     @Override
     public boolean isValid(final List<Long> bodyIds, final ConstraintValidatorContext constraintValidatorContext) {
         final long validCount = bodyRepository.countByIdIn(bodyIds);
-        if( validCount != bodyIds.size() ) {
+        if( bodyIds == null || validCount == bodyIds.size() ) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
@@ -12,14 +12,14 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class BodyIdsValidator implements ConstraintValidator<BodyIdsConstraint, List<Long>>  {
+public class BodyIdsValidator implements ConstraintValidator<BodyIdsConstraint, List<Long>> {
 
     private final BodyRepository bodyRepository;
 
     @Override
     public boolean isValid(final List<Long> bodyIds, final ConstraintValidatorContext constraintValidatorContext) {
         final long validCount = bodyRepository.countByIdIn(bodyIds);
-        if( bodyIds == null || validCount == bodyIds.size() ) {
+        if (bodyIds == null || validCount == bodyIds.size()) {
             return true;
         } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);

--- a/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/body/BodyIdsValidator.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.validation.body;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.body.repository.BodyRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BodyIdsValidator implements ConstraintValidator<BodyIdsConstraint, List<Long>>  {
+
+    private final BodyRepository bodyRepository;
+
+    @Override
+    public boolean isValid(final List<Long> bodyIds, final ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = bodyRepository.countByIdIn(bodyIds);
+        if( validCount != bodyIds.size() ) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BODY_ID);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/breed/BreedIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/breed/BreedIdValidator.java
@@ -16,9 +16,11 @@ public class BreedIdValidator implements ConstraintValidator<BreedIdConstraint, 
 
     @Override
     public boolean isValid(Long breedId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!breedRepository.existsById(breedId)) {
+        if (breedId == null || breedRepository.existsById(breedId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BREED_ID);
         }
-        return true;
+
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/breed/BreedIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/breed/BreedIdValidator.java
@@ -17,7 +17,7 @@ public class BreedIdValidator implements ConstraintValidator<BreedIdConstraint, 
     @Override
     public boolean isValid(Long breedId, ConstraintValidatorContext constraintValidatorContext) {
         if (!breedRepository.existsById(breedId)) {
-            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_HOSPITAL_ID);
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BREED_ID);
         }
         return true;
     }

--- a/src/main/java/com/cocos/cocos/validation/category/CategoryIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/category/CategoryIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.category;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = CategoryIdValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CategoryIdConstraint {
+    String message() default "Invalid Category Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/category/CategoryIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/category/CategoryIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.category;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.post.repository.PostCategoryRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryIdValidator implements ConstraintValidator<CategoryIdConstraint, Long> {
+
+    private final PostCategoryRepository postCategoryRepository;
+
+    @Override
+    public boolean isValid(final Long categoryId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (categoryId == null || postCategoryRepository.existsById(categoryId)) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_CATEGORY_ID);
+        }
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/comment/CommentIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/CommentIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.comment;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = CommentIdValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommentIdConstraint {
+    String message() default "Invalid Comment Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/comment/CommentIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/CommentIdValidator.java
@@ -16,9 +16,10 @@ public class CommentIdValidator implements ConstraintValidator<CommentIdConstrai
 
     @Override
     public boolean isValid(final Long commentId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!commentRepository.existsById(commentId)) {
+        if (commentId == null || commentRepository.existsById(commentId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_COMMENT_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/comment/CommentIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/CommentIdValidator.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.validation.comment;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.comment.repository.CommentRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentIdValidator implements ConstraintValidator<CommentIdConstraint, Long> {
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public boolean isValid(final Long commentId, ConstraintValidatorContext constraintValidatorContext) {
+        if (!commentRepository.existsById(commentId)) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_COMMENT_ID);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.comment;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SubCommentIdValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubCommentIdConstraint {
+    String message() default "Invalid SubComment Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdValidator.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.validation.comment;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.comment.repository.SubCommentRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubCommentIdValidator implements ConstraintValidator<SubCommentIdConstraint, Long> {
+
+    private final SubCommentRepository subCommentRepository;
+
+    @Override
+    public boolean isValid(final Long subCommentId, ConstraintValidatorContext constraintValidatorContext) {
+        if (!subCommentRepository.existsById(subCommentId)) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SUB_COMMENT_ID);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/comment/SubCommentIdValidator.java
@@ -16,9 +16,10 @@ public class SubCommentIdValidator implements ConstraintValidator<SubCommentIdCo
 
     @Override
     public boolean isValid(final Long subCommentId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!subCommentRepository.existsById(subCommentId)) {
+        if (subCommentId == null || subCommentRepository.existsById(subCommentId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SUB_COMMENT_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdValidator.java
@@ -16,9 +16,10 @@ public class DiseaseIdValidator implements ConstraintValidator<DiseaseIdConstrai
 
     @Override
     public boolean isValid(Long diseaseId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!diseaseRepository.existsById(diseaseId)) {
+        if (diseaseId == null || diseaseRepository.existsById(diseaseId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_DISEASE_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.disease;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = DiseaseIdsValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DiseaseIdsConstraint {
+    String message() default "Invalid Disease Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsValidator.java
@@ -19,9 +19,9 @@ public class DiseaseIdsValidator implements ConstraintValidator<DiseaseIdsConstr
     @Override
     public boolean isValid(List<Long> diseaseIds, ConstraintValidatorContext constraintValidatorContext) {
         final long validCount = diseaseRepository.countByIdIn(diseaseIds);
-        if( validCount != diseaseIds.size() ) {
-            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_DISEASE_ID);
+        if (diseaseIds == null || validCount == diseaseIds.size()) {
+            return true;
         }
-        return true;
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_DISEASE_ID);
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/disease/DiseaseIdsValidator.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.validation.disease;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.disease.repository.DiseaseRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DiseaseIdsValidator implements ConstraintValidator<DiseaseIdsConstraint, List<Long>> {
+
+    private final DiseaseRepository diseaseRepository;
+
+    @Override
+    public boolean isValid(List<Long> diseaseIds, ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = diseaseRepository.countByIdIn(diseaseIds);
+        if( validCount != diseaseIds.size() ) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_DISEASE_ID);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/hospital/HospitalIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/hospital/HospitalIdValidator.java
@@ -16,9 +16,10 @@ public class HospitalIdValidator implements ConstraintValidator<HospitalIdConstr
 
     @Override
     public boolean isValid(Long hospitalId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!hospitalRepository.existsById(hospitalId)) {
+        if (hospitalId == null || hospitalRepository.existsById(hospitalId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_HOSPITAL_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/member/MemberNicknameConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/member/MemberNicknameConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.member;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = MemberNicknameValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberNicknameConstraint {
+    String message() default "Invalid Member Nickname";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
@@ -16,9 +16,11 @@ public class MemberNicknameValidator implements ConstraintValidator<MemberNickna
 
     @Override
     public boolean isValid(final String nickname, final ConstraintValidatorContext constraintValidatorContext) {
-        if (!memberRepository.existsByNickname(nickname)) {
+        if (nickname == null || memberRepository.existsByNickname(nickname)) {
+            return true;
+        }
+        else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_NICKNAME);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.validation.member;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.member.repository.MemberRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberNicknameValidator implements ConstraintValidator<MemberNicknameConstraint, String> {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean isValid(final String nickname, final ConstraintValidatorContext constraintValidatorContext) {
+        if (!memberRepository.existsByNickname(nickname)) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_NICKNAME);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/member/MemberNicknameValidator.java
@@ -18,8 +18,7 @@ public class MemberNicknameValidator implements ConstraintValidator<MemberNickna
     public boolean isValid(final String nickname, final ConstraintValidatorContext constraintValidatorContext) {
         if (nickname == null || memberRepository.existsByNickname(nickname)) {
             return true;
-        }
-        else {
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_MEMBER_NICKNAME);
         }
     }

--- a/src/main/java/com/cocos/cocos/validation/pet/PetIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/pet/PetIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.pet;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PetIdValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PetIdConstraint {
+    String message() default "Invalid Pet Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/pet/PetIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/pet/PetIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.pet;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.pet.repository.PetRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PetIdValidator implements ConstraintValidator<PetIdConstraint, Long> {
+
+    private final PetRepository petRepository;
+
+    @Override
+    public boolean isValid(final Long petId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (petId == null || petRepository.existsById(petId)) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_PET_ID);
+        }
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/post/PostIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/post/PostIdConstraint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = PostIdValidator.class)
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PostIdConstraint {
     String message() default "Invalid Post Id";

--- a/src/main/java/com/cocos/cocos/validation/post/PostIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/post/PostIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.post;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PostIdValidator.class)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostIdConstraint {
+    String message() default "Invalid Post Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/post/PostIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/post/PostIdValidator.java
@@ -1,0 +1,24 @@
+package com.cocos.cocos.validation.post;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostIdValidator implements ConstraintValidator<PostIdConstraint, Long> {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public boolean isValid(final Long postId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (!postRepository.existsById(postId)) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_POST_ID);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/post/PostIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/post/PostIdValidator.java
@@ -16,9 +16,10 @@ public class PostIdValidator implements ConstraintValidator<PostIdConstraint, Lo
 
     @Override
     public boolean isValid(final Long postId, final ConstraintValidatorContext constraintValidatorContext) {
-        if (!postRepository.existsById(postId)) {
+        if (postId == null || postRepository.existsById(postId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_POST_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.purpose;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PurposeIdValidator.class)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PurposeIdConstraint {
+    String message() default "Invalid Purpose Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdValidator.java
@@ -21,5 +21,4 @@ public class PurposeIdValidator implements ConstraintValidator<PurposeIdConstrai
         }
         throw new CocosException(FailMessage.BAD_REQUEST_INVALID_PURPOSE_ID);
     }
-
 }

--- a/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/purpose/PurposeIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.purpose;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.hospital.repository.HospitalVisitPurposeRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PurposeIdValidator implements ConstraintValidator<PurposeIdConstraint, Long> {
+
+    private final HospitalVisitPurposeRepository hospitalVisitPurposeRepository;
+
+    @Override
+    public boolean isValid(final Long purposeId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (purposeId == null || hospitalVisitPurposeRepository.existsById(purposeId)) {
+            return true;
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_PURPOSE_ID);
+    }
+
+}

--- a/src/main/java/com/cocos/cocos/validation/review/BadReviewIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/review/BadReviewIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.review;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = BadReviewIdsValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BadReviewIdsConstraint {
+    String message() default "Invalid Bad Review Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/review/BadReviewIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/review/BadReviewIdsValidator.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.validation.review;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.review.repository.ReviewSummaryOptionRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BadReviewIdsValidator implements ConstraintValidator<BadReviewIdsConstraint, List<Long>> {
+
+    private final ReviewSummaryOptionRepository reviewSummaryOptionRepository;
+
+    @Override
+    public boolean isValid(final List<Long> summaryOptionIds, final ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = reviewSummaryOptionRepository.countByIdInAndIsGoodFalse(summaryOptionIds);
+        if (summaryOptionIds == null || validCount == summaryOptionIds.size()) {
+            return true;
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_BAD_SUMMARY_OPTION_ID);
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/review/GoodReviewIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/review/GoodReviewIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.review;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = GoodReviewIdsValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GoodReviewIdsConstraint {
+    String message() default "Invalid Good Review Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/review/GoodReviewIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/review/GoodReviewIdsValidator.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.validation.review;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.review.repository.ReviewSummaryOptionRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GoodReviewIdsValidator implements ConstraintValidator<GoodReviewIdsConstraint, List<Long>> {
+
+    private final ReviewSummaryOptionRepository reviewSummaryOptionRepository;
+
+    @Override
+    public boolean isValid(final List<Long> summaryOptionIds, final ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = reviewSummaryOptionRepository.countByIdInAndIsGoodTrue(summaryOptionIds);
+        if (summaryOptionIds == null || validCount == summaryOptionIds.size()) {
+            return true;
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_GOOD_SUMMARY_OPTION_ID);
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/review/ReviewIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/review/ReviewIdConstraint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = ReviewIdValidator.class)
-@Target({ElementType.PARAMETER})
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ReviewIdConstraint {
     String message() default "Invalid Review Id";

--- a/src/main/java/com/cocos/cocos/validation/review/ReviewIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/review/ReviewIdValidator.java
@@ -16,9 +16,10 @@ public class ReviewIdValidator implements ConstraintValidator<ReviewIdConstraint
 
     @Override
     public boolean isValid(Long reviewId, ConstraintValidatorContext constraintValidatorContext) {
-        if (!reviewRepository.existsById(reviewId)) {
+        if (reviewId == null || reviewRepository.existsById(reviewId)) {
+            return true;
+        } else {
             throw new CocosException(FailMessage.BAD_REQUEST_INVALID_REVIEW_ID);
         }
-        return true;
     }
 }

--- a/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.review;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SummaryOptionIdValidator.class)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SummaryOptionIdConstraint {
+    String message() default "Invalid Summary Option Id";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdConstraint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = SummaryOptionIdValidator.class)
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SummaryOptionIdConstraint {
     String message() default "Invalid Summary Option Id";

--- a/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/review/SummaryOptionIdValidator.java
@@ -1,0 +1,25 @@
+package com.cocos.cocos.validation.review;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.review.repository.ReviewSummaryOptionRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SummaryOptionIdValidator implements ConstraintValidator<SummaryOptionIdConstraint, Long> {
+
+    private final ReviewSummaryOptionRepository reviewSummaryOptionRepository;
+
+    @Override
+    public boolean isValid(final Long summaryOptionId, final ConstraintValidatorContext constraintValidatorContext) {
+        if (summaryOptionId == null || reviewSummaryOptionRepository.existsById(summaryOptionId)) {
+            return true;
+        } else {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SUMMARY_OPTION_ID);
+        }
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/symptom/SymptomIdsConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/symptom/SymptomIdsConstraint.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.symptom;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SymptomIdsValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SymptomIdsConstraint {
+    String message() default "Invalid Symptom Ids";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/symptom/SymptomIdsValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/symptom/SymptomIdsValidator.java
@@ -1,0 +1,27 @@
+package com.cocos.cocos.validation.symptom;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.symptom.repository.SymptomRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SymptomIdsValidator implements ConstraintValidator<SymptomIdsConstraint, List<Long>> {
+
+    private final SymptomRepository symptomRepository;
+
+    @Override
+    public boolean isValid(final List<Long> symptomIds, ConstraintValidatorContext constraintValidatorContext) {
+        final long validCount = symptomRepository.countByIdIn(symptomIds);
+        if (symptomIds == null || validCount == symptomIds.size()) {
+            return true;
+        }
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_SYMPTOM_ID);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #195 

## 👷 **작업한 내용**
- 모든 request dto와 path variable에 유효성 검증 로직을 추가하였습니다. 

## 🚨 **참고 사항**
- 검증하고자하는 필드가 null일 때 항상 true를 return하도록 하는 로직을 추가해두었습니다. 
- locationId와 locationType의 경우 현재는 따로 검증 로직을 두지 않았습니다! 추가로 필요하다면 이슈를 파서 작업할 것 같습니다! 여러 DTO에서 locationId와 locationType을 동시에 사용하고 있어서 공통 인터페이스를 만들어서 validator에서 인자로 받아서 유효성을 검증하도록 구현하려고 하는데 이에 대한 의견이 궁금합니다! 