### PR TITLE
Feat: Test Controller 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,13 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
+tasks.withType(JavaCompile).configureEach {
+    if (project.hasProperty('prod')) {
+        exclude("**/TestAuthController*.java")
+    }
+}
+
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/src/main/java/com/cocos/cocos/config/SecurityConfig.java
+++ b/src/main/java/com/cocos/cocos/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.cocos.cocos.auth.CustomJwtAuthenticationEntryPoint;
 import com.cocos.cocos.auth.JwtAuthenticationFilter;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +20,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
-@Slf4j
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
@@ -42,6 +40,7 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
                 apiPrefix + "/test/health-check",
+                apiPrefix + "/test/auth/login",
                 apiPrefix + "/symptoms",
                 apiPrefix + "/diseases",
                 apiPrefix + "/bodies",

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
@@ -1,0 +1,43 @@
+package com.cocos.cocos.test.controller;
+
+import com.cocos.cocos.api.member.dto.response.TokenResponse;
+import com.cocos.cocos.auth.JwtProvider;
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
+import com.cocos.cocos.test.dto.FakeLoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api.prefix}/test/auth")
+@RequiredArgsConstructor
+@Profile({"local", "dev", "test"})
+public class TestAuthController implements TestAuthControllerSwagger {
+
+    private final JwtProvider jwtProvider;
+
+    @Value("${test.auth-secret}")
+    private String testAuthSecret;
+
+    @PostMapping("/login")
+    public ResponseEntity<List<TokenResponse>> fakeLogin(
+            @RequestHeader("X-Test-Auth-Secret") final String secretKey,
+            @RequestBody final FakeLoginRequest request) {
+        
+        if (!testAuthSecret.equals(secretKey)) {
+            throw new CocosException(FailMessage.UNAUTHORIZED);
+        }
+
+        final List<TokenResponse> tokens = request.memberIds().stream()
+                .map(jwtProvider::reissueToken
+                )
+                .toList();
+
+        return ResponseEntity.ok(tokens);
+    }
+}

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.MessageDigest;
 import java.util.List;
 
 @RestController
@@ -33,7 +34,7 @@ public class TestAuthController implements TestAuthControllerSwagger {
             return ResponseEntity.ok(List.of());
         }
 
-        if (!testAuthSecret.equals(secretKey)) {
+        if (!MessageDigest.isEqual(testAuthSecret.getBytes(), secretKey.getBytes())) {
             throw new CocosException(FailMessage.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
@@ -35,6 +35,10 @@ public class TestAuthController implements TestAuthControllerSwagger {
             throw new CocosException(FailMessage.UNAUTHORIZED);
         }
 
+        if (request.memberIds() == null || request.memberIds().isEmpty()) {
+            return ResponseEntity.ok(List.of());
+        }
+
         final List<TokenResponse> tokens = request.memberIds().stream()
                 .map(jwtProvider::reissueToken
                 )

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.List;
 
@@ -30,11 +31,7 @@ public class TestAuthController implements TestAuthControllerSwagger {
             @RequestHeader("X-Test-Auth-Secret") final String secretKey,
             @RequestBody final FakeLoginRequest request) {
 
-        if (request.memberIds() == null || request.memberIds().isEmpty()) {
-            return ResponseEntity.ok(List.of());
-        }
-
-        if (!MessageDigest.isEqual(testAuthSecret.getBytes(), secretKey.getBytes())) {
+        if (!MessageDigest.isEqual(testAuthSecret.getBytes(StandardCharsets.UTF_8), secretKey.getBytes(StandardCharsets.UTF_8))) {
             throw new CocosException(FailMessage.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthController.java
@@ -28,7 +28,11 @@ public class TestAuthController implements TestAuthControllerSwagger {
     public ResponseEntity<List<TokenResponse>> fakeLogin(
             @RequestHeader("X-Test-Auth-Secret") final String secretKey,
             @RequestBody final FakeLoginRequest request) {
-        
+
+        if (request.memberIds() == null || request.memberIds().isEmpty()) {
+            return ResponseEntity.ok(List.of());
+        }
+
         if (!testAuthSecret.equals(secretKey)) {
             throw new CocosException(FailMessage.UNAUTHORIZED);
         }

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
@@ -1,0 +1,30 @@
+package com.cocos.cocos.test.controller;
+
+import com.cocos.cocos.api.member.dto.response.TokenResponse;
+import com.cocos.cocos.test.dto.FakeLoginRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.List;
+
+@Tag(name = "Test Auth Controller", description = "테스트 인증 관련 API")
+public interface TestAuthControllerSwagger {
+
+    @Operation(summary = "Test Login API", description = "테스트용 로그인 API입니다. (Local/Dev/Test only)")
+    @ApiResponse(
+            responseCode = "200",
+            description = "토큰 발급 성공",
+            content = @Content(schema = @Schema(implementation = TokenResponse.class)))
+    ResponseEntity<List<TokenResponse>> fakeLogin(
+            @Parameter(in = ParameterIn.HEADER, name = "X-Test-Auth-Secret", description = "테스트 인증 시크릿 키", required = true)
+            @RequestHeader("X-Test-Auth-Secret") final String secretKey,
+            @RequestBody final FakeLoginRequest memberIds);
+}

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
@@ -22,7 +22,7 @@ public interface TestAuthControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "토큰 발급 성공",
-            content = @Content(schema = @Schema(implementation = TokenResponse.class)))
+            content = @Content(schema = @Schema(type = "array", implementation = TokenResponse.class)))
     ResponseEntity<List<TokenResponse>> fakeLogin(
             @Parameter(in = ParameterIn.HEADER, name = "X-Test-Auth-Secret", description = "테스트 인증 시크릿 키", required = true)
             @RequestHeader("X-Test-Auth-Secret") final String secretKey,

--- a/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/test/controller/TestAuthControllerSwagger.java
@@ -26,5 +26,5 @@ public interface TestAuthControllerSwagger {
     ResponseEntity<List<TokenResponse>> fakeLogin(
             @Parameter(in = ParameterIn.HEADER, name = "X-Test-Auth-Secret", description = "테스트 인증 시크릿 키", required = true)
             @RequestHeader("X-Test-Auth-Secret") final String secretKey,
-            @RequestBody final FakeLoginRequest memberIds);
+            @RequestBody final FakeLoginRequest request);
 }

--- a/src/main/java/com/cocos/cocos/test/dto/FakeLoginRequest.java
+++ b/src/main/java/com/cocos/cocos/test/dto/FakeLoginRequest.java
@@ -1,0 +1,8 @@
+package com.cocos.cocos.test.dto;
+
+import java.util.List;
+
+public record FakeLoginRequest(
+        List<Long> memberIds
+) {
+}

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -22,7 +21,6 @@ import java.util.concurrent.Executors;
 
 @DataJpaTest
 @Import({SearchService.class,JpaAuditingConfig.class, QuerydslConfig.class })
-@ActiveProfiles("test")
 class SearchConcurrencyTest {
 
     @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,19 +25,19 @@ api:
   prefix: /api/test
 
 test:
-  auth-secret:
+  auth-secret: as
 
 aws:
-  access-key:
-  secret-key:
+  access-key: ak
+  secret-key: sk
   region: ap-northeast-2
-  app-data-s3-bucket-name:
-  member-data-s3-bucket-name:
+  app-data-s3-bucket-name: bucket
+  member-data-s3-bucket-name: bucket
 
 kakao:
-  client-id:
-  redirect-url:
-  admin-key:
+  client-id: client-id
+  redirect-url: redirect-url
+  admin-key: admin-key
 
 jwt:
-  secret:
+  secret: jwt-secret


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #311 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 테스트할 때 사용할 TestAuthController 를 생성했습니다.
- API 요청 시 header 에 인증키를 함께 전달해야 합니다.
- Prod 프로필에서는 사용할 수 없습니다. (local, test, dev only) 

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 테스트 환경용 인증 로그인 엔드포인트 추가(테스트 시크릿 검증 후 다수 사용자 토큰 발급).

* **테스트**
  * 테스트 설정값 업데이트(테스트 시크릿, AWS 자격, S3 버킷, 카카오 설정, JWT 시크릿 등).

* **Chores**
  * 운영 빌드에서 테스트 인증 엔드포인트 제외 설정 추가.
  * 특정 클래스의 불필요한 로깅 어노테이션 제거 및 테스트 로그인 경로 허용 목록에 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->