### PR TITLE
Hotfix: delete 이후 명시적으로 flush 호출

### DIFF
--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -119,6 +119,7 @@ public class PetService {
 
         if (petUpdateRequest.diseaseIds() != null) {
             petDiseaseRepository.deleteAllByPetId(petId);
+            petDiseaseRepository.flush();
             if (!petUpdateRequest.diseaseIds().isEmpty()) {
                 validatePetDiseases(petUpdateRequest.diseaseIds());
                 savePetDiseases(petUpdateRequest.diseaseIds(), pet.getId());
@@ -127,6 +128,7 @@ public class PetService {
 
         if (petUpdateRequest.symptomIds() != null) {
             petSymptomRepository.deleteAllByPetId(petId);
+            petSymptomRepository.flush();
             if (!petUpdateRequest.symptomIds().isEmpty()) {
                 validatePetSymptoms(petUpdateRequest.symptomIds());
                 savePetSymptoms(petUpdateRequest.symptomIds(), pet.getId());


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #295

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
Pet 수정 API에서 증상/질병 관계를 갱신할 때 pet_symptom 테이블의 (pet_id, symptom_id) UNIQUE 제약 조건으로 인해
다음과 같은 오류가 발생했습니다.

`Duplicate entry 'petId-symptomId' for key 'pet_symptom.UK...'`

같은 트랜잭션 내에서 bulk delete 이후 insert가 수행될 때 JPA의 flush 타이밍 문제로 인해
DELETE가 DB에 반영되기 전에 INSERT가 먼저 실행되면서 발생한 문제였습니다.

DELETE 이후 INSERT 전에 명시적으로 flush를 호출하여
DB 반영 순서를 보장하도록 수정했습니다.

```
petSymptomRepository.deleteAllByPetId(petId);
petSymptomRepository.flush();

```

질병(pet_disease) 관계도 동일한 방식으로 처리했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 펫의 질병 및 증상 정보 업데이트 시 데이터 처리 안정성 개선: 기존 질병 및 증상 정보를 삭제한 후 새로운 정보를 등록하는 과정에서 데이터 일관성과 무결성이 더욱 보장되어 신뢰할 수 있는 업데이트 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->