### PR TITLE
Fix: 종류(breed) 검색 시 찾는 종이 없음 선택지 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/breed/controller/BreedControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/breed/controller/BreedControllerSwagger.java
@@ -2,6 +2,7 @@ package com.cocos.cocos.api.breed.controller;
 
 import com.cocos.cocos.api.breed.dto.response.BreedsResponse;
 import com.cocos.cocos.common.response.BaseResponse;
+import com.cocos.cocos.validation.animal.AnimalIdConstraint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -21,6 +22,6 @@ public interface BreedControllerSwagger {
     @Parameter(name = "animalId", description = "동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long"))
     public ResponseEntity<BaseResponse<BreedsResponse>> getBreeds(
             final String breedName,
-            final Long animalId
+            final @AnimalIdConstraint Long animalId
     );
 }

--- a/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
+++ b/src/main/java/com/cocos/cocos/api/breed/service/BreedService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -18,17 +19,28 @@ public class BreedService {
 
     @Transactional(readOnly = true)
     public BreedsResponse getBreeds(final String breedName, final Long animalId) {
+
+        final List<Breed> allBreeds = getBreedsByBreedNameAndAnimalId(breedName, animalId);
+        allBreeds.sort(Comparator.comparing(Breed::isEtc));
+
+        return BreedsResponse.of(allBreeds.stream()
+                .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
+                .toList());
+    }
+
+    private List<Breed> getBreedsByBreedNameAndAnimalId(final String breedName, final Long animalId) {
         if (breedName == null || breedName.isEmpty()) {
-            final List<Breed> allBreeds = breedRepository.findAllByAnimalId(animalId);
-            return BreedsResponse.of(allBreeds.stream()
-                    .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
-                    .toList());
+            return breedRepository.findAllByAnimalId(animalId);
         } else {
             final List<Breed> breeds = breedRepository.findAllByNameContainingAndAnimalId(breedName, animalId);
-            return BreedsResponse.of(breeds.stream()
-                    .map(breed -> BreedResponse.of(breed.getId(), breed.getName()))
-                    .toList()
-            );
+            final boolean containsEtc = breeds.stream().anyMatch(Breed::isEtc);
+            if (!containsEtc) {
+                final Breed etcBreed = breedRepository.findByAnimalIdAndIsEtcTrue(animalId);
+                if (etcBreed != null) {
+                    breeds.add(etcBreed);
+                }
+            }
+            return breeds;
         }
     }
 }

--- a/src/main/java/com/cocos/cocos/db/breed/entity/Breed.java
+++ b/src/main/java/com/cocos/cocos/db/breed/entity/Breed.java
@@ -22,9 +22,13 @@ public class Breed {
     @Column(name = "animal_id", nullable = false)
     private Long animalId;
 
+    @Column(name = "is_etc", nullable = false)
+    private boolean isEtc;
+
     @Builder
-    public Breed(String name, Long animalId) {
+    public Breed(String name, Long animalId, boolean isEtc) {
         this.name = name;
         this.animalId = animalId;
+        this.isEtc = isEtc;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/breed/repository/BreedRepository.java
+++ b/src/main/java/com/cocos/cocos/db/breed/repository/BreedRepository.java
@@ -12,4 +12,6 @@ public interface BreedRepository extends JpaRepository<Breed, Long> {
     List<Breed> findAllByNameContainingAndAnimalId(final String Name, final Long animalId);
 
     List<Breed> findAllByAnimalId(final Long animalId);
+
+    Breed findByAnimalIdAndIsEtcTrue(final Long animalId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #221 
- 
## 👷 **작업한 내용**
- 종류 검색 시 찾는 종이 없음 선택지를 추가했습니다.
- breed table에 isEtc 필드(boolean)를 추가 하여 기타 필드를 분리했습니다.
- 모든 검색 결과의 마지막 결과값에 '찾는 종이 없음' 필드가 검색되도록 했습니다. 
- 스웨거에 검증 어노테이션이 누락되어 있어 추가하였습니다.

## 🚨 **참고 사항**
- isEtc 필드명이 적합하다고 생각하는지 궁금합니다 !
