### PR TITLE
Fix: 사용자 위치(정보) 업데이트 시 불필요한 요청값 제외하고 업데이트

### DIFF
--- a/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
+++ b/src/main/java/com/cocos/cocos/api/member/service/MemberService.java
@@ -104,7 +104,9 @@ public class MemberService {
             final MemberToken memberToken = memberTokenRepository.findByMemberId(member.getId());
             memberToken.updateRefreshToken(refreshToken);
         } else {
-            memberTokenRepository.save(MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("").build());
+            memberTokenRepository.save(
+                    MemberToken.builder().memberId(member.getId()).refreshToken(refreshToken).kakaoRefreshToken("")
+                            .build());
         }
         if (!memberAddressRepository.existsByMemberId(member.getId())) {
             memberAddressRepository.save(
@@ -145,9 +147,8 @@ public class MemberService {
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER)
         );
 
-        if (address != null && roadAddress != null) {
-            updateMemberLocation(memberId, address, roadAddress, locationId, locationType, latitude, longitude);
-
+        if (locationId != null && locationType != null) {
+            updateMemberLocation(memberId, locationId, locationType);
         }
 
         if (memberRepository.existsByNickname(nickname)) {
@@ -190,7 +191,8 @@ public class MemberService {
             return null;
         }
 
-        final Hospital hospital = hospitalRepository.findById(member.getMyHospitalId()).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL));
+        final Hospital hospital = hospitalRepository.findById(member.getMyHospitalId())
+                .orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_HOSPITAL));
         return MemberHospitalResponse.of(
                 hospital.getId(),
                 hospital.getName(),
@@ -204,24 +206,24 @@ public class MemberService {
         if (!hospitalRepository.existsById(hospitalId)) {
             throw new CocosException(FailMessage.NOT_FOUND_HOSPITAL);
         }
-        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         member.updateMyHospitalId(hospitalId);
     }
 
     private Member findMember(final String nickname, final Long memberId) {
         if (nickname != null) {
-            return memberRepository.findByNickname(nickname).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+            return memberRepository.findByNickname(nickname)
+                    .orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
         }
         return memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
     }
 
-    private void updateMemberLocation(final Long memberId, final String address, final String roadAddress,
-                                      final Long locationId, final LocationType locationType,
-                                      final Double latitude, final Double longitude) {
+    private void updateMemberLocation(final Long memberId, final Long locationId, final LocationType locationType) {
         final MemberAddress memberAddress = memberAddressRepository.findByMemberId(memberId).orElseThrow(
                 () -> new CocosException(FailMessage.NOT_FOUND_MEMBER_ADDRESS)
         );
-        memberAddress.updateAddress(address, roadAddress, locationId, latitude, longitude, locationType);
+        memberAddress.updateLocation(locationId, locationType);
     }
 
     @Transactional
@@ -296,7 +298,8 @@ public class MemberService {
     }
 
     private void deleteAboutComment(final List<Long> memberWritePostIds, final Long memberId) {
-        final List<Comment> memberWriteOrDeleteTargetComments = commentRepository.findAllByPostIdInOrMemberId(memberWritePostIds, memberId);
+        final List<Comment> memberWriteOrDeleteTargetComments = commentRepository.findAllByPostIdInOrMemberId(
+                memberWritePostIds, memberId);
         final List<Long> memberWriteOrDeleteTargetCommentsIds = memberWriteOrDeleteTargetComments.stream()
                 .map(Comment::getId)
                 .toList();

--- a/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
+++ b/src/main/java/com/cocos/cocos/db/member/entity/MemberAddress.java
@@ -49,7 +49,8 @@ public class MemberAddress {
     private Double longitude;
 
     @Builder
-    public MemberAddress(final Long memberId, final String address, final String roadAddress, final Long locationId, final Double latitude, final Double longitude, final LocationType locationType) {
+    public MemberAddress(final Long memberId, final String address, final String roadAddress, final Long locationId,
+                         final Double latitude, final Double longitude, final LocationType locationType) {
         this.memberId = memberId;
         this.address = address;
         this.roadAddress = roadAddress;
@@ -59,12 +60,18 @@ public class MemberAddress {
         this.locationType = locationType;
     }
 
-    public void updateAddress(final String address, final String roadAddress, final Long locationId, final Double latitude, final Double longitude, final LocationType locationType) {
+    public void updateAddress(final String address, final String roadAddress, final Long locationId,
+                              final Double latitude, final Double longitude, final LocationType locationType) {
         this.address = address;
         this.roadAddress = roadAddress;
         this.locationId = locationId;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.locationType = locationType;
+    }
+
+    public void updateLocation(final Long locationId, final LocationType locationType) {
+        this.locationId = locationId;
         this.locationType = locationType;
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #269 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
1. 사용자 위치(정보) 업데이트 시 불필요한 요청값을 제외하고 업데이트하도록 수정했습니다.
- 기존 : address, roadAddress, locationId, latitude, longitude, locationType 요청 값으로 사용자 주소를 업데이트했습니다
- 변경 :  locationId, locationType 만으로 사용자 위치를 업데이트 하도록 메서드를 추가했습니다.
- 요청 값을 아에 제외하지 않은 이유는 두 가지입니다.
    1. 카카오맵 API 호출을 위해서 추가해놓은 요청값이었는데 이후 기능에서 다시 추가할지 아닐지 논의가 확실하게 된 부분이 없기에 남겨두었습니다.
    2. 클라이언트의 영향을 최소화하려는 목적이었습니다. (이 부분은 클라이언트 쪽에서 필드를 아에 보내지 않으면 자동으로 null값이 오기 때문에 괜찮을 듯 싶습니다.)

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 기존에 자동정렬이 안 되었는지는 모르겠지만 정렬을 하니 다음과 변경점이 많이 생겼습니다. 다음 부분이 주요 변경점이니 확인해주시면 감사하겠습니다 : )

```
        if (locationId != null && locationType != null) {
            updateMemberLocation(memberId, locationId, locationType);
        }
```

```
    public void updateLocation(final Long locationId, final LocationType locationType) {
        this.locationId = locationId;
        this.locationType = locationType;
    }
```
