### PR TITLE
Hotfix: 병원 상세 조회 응답에 누락된 위도, 경도 필드 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/dto/response/HospitalDetailResponse.java
@@ -20,9 +20,13 @@ public record HospitalDetailResponse(
         @Schema(description = "병원 키워드들", example = "#친절함, #강아지")
         String keywords,
         @Schema(description = "병원 홈페이지 URL", example = "https://www.~~")
-        String homepageUrl
+        String homepageUrl,
+        @Schema(description = "병원 위도", example = "36.68372225927701")
+        Double latitude,
+        @Schema(description = "병원 경도", example = "126.82909060661319")
+        Double longitude
 ) {
-    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String image, final String keywords, final String homepageUrl) {
-        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, image, keywords, homepageUrl);
+    public static HospitalDetailResponse of(final String name, final String phoneNumber, final List<String> tags, final String introduction, final String address, final String image, final String keywords, final String homepageUrl, final Double latitude, final Double longitude) {
+        return new HospitalDetailResponse(name, phoneNumber, tags, introduction, address, image, keywords, homepageUrl, latitude, longitude);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
+++ b/src/main/java/com/cocos/cocos/api/hospital/service/HospitalService.java
@@ -148,7 +148,9 @@ public class HospitalService {
                 hospital.getDisplayAddress(),
                 appDataS3Client.getPresignedUrl(hospital.getImage()),
                 hospital.getKeywords(),
-                hospital.getHomepageUrl()
+                hospital.getHomepageUrl(),
+                hospital.getLatitude(),
+                hospital.getLongitude()
         );
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #266

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 카카오맵에서 병원 위치 정보 표시하는데 필요한 필드인데 누락되어 추가했습니다. 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
