### PR TITLE
Fix: pet age 필드에 1 이상 유효성 검증 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ public record PetCreateRequest(
         Gender gender,
 
         @Schema(description = "나이", example = "12")
+        @Min(1)
         int age,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -5,6 +5,7 @@ import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ public record PetUpdateRequest(
         Gender gender,
 
         @Schema(description = "나이", example = "12")
+        @Min(1)
         Integer age,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
@@ -17,10 +17,13 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -94,6 +97,16 @@ public class GlobalExceptionHandler {
             return FailResponse.failure(FailMessage.INTEGRITY_CONFLICT);
         }
     }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<BaseResponse<?>> handleHandlerMethodValidationException(HandlerMethodValidationException e) {
+        final String errorMessage = Arrays.stream(Objects.requireNonNull(e.getDetailMessageArguments()))
+                .map(Object::toString)
+                .collect(Collectors.joining("\n"));
+
+        return FailResponse.failure(FailMessage.BAD_REQUEST_VALIDATION_ERROR, errorMessage);
+    }
+
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<?>> handleGeneralException(Exception e) {

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -36,7 +36,7 @@ public class Pet extends BaseTime {
     @Column(name = "breed_id", nullable = false)
     private Long breedId;
 
-    @Column(name = "image",nullable = false)
+    @Column(name = "image", nullable = false)
     private String image;
 
     @Builder
@@ -50,10 +50,17 @@ public class Pet extends BaseTime {
     }
 
     public void updateFields(final String name, final Gender gender, final Integer age, final Long breedId) {
-        //ToDo: {}작성하는 것이 의미를 더 명확하고 이후 예기치 못한 오류를 예방할 수 있어 보임
-        if (name != null) this.name = name;
-        if (gender != null) this.gender = gender;
-        if (age != null) this.age = age;
-        if (breedId != null) this.breedId = breedId;
+        if (name != null) {
+            this.name = name;
+        }
+        if (gender != null) {
+            this.gender = gender;
+        }
+        if (age != null) {
+            this.age = age;
+        }
+        if (breedId != null) {
+            this.breedId = breedId;
+        }
     }
 }

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.db.pet.entity;
 import com.cocos.cocos.db.BaseTime;
 import com.cocos.cocos.enums.pet.Gender;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,7 @@ public class Pet extends BaseTime {
     private Gender gender;
 
     @Column(name = "age", nullable = false)
+    @Min(1)
     private int age;
 
     @Column(name = "member_id", nullable = false)

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -40,6 +40,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_BAD_SUMMARY_OPTION_ID(HttpStatus.BAD_REQUEST, 40026, "유효하지 않은 나쁜 리뷰 요약 아이디입니다. "),
     BAD_REQUEST_INVALID_CITY_ID(HttpStatus.BAD_REQUEST, 40027, "유효하지 않은 도시 아이디입니다. "),
     BAD_REQUEST_INVALID_DISTRICT_ID(HttpStatus.BAD_REQUEST, 40028, "유효하지 않은 지역 아이디입니다. "),
+    BAD_REQUEST_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, 40029, "요청에 유효하지 않은 데이터가 있습니다. "),
     /**
      * 401
      */


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #244 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- PetCreateRequest age 필드에 1 이상 유효성 검증 추가
- PetUpdateRequest age 필드에 1 이상 유효성 검증 추가
- 유효성 검증 실패 시 `HandlerMethodValidationException`이 발생하며, 이를 처리하는 handler에서 필드명 + 에러 메시지를 포함한 응답을 반환하도록 하였습니다. 
<img width="367" alt="image" src="https://github.com/user-attachments/assets/a3383a57-bbaf-4720-8599-0c83a94f36b5" />



## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
- Spring Boot 3 이상에서는 메서드 파라미터에 직접 `@Min`, `@NotBlank` 등의 constraint 어노테이션이 선언된 경우, 
개별 argument validation이 아닌 메서드 단위 validation이 적용되며, 이때 발생하는 예외는 MethodArgumentNotValidException이 아니라 HandlerMethodValidationException입니다.

- Applications must handle both MethodArgumentNotValidException and HandlerMethodValidationException as either may be raised depending on the controller method signature. (https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-validation.html)