### PR TITLE
Feat: 병원 상세 조회 응답에 키워드, 홈페이지 URL 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
@@ -16,9 +16,13 @@ public record HospitalDetailResponse(
         @Schema(description = "병원 주소", example = "서울특별시 강남구 논현동")
         String address,
         @Schema(description = "병원 이미지", example = "https://www.~~")
-        String image
+        String image,
+        @Schema(description = "병원 키워드들", example = "#친절함, #강아지")
+        String keywords,
+        @Schema(description = "병원 홈페이지 URL", example = "https://www.~~")
+        String homepageUrl
 ) {
-    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String image) {
-        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, image);
+    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String image, final String keywords, final String homepageUrl) {
+        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, image, keywords, homepageUrl);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -146,7 +146,9 @@ public class HospitalService {
                 hospitalTags,
                 hospital.getIntroduction(),
                 hospital.getDisplayAddress(),
-                appDataS3Client.getPresignedUrl(hospital.getImage())
+                appDataS3Client.getPresignedUrl(hospital.getImage()),
+                hospital.getKeywords(),
+                hospital.getHomepageUrl()
         );
     }
 

--- a/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
+++ b/src/main/java/com/cocos/cocos/db/hospital/entity/Hospital.java
@@ -46,8 +46,14 @@ public class Hospital {
     @Column(name = "introduction", nullable = true)
     private String introduction;
 
+    @Column(name = "keywords", nullable = true)
+    private String keywords;
+
+    @Column(name = "homepage_url", nullable = true)
+    private String homepageUrl;
+
     @Builder
-    public Hospital(final String name, final String address, final String roadAddress, final String image, final Double latitude, final Double longitude, final int reviewCount, final Long districtId, final String phoneNumber, final String introduction) {
+    public Hospital(final String name, final String address, final String roadAddress, final String image, final Double latitude, final Double longitude, final int reviewCount, final Long districtId, final String phoneNumber, final String introduction, final String keywords, final String homepageUrl) {
         this.name = name;
         this.address = address;
         this.roadAddress = roadAddress;
@@ -58,6 +64,8 @@ public class Hospital {
         this.phoneNumber = phoneNumber;
         this.introduction = introduction;
         this.districtId = districtId;
+        this.keywords = keywords;
+        this.homepageUrl = homepageUrl;
     }
 
     public void addReview() {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #237 

## 👷 **작업한 내용**
- 병원 테이블에 키워드(keywords), 홈페이지 URL(homepage_url) 데이터를 넣었습니다.
- ERD에도 추가했어요. 
- 변경 과정은 노션에 정리해뒀습니다.

## 🚨 **참고 사항**
- 강남 병원에 대한 데이터만 존재하는 상태입니다.
- 키워드나 홈페이지 URL이 없을 경우 null로 전달됩니다. 