### PR TITLE
Fix: 사용자 리뷰 리스트 조회 시에도 disease id가 null일 수 있도록 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -202,7 +202,7 @@ public class ReviewService {
                             summaryOptionList,
                             imageUrls,
                             symptoms,
-                            disease.getName(),
+                            disease != null ? disease.getName() : null,
                             animal.getName(),
                             review.getGender(),
                             breed.getName(),


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #227 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
사용자 리뷰 리스트 조회 시에도 disease id가 null일 수 있도록 수정했습니다

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
프엔분들 작업할 때 영향이 갈 수 있어서 빠르게 리뷰되면 좋을 것 같습니다 