### PR TITLE
Fix: 사용자 게시글 리스트 조회 시 pet이 없는 상황에 대한 예외처리 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -419,6 +419,9 @@ public class PostService {
         final Member member = findMember(memberId, nickname);
         final List<Post> posts = postRepository.findAllByMemberId(member.getId());
         final Pet pet = petRepository.findByMemberId(member.getId());
+        if (pet == null) {
+            throw new CocosException(FailMessage.NOT_FOUND_PET);
+        }
         final Breed breed = breedRepository.findById(pet.getBreedId()).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_BREED)
         );


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #229 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
사용자 게시글 리스트 조회 시 pet이 없는 상황에 대한 예외처리 추가

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
프론트에서 PET 유무 API로 먼저 확인하기 때문에 예외처리를 추가하지 않아도 괜찮지만, 현재 PET이 없는 상황에 대해서 404 예외가 아닌 500에러가 발생하고 있기 때문에 예외처리를 추가하였습니다. 
