### PR TITLE
Fix: 리뷰 리스트 조회 시 DISTINCT 추가하여 중복 row 제거

### DIFF
--- a/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cocos/cocos/db/review/repository/ReviewRepository.java
@@ -21,7 +21,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByMemberId(final Long memberId, final Pageable pageable);
 
     @Query("""
-                SELECT r FROM Review r
+                SELECT DISTINCT r FROM Review r
                 JOIN ReviewSummary s ON r.id = s.reviewId
                 WHERE r.hospitalId = :hospitalId
                 AND (:summaryOptionId IS NULL OR s.reviewSummaryOptionId = :summaryOptionId)
@@ -32,7 +32,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     );
 
     @Query("""
-                SELECT r FROM Review r
+                SELECT DISTINCT r FROM Review r
                 JOIN ReviewSummary s ON r.id = s.reviewId
                 WHERE (:reviewIds IS NULL OR r.id IN :reviewIds)
                 AND (:summaryOptionId IS NULL OR s.reviewSummaryOptionId = :summaryOptionId)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #240 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 리뷰 리스트 조회 API에서 Review 와 ReviewSummary 를 JOIN 하여 데이터를 조회할 때,
Review 기준으로 중복 row 가 발생하여 페이지네이션 size 만큼 리뷰가 반환되지 않는 문제가 있었습니다.
- size = 4 요청 → 실제 반환 개수 2개와 같은 현상 발생 
- Review 기준 중복 row 를 제거하기 위해 JPQL 에 DISTINCT 추가

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
