### PR TITLE
Feat: 게시글 작성 가능 카테고리 조회 API 개발

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostController.java
@@ -44,6 +44,11 @@ public class PostController implements PostControllerSwagger {
         return SuccessResponse.success(SuccessMessage.OK, postService.getCategories());
     }
 
+    @GetMapping("/categories/writable")
+    public ResponseEntity<BaseResponse<PostCategoriesResponse>> getWritablePostCategories() {
+        return SuccessResponse.success(SuccessMessage.OK, postService.getWritablePostCategories(PrincipalHandler.getMemberIdFromPrincipal()));
+    }
+
     @PostMapping
     public ResponseEntity<BaseResponse<PostImagesResponse>> addPost(
             @RequestBody @Valid final PostRequest postRequest

--- a/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/post/controller/PostControllerSwagger.java
@@ -39,6 +39,12 @@ public interface PostControllerSwagger {
             description = "게시글 카테고리 리스트 조회 성공")
     public ResponseEntity<BaseResponse<PostCategoriesResponse>> getPostCategories();
 
+    @Operation(summary = "게시글 작성 가능 카테고리 리스트 API", description = "게시글 작성 가능 카테고리 리스트를 조회하는 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "게시글 작성 가능 카테고리 리스트 조회 성공")
+    public ResponseEntity<BaseResponse<PostCategoriesResponse>> getWritablePostCategories();
+
     @Operation(summary = "게시글 추가 API", description = "게시글을 추가하는 API입니다.")
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -182,6 +182,25 @@ public class PostService {
                 .toList());
     }
 
+    @Transactional(readOnly = true)
+    public PostCategoriesResponse getWritablePostCategories(final Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+
+        final List<PostCategory> postCategories = getWritableCategories(member.isAdmin());
+
+        return PostCategoriesResponse.of(postCategories.stream()
+                .map(postCategory -> PostCategoryResponse.of(postCategory.getId(), postCategory.getName(), appDataS3Client.getPresignedUrl(postCategory.getImage())))
+                .toList());
+    }
+
+    private List<PostCategory> getWritableCategories(final boolean isAdmin) {
+        if (isAdmin) {
+            return postCategoryRepository.findAll();
+        } else {
+            return postCategoryRepository.findAllByIsAdminOnlyFalse();
+        }
+    }
+
     @Transactional
     public PostImagesResponse addPost(final Long memberId, final Long categoryId, final String title,
                                       final String content, final List<String> images, final Long animalId,

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
         BLACK_LIST_GET_METHOD_URL_IN_WHITE_LIST = new String[]{
                 apiPrefix + "/posts/members",
                 apiPrefix + "/comments/members",
-                apiPrefix + "/hospitals/reviews/members"
+                apiPrefix + "/hospitals/reviews/members",
+                apiPrefix + "/posts/categories/writable"
         };
 
         BLACK_LIST_POST_METHOD_URL_IN_WHITE_LIST = new String[]{

--- a/src/main/java/com/cocos/cocos/db/post/entity/PostCategory.java
+++ b/src/main/java/com/cocos/cocos/db/post/entity/PostCategory.java
@@ -22,9 +22,13 @@ public class PostCategory {
     @Column(name = "image", nullable = false)
     private String image;
 
+    @Column(name = "is_admin_only", nullable = false)
+    private boolean isAdminOnly;
+
     @Builder
-    public PostCategory(String name, String image) {
+    public PostCategory(String name, String image, boolean isAdminOnly) {
         this.name = name;
         this.image = image;
+        this.isAdminOnly = isAdminOnly;
     }
 }

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostCategoryRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostCategoryRepository.java
@@ -4,6 +4,10 @@ import com.cocos.cocos.db.post.entity.PostCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostCategoryRepository extends JpaRepository<PostCategory, Long> {
+
+    List<PostCategory> findAllByIsAdminOnlyFalse();
 }

--- a/src/main/resources/db/migration/V0.3__add_is_admin_only_to_post_category.sql
+++ b/src/main/resources/db/migration/V0.3__add_is_admin_only_to_post_category.sql
@@ -1,0 +1,3 @@
+ALTER TABLE post_category
+ADD COLUMN is_admin_only BOOLEAN NOT NULL DEFAULT FALSE
+COMMENT '관리자 전용 카테고리 여부';

--- a/src/main/resources/db/migration/V0.3__add_is_admin_only_to_post_category.sql
+++ b/src/main/resources/db/migration/V0.3__add_is_admin_only_to_post_category.sql
@@ -1,3 +1,2 @@
 ALTER TABLE post_category
-ADD COLUMN is_admin_only BOOLEAN NOT NULL DEFAULT FALSE
-COMMENT '관리자 전용 카테고리 여부';
+ADD COLUMN is_admin_only BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -534,7 +534,7 @@ class PostServiceTest {
     @DisplayName("어드민 권한을 가진 사용자의 경우 admin-only 카테고리를 포함한 4개의 카테고리를 조회할 수 있다.")
     void getWritablePostCategories_admin_includesAdminOnlyCategory() {
         // given
-        Long memberId = 1L;
+        final Long memberId = 1L;
         Member admin = Member.builder()
                 .isAdmin(true)
                 .build();
@@ -564,7 +564,7 @@ class PostServiceTest {
                 .isAdminOnly(true)
                 .build();
 
-        List<PostCategory> categories = List.of(
+        final List<PostCategory> categories = List.of(
                 postCategory1, postCategory2, postCategory3, postCategory4
         );
 
@@ -576,7 +576,7 @@ class PostServiceTest {
                 .willReturn("presigned-url");
 
         // when
-        PostCategoriesResponse response =
+        final PostCategoriesResponse response =
                 postService.getWritablePostCategories(memberId);
 
         // then
@@ -590,7 +590,7 @@ class PostServiceTest {
     @DisplayName("어드민 권한을 가지지 않은 사용자의 경우 admin-only 카테고리를 제외한 3개의 카테고리를 조회할 수 있다.")
     void getWritablePostCategories_nonAdmin_excludesAdminOnlyCategory() {
         // given
-        Long memberId = 2L;
+        final Long memberId = 2L;
         Member user = Member.builder()
                 .isAdmin(false)
                 .build();
@@ -614,7 +614,7 @@ class PostServiceTest {
                 .isAdminOnly(false)
                 .build();
 
-        List<PostCategory> categories = List.of(
+        final List<PostCategory> categories = List.of(
                 postCategory1, postCategory2, postCategory3
         );
 
@@ -626,7 +626,7 @@ class PostServiceTest {
                 .willReturn("presigned-url");
 
         // when
-        PostCategoriesResponse response =
+        final PostCategoriesResponse response =
                 postService.getWritablePostCategories(memberId);
 
         // then

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -48,6 +48,7 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -528,4 +529,111 @@ class PostServiceTest {
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("어드민 권한을 가진 사용자의 경우 admin-only 카테고리를 포함한 4개의 카테고리를 조회할 수 있다.")
+    void getWritablePostCategories_admin_includesAdminOnlyCategory() {
+        // given
+        Long memberId = 1L;
+        Member admin = Member.builder()
+                .isAdmin(true)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", memberId);
+
+        final PostCategory postCategory1 = PostCategory.builder()
+                .name("증상·질병")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        final PostCategory postCategory2 = PostCategory.builder()
+                .name("병원고민")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        final PostCategory postCategory3 = PostCategory.builder()
+                .name("일상·치유")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        final PostCategory postCategory4 = PostCategory.builder()
+                .name("코코스매거진")
+                .image("")
+                .isAdminOnly(true)
+                .build();
+
+        List<PostCategory> categories = List.of(
+                postCategory1, postCategory2, postCategory3, postCategory4
+        );
+
+        BDDMockito.given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(admin));
+        BDDMockito.given(postCategoryRepository.findAll())
+                .willReturn(categories);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(any()))
+                .willReturn("presigned-url");
+
+        // when
+        PostCategoriesResponse response =
+                postService.getWritablePostCategories(memberId);
+
+        // then
+        Assertions.assertThat(response.categories())
+                .hasSize(4)
+                .extracting(PostCategoryResponse::name)
+                .contains("코코스매거진");
+    }
+
+    @Test
+    @DisplayName("어드민 권한을 가지지 않은 사용자의 경우 admin-only 카테고리를 제외한 3개의 카테고리를 조회할 수 있다.")
+    void getWritablePostCategories_nonAdmin_excludesAdminOnlyCategory() {
+        // given
+        Long memberId = 2L;
+        Member user = Member.builder()
+                .isAdmin(false)
+                .build();
+        ReflectionTestUtils.setField(user, "id", memberId);
+
+        final PostCategory postCategory1 = PostCategory.builder()
+                .name("증상·질병")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        final PostCategory postCategory2 = PostCategory.builder()
+                .name("병원고민")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        final PostCategory postCategory3 = PostCategory.builder()
+                .name("일상·치유")
+                .image("")
+                .isAdminOnly(false)
+                .build();
+
+        List<PostCategory> categories = List.of(
+                postCategory1, postCategory2, postCategory3
+        );
+
+        BDDMockito.given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(user));
+        BDDMockito.given(postCategoryRepository.findAllByIsAdminOnlyFalse())
+                .willReturn(categories);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(any()))
+                .willReturn("presigned-url");
+
+        // when
+        PostCategoriesResponse response =
+                postService.getWritablePostCategories(memberId);
+
+        // then
+        Assertions.assertThat(response.categories())
+                .hasSize(3)
+                .extracting(PostCategoryResponse::name)
+                .doesNotContain("코코스매거진");
+    }
+
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #288

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 사용자 권한에 따라 게시글 작성 가능 리스트를 조회하는 API를 개발했습니다.
- Admin 권한을 가진 사용자 -> 4개 카테고리 조회 가능
- Admin 권한을 가지지 않은 사용자 -> 3개 카테고리 조회 가능 (매거진 제외)

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
- 명세서는 작성 완료했습니다. 
- 프론트에 기존 엔드포인트 변경 요청할 예정입니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시물 카테고리용 별도 조회 엔드포인트 추가(쓰기 가능한 카테고리 전용 목록 제공).
  * 카테고리에 관리자 전용 표시(isAdminOnly) 도입 — 관리자에게는 전체 카테고리, 일반 사용자에게는 관리자 전용 항목이 자동으로 제외되어 표시됩니다.

* **Chores**
  * 카테고리 필드를 위한 데이터베이스 스키마 업데이트가 포함되었습니다.

* **Tests**
  * 관리자/비관리자 경로에 대한 단위 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->