### PR TITLE
Fix: 회원 탈퇴 시 pet 삭제 전에 pet이 null인지 확인하는 코드 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -263,6 +263,10 @@ public class MemberService {
     private void deleteAboutPet(final Long memberId) {
         final Pet pet = petRepository.findByMemberId(memberId);
 
+        if (pet == null) {
+            return;
+        }
+
         petSymptomRepository.deleteAllByPetId(pet.getId());
         petDiseaseRepository.deleteAllByPetId(pet.getId());
         petRepository.deleteById(pet.getId());


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #248 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 문제: 회원 탈퇴 시 pet이 없는 사용자인 경우 NullPointerException 발생
- 해결: 회원 탈퇴 시 pet이 null인지 확인하는 코드를 추가했습니다

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
