### PR TITLE
Fix: 위치 리스트 조회 시 응답 값 수정

### DIFF
--- a/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
+++ b/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
@@ -2,9 +2,10 @@ package com.cocos.cocos.api.location.dto.response;
 
 public record DistrictResponse(
         Long id,
-        String name
+        String name,
+        String locationType
 ) {
-    public static DistrictResponse of(final Long id, final String name) {
-        return new DistrictResponse(id, name);
+    public static DistrictResponse of(final Long id, final String name, final String locationType) {
+        return new DistrictResponse(id, name, locationType);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
+++ b/src/main/java/com/cocos/cocos/api/location/dto/response/DistrictResponse.java
@@ -3,9 +3,9 @@ package com.cocos.cocos.api.location.dto.response;
 public record DistrictResponse(
         Long id,
         String name,
-        String locationType
+        String type
 ) {
-    public static DistrictResponse of(final Long id, final String name, final String locationType) {
-        return new DistrictResponse(id, name, locationType);
+    public static DistrictResponse of(final Long id, final String name, final String type) {
+        return new DistrictResponse(id, name, type);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
+++ b/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
@@ -7,11 +7,12 @@ import com.cocos.cocos.db.city.entity.City;
 import com.cocos.cocos.db.city.repository.CityRepository;
 import com.cocos.cocos.db.district.entity.District;
 import com.cocos.cocos.db.district.repository.DistrictRepository;
+import com.cocos.cocos.enums.location.LocationType;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,8 @@ public class LocationService {
     private final DistrictRepository districtRepository;
     private final CityRepository cityRepository;
 
+    private static final String ALL_CITY_LABEL = " 전체";
+
     @Transactional(readOnly = true)
     public LocationResponse getLocations() {
         final List<City> cities = cityRepository.findAll();
@@ -27,12 +30,22 @@ public class LocationService {
                 cities.stream()
                         .map(city -> {
                             final List<District> districts = districtRepository.findAllByCityId(city.getId());
+                            final List<DistrictResponse> districtResponses = new ArrayList<>(List.of(
+                                    DistrictResponse.of(city.getId(), city.getName() + ALL_CITY_LABEL,
+                                            LocationType.CITY.toString())
+                            ));
+                            districtResponses.addAll(
+                                    districts.stream()
+                                            .map(district -> DistrictResponse.of(district.getId(), district.getName(),
+                                                    LocationType.DISTRICT.toString()))
+                                            .toList()
+                            );
+
                             return CityResponse.of(
                                     city.getId(),
                                     city.getName(),
-                                    districts.stream()
-                                            .map(district -> DistrictResponse.of(district.getId(), district.getName()))
-                                            .toList());
+                                    districtResponses
+                            );
 
                         })
                         .toList()

--- a/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
+++ b/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
@@ -21,7 +21,7 @@ public class LocationService {
     private final DistrictRepository districtRepository;
     private final CityRepository cityRepository;
 
-    private static final String ALL_CITY_LABEL = " 전체";
+    private static final String ALL_CITY_NAME_SUFFIX = " 전체";
 
     @Transactional(readOnly = true)
     public LocationResponse getLocations() {
@@ -31,7 +31,7 @@ public class LocationService {
                         .map(city -> {
                             final List<District> districts = districtRepository.findAllByCityId(city.getId());
                             final List<DistrictResponse> districtResponses = new ArrayList<>(List.of(
-                                    DistrictResponse.of(city.getId(), city.getName() + ALL_CITY_LABEL,
+                                    DistrictResponse.of(city.getId(), city.getName() + ALL_CITY_NAME_SUFFIX,
                                             LocationType.CITY.toString())
                             ));
                             districtResponses.addAll(

--- a/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
+++ b/src/main/java/com/cocos/cocos/api/location/service/LocationService.java
@@ -32,12 +32,12 @@ public class LocationService {
                             final List<District> districts = districtRepository.findAllByCityId(city.getId());
                             final List<DistrictResponse> districtResponses = new ArrayList<>(List.of(
                                     DistrictResponse.of(city.getId(), city.getName() + ALL_CITY_NAME_SUFFIX,
-                                            LocationType.CITY.toString())
+                                            LocationType.CITY.name())
                             ));
                             districtResponses.addAll(
                                     districts.stream()
                                             .map(district -> DistrictResponse.of(district.getId(), district.getName(),
-                                                    LocationType.DISTRICT.toString()))
+                                                    LocationType.DISTRICT.name()))
                                             .toList()
                             );
 

--- a/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
+++ b/src/test/java/com/cocos/cocos/location/LocationServiceTest.java
@@ -8,6 +8,7 @@ import com.cocos.cocos.db.city.entity.City;
 import com.cocos.cocos.db.city.repository.CityRepository;
 import com.cocos.cocos.db.district.entity.District;
 import com.cocos.cocos.db.district.repository.DistrictRepository;
+import com.cocos.cocos.enums.location.LocationType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -62,9 +63,14 @@ public class LocationServiceTest {
         BDDMockito.given(cityRepository.findAll()).willReturn(cities);
         BDDMockito.given(districtRepository.findAllByCityId(any())).willReturn(districts);
 
-        final DistrictResponse districtResponse1 = DistrictResponse.of(district1.getId(), district1.getName());
-        final DistrictResponse districtResponse2 = DistrictResponse.of(district2.getId(), district2.getName());
-        final CityResponse cityResponse = CityResponse.of(city.getId(), city.getName(), List.of(districtResponse1, districtResponse2));
+        final DistrictResponse districtResponse1 = DistrictResponse.of(district1.getId(), district1.getName(),
+                LocationType.DISTRICT.toString());
+        final DistrictResponse districtResponse2 = DistrictResponse.of(district2.getId(), district2.getName(),
+                LocationType.DISTRICT.toString());
+        final DistrictResponse cityDistrictResponse = DistrictResponse.of(city.getId(), city.getName() + " 전체",
+                LocationType.CITY.toString());
+        final CityResponse cityResponse = CityResponse.of(city.getId(), city.getName(),
+                List.of(cityDistrictResponse, districtResponse1, districtResponse2));
         final LocationResponse expected = LocationResponse.of(List.of(cityResponse));
 
         // when


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #242 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 위치 리스트 조회 시 응답 값을 수정하였습니다.
* 우선 City에 해당하는 전체를 뜻하는 구역 응답 값을 하나 만든 후, 그에 해당하는 구역 응답 값을 그 뒤에 붙이는 형식으로 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
