### PR TITLE
Fix: CI/CD파이프라인에서 resources폴더가 이미 있는경우 무시하도록 옵션 추가

### DIFF
--- a/.github/workflows/CICD-dev.yml
+++ b/.github/workflows/CICD-dev.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: create application.yml
         run: |
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           
           touch ./application.yml

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: create application.yml
         run: |
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           
           touch ./application.yml


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #271 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
<img width="1044" height="277" alt="image" src="https://github.com/user-attachments/assets/a5ca86b7-22b3-49af-965d-ec57504f2ad8" />

* 기존 : resources폴더 안에 application.yml이 존재했지만 .gitignore에 application.yml를 추가했고, github에는 resources폴더에 아무것도 없다고 판단하여 폴더또한 존재하지 않았습니다. 
    * 따라서 파이프라인 과정에서 `mkdir ./src/main/resources`를 통해 폴더를 우선 생성하고 application.yml을 생성했습니다. 하지만 이번 flyway설정을 하면서 resource 폴더를 생성했고 이로 인해서 이미 만들어져있는 resources폴더를 추가하려고 했기 때문에 오류가 발생했습니다.

* 수정 : `mkdir ./src/main/resources`에 -p 옵션을 추가하여 이미 존재하는 경우 무시하고 넘어가도록 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->

