### PR TITLE
Fix: 좋아요 카운트 원자적 업데이트

### DIFF
--- a/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostLikeService.java
@@ -29,21 +29,23 @@ public class PostLikeService {
 
     @Transactional
     public void addPostLike(final Long memberId, final Long postId) {
+
         postLikeRepository.save(
                 PostLike.builder()
                         .memberId(memberId)
                         .postId(postId)
                         .build()
         );
-        final Post post = postRepository.findById(postId).orElseThrow(
-                () -> new CocosException(FailMessage.NOT_FOUND_POST)
-        );
 
-        post.addLike();
-        final int likeCount = post.getLikeCount();
-        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+        postRepository.increaseLikeCount(postId);
+
+        final int likeCount = postRepository.findLikeCount(postId);
+
 
         if (isLikeMilestone(likeCount)) {
+            final Post post = postRepository.findById(postId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_POST));
+            final Member member = memberRepository.findById(memberId).orElseThrow(() -> new CocosException(FailMessage.NOT_FOUND_MEMBER));
+
             eventPublisher.publishEvent(
                     new PostLikeMilestoneEvent(postId, post.getMemberId(), post.getTitle(), memberId, member.getNickname(), likeCount)
             );

--- a/src/main/java/com/cocos/cocos/db/post/entity/Post.java
+++ b/src/main/java/com/cocos/cocos/db/post/entity/Post.java
@@ -1,7 +1,12 @@
 package com.cocos.cocos.db.post.entity;
 
 import com.cocos.cocos.db.BaseTime;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,10 +45,6 @@ public class Post extends BaseTime {
         this.content = content;
         this.memberId = memberId;
         this.categoryId = categoryId;
-    }
-
-    public void addLike() {
-        this.likeCount++;
     }
 
     public boolean isMagazine() {

--- a/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
+++ b/src/main/java/com/cocos/cocos/db/post/repository/PostRepository.java
@@ -4,6 +4,7 @@ import com.cocos.cocos.db.post.entity.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -22,4 +23,19 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     List<Post> findAllByMemberId(final Long memberId);
 
     void deleteAllByMemberId(final Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+                update Post p
+                set p.likeCount = p.likeCount + 1
+                where p.id = :postId
+            """)
+    void increaseLikeCount(@Param("postId") final Long postId);
+
+    @Query("""
+                select p.likeCount
+                from Post p
+                where p.id = :postId
+            """)
+    int findLikeCount(@Param("postId") final Long postId);
 }

--- a/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostLikeServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,19 +58,22 @@ class PostLikeServiceTest {
         Long postId = 1L;
         Long postOwnerId = 10L;
         Long memberId = 20L;
+        int likeCount = 10;
 
         Post post = Post.builder()
                 .memberId(postOwnerId)
                 .title("게시글 제목")
                 .build();
         ReflectionTestUtils.setField(post, "id", postId);
-        ReflectionTestUtils.setField(post, "likeCount", 9);
 
         Member member = Member.builder()
                 .nickname("닉네임")
                 .build();
         ReflectionTestUtils.setField(member, "id", memberId);
 
+        willDoNothing().given(postRepository).increaseLikeCount(postId);
+        given(postRepository.findLikeCount(postId))
+                .willReturn(likeCount);
         given(postRepository.findById(postId))
                 .willReturn(Optional.of(post));
         given(memberRepository.findById(memberId))
@@ -88,7 +92,7 @@ class PostLikeServiceTest {
         assertThat(event.postId()).isEqualTo(postId);
         assertThat(event.postOwnerId()).isEqualTo(postOwnerId);
         assertThat(event.actorId()).isEqualTo(memberId);
-        assertThat(event.likeCount()).isEqualTo(10);
+        assertThat(event.likeCount()).isEqualTo(likeCount);
     }
 
     @Test
@@ -96,23 +100,11 @@ class PostLikeServiceTest {
         // given
         Long postId = 1L;
         Long memberId = 20L;
+        int likeCount = 3;
 
-        Post post = Post.builder()
-                .memberId(10L)
-                .title("게시글 제목")
-                .build();
-        ReflectionTestUtils.setField(post, "id", postId);
-        ReflectionTestUtils.setField(post, "likeCount", 3);
-
-        Member member = Member.builder()
-                .nickname("닉네임")
-                .build();
-        ReflectionTestUtils.setField(member, "id", memberId);
-
-        given(postRepository.findById(postId))
-                .willReturn(Optional.of(post));
-        given(memberRepository.findById(memberId))
-                .willReturn(Optional.of(member));
+        willDoNothing().given(postRepository).increaseLikeCount(postId);
+        given(postRepository.findLikeCount(postId))
+                .willReturn(likeCount);
 
         // when
         postLikeService.addPostLike(memberId, postId);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #305 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

- 엔티티 기반 `likeCount++`  방식으로 인해 동시 요청 시 lost update 및 알림 마일스톤 판단 오류 가능성이 있었습니다.
- DB에서` likeCount = likeCount +1` 원자적 업데이트를 사용하고, 마일스톤 판단은 영속성 컨텍스트를 거치지 않도록 변경했습니다.
- 동시성 환경에서도` likeCount `정합성을 보장하고, 마일스톤 알림 누락 가능성을 제거했습니다. 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->

`@Modifying(flushAutomatically = true)`
→ JPQL UPDATE 실행 전에 영속성 컨텍스트에 남아 있던 변경 사항을 DB에 먼저 반영하여 쿼리 실행 순서를 보장함

`@Modifying(clearAutomatically = true)`
→ JPQL UPDATE 이후 영속성 컨텍스트를 초기화하여, DB와 JPA 상태 불일치를 방지함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 게시물 좋아요 기능의 내부 처리 로직을 최적화했습니다. 좋아요 카운팅이 더욱 효율적으로 작동하도록 개선되었습니다.

* **테스트**
  * 좋아요 기능 관련 테스트를 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->