### PR TITLE
Fix: locationType과 locationId에 대한 검증 로직 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
@@ -3,20 +3,22 @@ package com.cocos.cocos.api.hospital.dto.request;
 import com.cocos.cocos.enums.hospital.HospitalSortCriteria;
 import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.location.HasLocation;
+import com.cocos.cocos.validation.location.LocationConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 
-
 @Builder
+@LocationConstraint
 public record HospitalListRequest(
 
         @Schema(description = "지역 타입",nullable = true, example = "CITY")
         LocationType locationType,
 
         @Schema(description = "지역 아이디", nullable = true, example = "1")
-        Long locationId, // TODO: 유효성 검증 로직 추가
+        Long locationId,
 
         @Schema(description = "마지막으로 조회된 병원 아이디 (첫 요청을 제외하고 필수로 보내야 합니다.)", nullable = true, example = "1")
         @HospitalIdConstraint
@@ -35,5 +37,5 @@ public record HospitalListRequest(
 
         @Schema(description = "정렬 기준", nullable = true, example = "REVIEW")
         HospitalSortCriteria sortBy
-) {
+) implements HasLocation {
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/request/HospitalListRequest.java
@@ -8,9 +8,7 @@ import com.cocos.cocos.validation.location.LocationConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import lombok.Builder;
 
-@Builder
 @LocationConstraint
 public record HospitalListRequest(
 

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
@@ -1,8 +1,13 @@
 package com.cocos.cocos.api.member.dto.request;
 
 import com.cocos.cocos.enums.location.LocationType;
+import com.cocos.cocos.validation.location.HasLocation;
+import com.cocos.cocos.validation.location.LocationConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
+@LocationConstraint
 public record ProfileUpdateRequest(
         @Schema(description = "닉네임", example = "코코스")
         String nickname,
@@ -21,8 +26,8 @@ public record ProfileUpdateRequest(
         @Schema(description = "경도", example = "128.xxx")
         Double longitude,
         @Schema(description = "위치 아이디", example = "1")
-        Long locationId,  // TODO: 유효성 검증 로직 추가
+        Long locationId,
         @Schema(description = "위치 종류", example = "CITY | DISTRICT")
         LocationType locationType
-) {
+) implements HasLocation {
 }

--- a/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/member/dto/request/ProfileUpdateRequest.java
@@ -4,9 +4,7 @@ import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.validation.location.HasLocation;
 import com.cocos.cocos.validation.location.LocationConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 
-@Builder
 @LocationConstraint
 public record ProfileUpdateRequest(
         @Schema(description = "닉네임", example = "코코스")

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
@@ -10,9 +10,7 @@ import com.cocos.cocos.validation.review.SummaryOptionIdConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import lombok.Builder;
 
-@Builder
 @LocationConstraint
 public record ReviewListRequest(
         @Schema(description = "리뷰 요약 아이디", example = "1", nullable = true)

--- a/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
+++ b/src/main/java/com/cocos/cocos/api/review/dto/request/ReviewListRequest.java
@@ -3,12 +3,17 @@ package com.cocos.cocos.api.review.dto.request;
 import com.cocos.cocos.enums.location.LocationType;
 import com.cocos.cocos.validation.body.BodyIdConstraint;
 import com.cocos.cocos.validation.hospital.HospitalIdConstraint;
+import com.cocos.cocos.validation.location.HasLocation;
+import com.cocos.cocos.validation.location.LocationConstraint;
 import com.cocos.cocos.validation.review.ReviewIdConstraint;
 import com.cocos.cocos.validation.review.SummaryOptionIdConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import lombok.Builder;
 
+@Builder
+@LocationConstraint
 public record ReviewListRequest(
         @Schema(description = "리뷰 요약 아이디", example = "1", nullable = true)
         @SummaryOptionIdConstraint
@@ -23,16 +28,12 @@ public record ReviewListRequest(
         @BodyIdConstraint
         Long bodyId,
         @Schema(description = "지역 아이디", nullable = true, example = "1")
-        Long locationId,  // TODO: 유효성 검증 로직 추가
+        Long locationId,
         @Schema(description = "지역 타입", nullable = true, example = "DISTRICT")
         LocationType locationType,
         @Schema(description = "페이지네이션 크기 ", example = "10", defaultValue = "10")
         @Min(value = 1, message = "size는 1이상입니다.")
         @Max(value = 20, message = "size는 20이하입니다.")
         int size
-) {
-    public ReviewListRequest(final Long summaryReviewId, final Long cursorId, final Long hospitalId, final Long bodyId, final Long locationId, final LocationType locationType) {
-        this(summaryReviewId, cursorId, hospitalId, bodyId, locationId, locationType, 10);
-    }
-
+) implements HasLocation  {
 }

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -37,7 +37,9 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_PURPOSE_ID(HttpStatus.BAD_REQUEST, 40023, "유효하지 않은 방문목적 아이디 입니다. "),
     BAD_REQUEST_INVALID_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40024, "유효하지 않은 리뷰 요약 아이디입니다. "),
     BAD_REQUEST_INVALID_GOOD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40025, "유효하지 않은 좋은 리뷰 요약 아이디입니다. "),
-    BAD_REQUEST_INVALID_BAD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 440026, "유효하지 않은 나쁜 리뷰 요약 아이디입니다. "),
+    BAD_REQUEST_INVALID_BAD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40026, "유효하지 않은 나쁜 리뷰 요약 아이디입니다. "),
+    BAD_REQUEST_INVALID_CITY_ID(HttpStatus.BAD_REQUEST, 40027, "유효하지 않은 도시 아이디입니다. "),
+    BAD_REQUEST_INVALID_DISTRICT_ID(HttpStatus.BAD_REQUEST, 40028, "유효하지 않은 지역 아이디입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/validation/location/HasLocation.java
+++ b/src/main/java/com/cocos/cocos/validation/location/HasLocation.java
@@ -1,0 +1,8 @@
+package com.cocos.cocos.validation.location;
+
+import com.cocos.cocos.enums.location.LocationType;
+
+public interface HasLocation {
+    LocationType locationType();
+    Long locationId();
+}

--- a/src/main/java/com/cocos/cocos/validation/location/LocationConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/location/LocationConstraint.java
@@ -1,0 +1,21 @@
+package com.cocos.cocos.validation.location;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = LocationValidator.class)
+public @interface LocationConstraint {
+    String message() default "Invalid Location";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+//

--- a/src/main/java/com/cocos/cocos/validation/location/LocationValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/location/LocationValidator.java
@@ -1,0 +1,36 @@
+package com.cocos.cocos.validation.location;
+
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.db.city.repository.CityRepository;
+import com.cocos.cocos.db.district.repository.DistrictRepository;
+import com.cocos.cocos.enums.message.FailMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.cocos.cocos.enums.location.LocationType.CITY;
+import static com.cocos.cocos.enums.location.LocationType.DISTRICT;
+
+@Component
+@RequiredArgsConstructor
+public class LocationValidator implements ConstraintValidator<LocationConstraint, HasLocation> {
+
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
+
+    @Override
+    public boolean isValid(HasLocation request, ConstraintValidatorContext constraintValidatorContext) {
+        if (request.locationId() == null || request.locationType() == null) {
+            return true;
+        }
+
+        if (request.locationType() == CITY && !cityRepository.existsById(request.locationId())) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_CITY_ID);
+        }
+        if (request.locationType() == DISTRICT && !districtRepository.existsById(request.locationId())) {
+            throw new CocosException(FailMessage.BAD_REQUEST_INVALID_DISTRICT_ID);
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #215 

## 👷 **작업한 내용**
- locationId, locationType에 대한 검증 로직을 추가하였습니다.
- HasLocation 인터페이스 구현을 통해 공통 유효성 검증 구조 재사용 가능하도록 설계하였습니다. 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
