### PR TITLE
Fix: 병원, 리뷰 API 비로그인 로직 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -31,7 +31,6 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
             @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
-        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 

--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.util.validation.EntityExistsValidator;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
 import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +25,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerSwagger {
 
     private final MemberService memberService;
+    private final EntityExistsValidator entityExistsValidator;
 
     @GetMapping
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getMemberProfile(
             @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberProfile(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
@@ -83,11 +86,13 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<BaseResponse<MemberHospitalResponse>> getMemberHospital(
             @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberHospital(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 
     @PatchMapping("/hospitals/{hospitalId}")
     public ResponseEntity<BaseResponse<Void>> updateMemberHospital(@PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId) {
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         memberService.updateMemberHospital(hospitalId, PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, null);
     }

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -13,6 +13,7 @@ import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.common.response.SuccessResponse;
 import com.cocos.cocos.enums.message.SuccessMessage;
 import com.cocos.cocos.util.PrincipalHandler;
+import com.cocos.cocos.util.validation.EntityExistsValidator;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
 import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import com.cocos.cocos.validation.review.ReviewIdConstraint;
@@ -31,12 +32,14 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController implements ReviewControllerSwagger {
 
     private final ReviewService reviewService;
+    private final EntityExistsValidator entityExistsValidator;
 
     @PostMapping("/hospitals/{hospitalId}/reviews")
     public ResponseEntity<BaseResponse<ReviewAddResponse>> addReview(
             @PathVariable(name = "hospitalId") @HospitalIdConstraint final Long hospitalId,
             @RequestBody @Valid final ReviewAddRequest reviewAddRequest
     ) {
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.CREATED, reviewService.addReview(
                 PrincipalHandler.getMemberIdFromPrincipal(), hospitalId, reviewAddRequest.breedId(), reviewAddRequest.gender(),
                 reviewAddRequest.weight(), reviewAddRequest.visitedAt(), reviewAddRequest.content(),
@@ -63,6 +66,7 @@ public class ReviewController implements ReviewControllerSwagger {
             @RequestParam(name = "cursorId", required = false) @ReviewIdConstraint final Long cursorId,
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
     ) {
+        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getMemberHospitalReviewList(nickname, cursorId, size, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -49,19 +49,20 @@ public class SecurityConfig {
                 apiPrefix + "/posts/**",
                 apiPrefix + "/comments/**",
                 apiPrefix + "/members/login",
-                //TODO: 클라쌤들의 개발을 위해 임시로 추가
-                apiPrefix + "/hospitals/**",
+                apiPrefix + "/hospitals/**"
         };
 
         BLACK_LIST_GET_METHOD_URL_IN_WHITE_LIST = new String[]{
                 apiPrefix + "/posts/members",
                 apiPrefix + "/comments/members",
+                apiPrefix + "/hospitals/reviews/members"
         };
 
         BLACK_LIST_POST_METHOD_URL_IN_WHITE_LIST = new String[]{
                 apiPrefix + "/posts",
                 apiPrefix + "/comments/{postId}",
                 apiPrefix + "/comments/sub/{commentId}",
+                apiPrefix + "/hospitals/{hospitalId}/reviews"
         };
 
         BLACK_LIST_PATCH_METHOD_URL_IN_WHITE_LIST = new String[]{
@@ -72,6 +73,7 @@ public class SecurityConfig {
                 apiPrefix + "/posts/{postId}",
                 apiPrefix + "/comments/{commentId}",
                 apiPrefix + "/comments/sub/{subCommentId}",
+                apiPrefix + "/hospitals/reviews/{reviewId}"
         };
     }
 

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -53,7 +53,7 @@ public enum FailMessage {
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "권한이 없습니다. "),
     FORBIDDEN_COMMENT_DELETE(HttpStatus.FORBIDDEN, 40301, "댓글을 삭제할 권한이 없습니다. "),
-    FORBIDDEN_PET_UPDATE(HttpStatus.FORBIDDEN, 40302, "애완동물 정보를 수정할 권리가 없습니다. "),
+    FORBIDDEN_PET_UPDATE(HttpStatus.FORBIDDEN, 40302, "반려동물 정보를 수정할 권리가 없습니다. "),
     FORBIDDEN_POST_DELETE(HttpStatus.FORBIDDEN, 40303, "게시글을 삭제할 권리가 없습니다. "),
 
     /**
@@ -74,7 +74,7 @@ public enum FailMessage {
     NOT_FOUND_POSTTAG(HttpStatus.NOT_FOUND, 40412, "태그를 찾을 수 없습니다."),
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, 40413, "댓글을 찾을 수 없습니다."),
     NOT_FOUND_SUB_COMMENT(HttpStatus.NOT_FOUND, 40414, "대댓글을 찾을 수 없습니다."),
-    NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "애완동물을 찾을 수 없습니다. "),
+    NOT_FOUND_PET(HttpStatus.NOT_FOUND, 40415, "반려동물을 찾을 수 없습니다. "),
     NOT_FOUND_MENTIONED_MEMBER(HttpStatus.NOT_FOUND, 40416, "언급된 사용자를 찾을 수 없습니다. "),
     NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, 40417, "동을 찾을 수 없습니다. "),
     NOT_FOUND_MEMBER_ADDRESS(HttpStatus.NOT_FOUND, 40418, "사용자 위치를 찾을 수 없습니다."),
@@ -95,7 +95,7 @@ public enum FailMessage {
     CONFLICT(HttpStatus.CONFLICT, 40900, "데이터 충돌이 발생했습니다. "),
     INTEGRITY_CONFLICT(HttpStatus.CONFLICT, 40901, "데이터 무결성 위반입니다."),
     CONFLICT_POSTLIKE(HttpStatus.CONFLICT, 40902, "이미 존재하는 게시글 공감입니다."),
-    CONFLICT_PET(HttpStatus.CONFLICT, 40903, "이미 사용자의 애완동물이 존재합니다."),
+    CONFLICT_PET(HttpStatus.CONFLICT, 40903, "이미 사용자의 반려동물이 존재합니다."),
     CONFLICT_MEMBER_HOSPITAL(HttpStatus.CONFLICT, 40904, "이미 사용자의 즐겨찾는 병원이 존재합니다."),
 
     /**


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #217 

## 👷 **작업한 내용**
`변경 (펫 검증 로직 추가)`
POST /hospitals/{hospitalId}/reviews - 리뷰 작성 API → 펫 있어야 작성 가능
GET /hospitals/reviews/members - 사용자 리뷰 리스트 조회 API → 펫 있어야 다른 사람 리뷰 조회 가능
GET /member/hospitals - 사용자 즐겨찾는 병원 조회 API -> 펫 있어야 조회 가능
PATCH /member/hospitals/{hospitalId} - 사용자 즐겨찾는 병원 추가&수정 API -> 펫 있어야 추가&수정 가능

`유지`
POST /hospitals/reviews/filter - 리뷰 리스트 조회 API → 비로그인 유저도 가능
GET /hospitals/{hospitalId}/reviews/summary - 리뷰 요약 조회 API → 비로그인 유저도 가능
GET /hospitals/reviews/summary/option - 리뷰 요약 옵션 리스트 조회 API → 비로그인 유저도 가능

POST /hospitals - 병원 리스트 조회 API → 비로그인 유저도 가능
GET /hospitals/{hospitalId} - 병원 상세 조회 API → 비로그인 유저도 가능
GET /hospitals/purposes - 병원 방문 목적 리스트 조회 API → 비로그인 유저도 가능
DELETE /hospitals/reviews/{reviewId} - 리뷰 삭제 API (리뷰 작성 시 펫이 있어야 하므로 이미 펫이 있다고 가정. PET 확인 로직 추가 X) 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
- DELETE할 때도 Pet 유무를 검증하는 게 좋을까요?