### PR TITLE
Fix: 마이페이지 조회 시 pet 검증 로직 제거

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
+++ b/src/main/java/com/cocos/cocos/api/member/controller/MemberController.java
@@ -85,7 +85,6 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<BaseResponse<MemberHospitalResponse>> getMemberHospital(
             @RequestParam(name = "nickname", required = false) @MemberNicknameConstraint final String nickname
     ) {
-        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, memberService.getMemberHospital(nickname, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 

--- a/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
+++ b/src/main/java/com/cocos/cocos/api/review/controller/ReviewController.java
@@ -66,7 +66,6 @@ public class ReviewController implements ReviewControllerSwagger {
             @RequestParam(name = "cursorId", required = false) @ReviewIdConstraint final Long cursorId,
             @RequestParam(name = "size", defaultValue = "10") @Min(value = 1) @Max(value = 20) final int size
     ) {
-        entityExistsValidator.validatePetByMemberId(PrincipalHandler.getMemberIdFromPrincipal());
         return SuccessResponse.success(SuccessMessage.OK, reviewService.getMemberHospitalReviewList(nickname, cursorId, size, PrincipalHandler.getMemberIdFromPrincipal()));
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #225 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
멤버 즐겨찾는 병원 조회 시 pet 검증 로직을 제거하였습니다.
멤버 병원 리뷰 리스트 조회 시 pet 검증 로직을 제거하였습니다. 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
기획이 변경됨에 따른 변경사항입니다. 
