### PR TITLE
Feat: querydsl 환경 세팅 ((OpenFeign 유지보수 버전 적용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,14 @@ dependencies {
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // query dsl
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cocos/cocos/config/QuerydslConfig.java
+++ b/src/main/java/com/cocos/cocos/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.cocos.cocos.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
+++ b/src/test/java/com/cocos/cocos/hospital/HospitalServiceTest.java
@@ -101,7 +101,9 @@ public class HospitalServiceTest {
                 new ArrayList<>(List.of("라벨1")),
                 "병원 소개",
                 "병원 도로명주소",
-                "병원 이미지"
+                "병원 이미지",
+                "",
+                ""
         );
 
         //when
@@ -158,7 +160,9 @@ public class HospitalServiceTest {
                 new ArrayList<>(List.of("라벨1")),
                 "병원 소개",
                 "병원 주소",
-                "병원 이미지"
+                "병원 이미지",
+                "",
+                ""
         );
 
         //when
@@ -219,4 +223,3 @@ public class HospitalServiceTest {
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 }
-


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #262 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 프로젝트에 QueryDSL 환경을 세팅했습니다.
- 기존 com.querydsl 버전 대신, 유지보수 이슈로 인해 [OpenFeign/querydsl](https://github.com/OpenFeign/querydsl) 버전을 선택했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
- 팀노션에 도입 이유와 세팅 방법을 적어뒀어요
https://www.notion.so/SETTING-Querydsl-24cc12bc853380f181c2e459e3afe9ea?source=copy_link
- 사용 예시 (생각해본 리팩 예시는 아래와 같습니당) 

`리포지토리 인터페이스`

```java
public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
}

public interface MemberRepositoryCustom {
    List<Member> findAdults();
}
```

`구현체`

```java
@RequiredArgsConstructor
public class MemberRepositoryImpl implements MemberRepositoryCustom {
    private final JPAQueryFactory queryFactory;

    @Override
    public List<Member> findAdults() {
        QMember member = QMember.member;
        return queryFactory
            .selectFrom(member)
            .where(member.age.goe(20))
            .fetch();
    }
}

```

`서비스에서 호출`

```java
@Service
@RequiredArgsConstructor
public class MemberService {
    private final MemberRepository memberRepository;

    public List<Member> getAdults() {
        return memberRepository.findAdults();
    }
}
```