### PR TITLE
Feat: 펫 생년월일 필드 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/comment/dto/response/CommentAndSubCommentsResponse.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/response/CommentAndSubCommentsResponse.java
@@ -12,9 +12,9 @@ public record CommentAndSubCommentsResponse(
         String nickname,
         @Schema(description = "댓글 단 사용자의 프로필 이미지 주소", example = "https://")
         String profileImage,
-        @Schema(description = "댓글 단 사용자의 애완동물 종", example = "포메라니안")
+        @Schema(description = "댓글 단 사용자의 반려동물 종", example = "포메라니안")
         String breed,
-        @Schema(description = "애완동물 나이", example = "11")
+        @Schema(description = "반려동물 나이", example = "11")
         int petAge,
         @Schema(description = "댓글 내용", example = "요즘 ~~고민ㄴ이..")
         String content,
@@ -31,5 +31,3 @@ public record CommentAndSubCommentsResponse(
         return new CommentAndSubCommentsResponse(id, nickname, profileImage, breed, petAge, content, createdAt, isWriter, isPostWriter, List.copyOf(subComments));
     }
 }
-
-

--- a/src/main/java/com/cocos/cocos/api/comment/dto/response/SubCommentResponse.java
+++ b/src/main/java/com/cocos/cocos/api/comment/dto/response/SubCommentResponse.java
@@ -11,9 +11,9 @@ public record SubCommentResponse(
         String nickname,
         @Schema(description = "대댓글 사용자 프로필 사진", example = "https://")
         String profileImage,
-        @Schema(description = "대댓글 사용자 애완동물 종", example = "포메라니안")
+        @Schema(description = "대댓글 사용자 반려동물 종", example = "포메라니안")
         String breed,
-        @Schema(description = "애완동물 나이", example = "12")
+        @Schema(description = "반려동물 나이", example = "12")
         int petAge,
         @Schema(description = "대댓글 내용", example = "~~좋아요")
         String content,

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -45,8 +45,7 @@ public class CommentService {
     private final PostRepository postRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final S3PresignClient s3PresignClient;
-
-    private static final Clock CLOCK = Clock.systemDefaultZone();
+    private final Clock clock;
 
     @Transactional
     public void addPostComment(final Long postId, final String content, final Long memberId) {
@@ -252,7 +251,7 @@ public class CommentService {
                 commentMember.getNickname(),
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, commentMember.getImage()),
                 commentBreed.getName(),
-                commentPet.calculateAge(CLOCK),
+                commentPet.calculateAge(clock),
                 comment.getContent(),
                 comment.getCreatedAt(),
                 isCommentWriter(comment.getMemberId(), memberId),
@@ -278,7 +277,7 @@ public class CommentService {
                 subCommentMember.getNickname(),
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, subCommentMember.getImage()),
                 subCommentBreed.getName(),
-                subCommentPet.calculateAge(CLOCK),
+                subCommentPet.calculateAge(clock),
                 subComment.getContent(),
                 subComment.getCreatedAt(),
                 isCommentWriter(subComment.getMemberId(), memberId),

--- a/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
+++ b/src/main/java/com/cocos/cocos/api/comment/service/CommentService.java
@@ -1,6 +1,11 @@
 package com.cocos.cocos.api.comment.service;
 
-import com.cocos.cocos.api.comment.dto.response.*;
+import com.cocos.cocos.api.comment.dto.response.CommentAndSubCommentsResponse;
+import com.cocos.cocos.api.comment.dto.response.CommentsAndSubCommentsResponse;
+import com.cocos.cocos.api.comment.dto.response.MemberAllCommentsResponse;
+import com.cocos.cocos.api.comment.dto.response.MemberCommentResponse;
+import com.cocos.cocos.api.comment.dto.response.MemberSubCommentResponse;
+import com.cocos.cocos.api.comment.dto.response.SubCommentResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.breed.entity.Breed;
 import com.cocos.cocos.db.breed.repository.BreedRepository;
@@ -24,6 +29,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,6 +45,8 @@ public class CommentService {
     private final PostRepository postRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final S3PresignClient s3PresignClient;
+
+    private static final Clock CLOCK = Clock.systemDefaultZone();
 
     @Transactional
     public void addPostComment(final Long postId, final String content, final Long memberId) {
@@ -244,7 +252,7 @@ public class CommentService {
                 commentMember.getNickname(),
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, commentMember.getImage()),
                 commentBreed.getName(),
-                commentPet.getAge(),
+                commentPet.calculateAge(CLOCK),
                 comment.getContent(),
                 comment.getCreatedAt(),
                 isCommentWriter(comment.getMemberId(), memberId),
@@ -270,7 +278,7 @@ public class CommentService {
                 subCommentMember.getNickname(),
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, subCommentMember.getImage()),
                 subCommentBreed.getName(),
-                subCommentPet.getAge(),
+                subCommentPet.calculateAge(CLOCK),
                 subComment.getContent(),
                 subComment.getCreatedAt(),
                 isCommentWriter(subComment.getMemberId(), memberId),

--- a/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/pet/controller/PetControllerSwagger.java
@@ -1,9 +1,9 @@
 package com.cocos.cocos.api.pet.controller;
 
-import com.cocos.cocos.api.pet.dto.response.PetOwnerCheckResponse;
-import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
+import com.cocos.cocos.api.pet.dto.response.PetOwnerCheckResponse;
+import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.common.response.BaseResponse;
 import com.cocos.cocos.validation.member.MemberNicknameConstraint;
 import com.cocos.cocos.validation.pet.PetIdConstraint;
@@ -35,7 +35,7 @@ public interface PetControllerSwagger {
             responseCode = "200",
             description = "요청이 성공했습니다. ")
     public ResponseEntity<BaseResponse<Void>> updatePet(
-            @Parameter(name = "petId", description = "애완동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @PetIdConstraint final Long petId,
+            @Parameter(name = "petId", description = "반려동물 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Long")) @PetIdConstraint final Long petId,
             @RequestBody @Valid final PetUpdateRequest petUpdateRequest
     );
 

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.api.pet.dto.request;
 import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
+import com.cocos.cocos.validation.pet.AgeOrBirthDateRequiredConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "반려동물 생성 형식")
+@AgeOrBirthDateRequiredConstraint
 public record PetCreateRequest(
         @Schema(description = "동물 종 아이디", example = "1")
         @BreedIdConstraint

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -7,9 +7,10 @@ import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 
+import java.time.LocalDate;
 import java.util.List;
 
-@Schema(description = "애완동물 생성 형식")
+@Schema(description = "반려동물 생성 형식")
 public record PetCreateRequest(
         @Schema(description = "동물 종 아이디", example = "1")
         @BreedIdConstraint
@@ -21,9 +22,12 @@ public record PetCreateRequest(
         @Schema(description = "성별", example = "F or M")
         Gender gender,
 
-        @Schema(description = "나이", example = "12")
+        @Schema(description = "나이", example = "12", nullable = true)
         @Min(1)
-        int age,
+        Integer age, // [TODO] 프론트 배포 후 제거 필요
+
+        @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
+        LocalDate birthDate,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")
         @DiseaseIdsConstraint

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -6,6 +6,7 @@ import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,6 +28,7 @@ public record PetCreateRequest(
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
         @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
+        @PastOrPresent
         LocalDate birthDate,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -6,6 +6,7 @@ import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,6 +28,7 @@ public record PetUpdateRequest(
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
         @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
+        @PastOrPresent
         LocalDate birthDate,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]", nullable = true)

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -22,11 +22,11 @@ public record PetUpdateRequest(
         @Schema(description = "성별", example = "F or M")
         Gender gender,
 
-        @Schema(description = "나이", example = "12", nullable = true)
+        @Schema(description = "나이", example = "12")
         @Min(1)
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
-        @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
+        @Schema(description = "생년월일", example = "2020-01-01")
         LocalDate birthDate,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -12,28 +12,28 @@ import java.util.List;
 
 @Schema(description = "반려동물 수정 형식")
 public record PetUpdateRequest(
-        @Schema(description = "동물 종 아이디", example = "1")
+        @Schema(description = "동물 종 아이디", example = "1", nullable = true)
         @BreedIdConstraint
         Long breedId,
 
-        @Schema(description = "반려동물 이름", example = "포리")
+        @Schema(description = "반려동물 이름", example = "포리", nullable = true)
         String name,
 
-        @Schema(description = "성별", example = "F or M")
+        @Schema(description = "성별", example = "F or M", nullable = true)
         Gender gender,
 
-        @Schema(description = "나이", example = "12")
+        @Schema(description = "나이", example = "12", nullable = true)
         @Min(1)
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
-        @Schema(description = "생년월일", example = "2020-01-01")
+        @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
         LocalDate birthDate,
 
-        @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")
+        @Schema(description = "질병 아이디 리스트", example = "[1,2,3]", nullable = true)
         @DiseaseIdsConstraint
         List<Long> diseaseIds,
 
-        @Schema(description = "증상 아이디 리스트", example = "[1,2,3]")
+        @Schema(description = "증상 아이디 리스트", example = "[1,2,3]", nullable = true)
         @SymptomIdsConstraint
         List<Long> symptomIds
 ) {

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -7,10 +7,10 @@ import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 
+import java.time.LocalDate;
 import java.util.List;
 
-
-@Schema(description = "애완동물 수정 형식")
+@Schema(description = "반려동물 수정 형식")
 public record PetUpdateRequest(
         @Schema(description = "동물 종 아이디", example = "1")
         @BreedIdConstraint
@@ -22,9 +22,12 @@ public record PetUpdateRequest(
         @Schema(description = "성별", example = "F or M")
         Gender gender,
 
-        @Schema(description = "나이", example = "12")
+        @Schema(description = "나이", example = "12", nullable = true)
         @Min(1)
-        Integer age,
+        Integer age, // [TODO] 프론트 배포 후 제거 필요
+
+        @Schema(description = "생년월일", example = "2020-01-01", nullable = true)
+        LocalDate birthDate,
 
         @Schema(description = "질병 아이디 리스트", example = "[1,2,3]")
         @DiseaseIdsConstraint

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
@@ -32,7 +32,7 @@ public record PetResponse(
         @Schema(description = "증상 리스트")
         List<PetSymptomResponse> symptoms
 ) {
-    public static PetResponse of(final Long petId, final String petImage, final String petName, final int petAge, final LocalDate petBirtDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
+    public static PetResponse of(final Long petId, final String petImage, final String petName, final Integer petAge, final LocalDate petBirtDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
         return new PetResponse(petId, petImage, petName, petAge, petBirtDate, petGender, breedId, breed, animalId, animal, diseases, symptoms);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
@@ -3,18 +3,21 @@ package com.cocos.cocos.api.pet.dto.response;
 import com.cocos.cocos.enums.pet.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record PetResponse(
-        @Schema(description = "애완동물 아이디", example = "1")
+        @Schema(description = "반려동물 아이디", example = "1")
         Long petId,
-        @Schema(description = "애완동물 이미지", example = "url")
+        @Schema(description = "반려동물 이미지", example = "url")
         String petImage,
-        @Schema(description = "애완동물 이름", example = "펫이름")
+        @Schema(description = "반려동물 이름", example = "펫이름")
         String petName,
-        @Schema(description = "애완동물 성별", example = "12")
-        int petAge,
-        @Schema(description = "애완동물 나이", example = "M or F")
+        @Schema(description = "반려동물 나이", example = "12")
+        Integer petAge,
+        @Schema(description = "반려동물 생년월일", example = "2022-02-13")
+        LocalDate petBirthDate,
+        @Schema(description = "반려동물 성별", example = "M or F")
         Gender petGender,
         @Schema(description = "종 아이디", example = "1")
         Long breedId,
@@ -29,7 +32,7 @@ public record PetResponse(
         @Schema(description = "증상 리스트")
         List<PetSymptomResponse> symptoms
 ) {
-    public static PetResponse of(final Long petId, final String petImage, final String petName, final int petAge, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
-        return new PetResponse(petId, petImage, petName, petAge, petGender, breedId, breed, animalId, animal, diseases, symptoms);
+    public static PetResponse of(final Long petId, final String petImage, final String petName, final int petAge, final LocalDate petBirtDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
+        return new PetResponse(petId, petImage, petName, petAge, petBirtDate, petGender, breedId, breed, animalId, animal, diseases, symptoms);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
@@ -32,7 +32,7 @@ public record PetResponse(
         @Schema(description = "증상 리스트")
         List<PetSymptomResponse> symptoms
 ) {
-    public static PetResponse of(final Long petId, final String petImage, final String petName, final Integer petAge, final LocalDate petBirtDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
-        return new PetResponse(petId, petImage, petName, petAge, petBirtDate, petGender, breedId, breed, animalId, animal, diseases, symptoms);
+    public static PetResponse of(final Long petId, final String petImage, final String petName, final Integer petAge, final LocalDate petBirthDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
+        return new PetResponse(petId, petImage, petName, petAge, petBirthDate, petGender, breedId, breed, animalId, animal, diseases, symptoms);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -20,6 +20,8 @@ import com.cocos.cocos.db.pet.entity.PetSymptom;
 import com.cocos.cocos.db.pet.repository.PetDiseaseRepository;
 import com.cocos.cocos.db.pet.repository.PetRepository;
 import com.cocos.cocos.db.pet.repository.PetSymptomRepository;
+import com.cocos.cocos.db.pet.support.PetAgeResolver;
+import com.cocos.cocos.db.pet.support.PetAgeResolver.AgeAndBirthDate;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.util.List;
 
 @Service
@@ -43,6 +46,7 @@ public class PetService {
     private final SymptomRepository symptomRepository;
     private final MemberRepository memberRepository;
     private final S3PresignClient s3PresignClient;
+    private final Clock clock;
 
     //ToDo: yml에 추가하는 방향 고민 중
     private static final String PET_BASE_IMAGE_URL = "member/basePetImage.png";
@@ -54,13 +58,20 @@ public class PetService {
             throw new CocosException(FailMessage.CONFLICT_PET);
         }
 
+        AgeAndBirthDate reconciled =
+                PetAgeResolver.resolve(
+                        petCreateRequest.age(),
+                        petCreateRequest.birthDate(),
+                        clock
+                );
+
         final Pet pet = petRepository.save(
                 Pet.builder()
                         .name(petCreateRequest.name())
                         .gender(petCreateRequest.gender())
                         .image(PET_BASE_IMAGE_URL)
-                        .age(petCreateRequest.age())
-                        .birthDate(petCreateRequest.birthDate())
+                        .age(reconciled.age())
+                        .birthDate(reconciled.birthDate())
                         .memberId(memberId)
                         .breedId(petCreateRequest.breedId())
                         .build()
@@ -115,7 +126,14 @@ public class PetService {
             throw new CocosException(FailMessage.NOT_FOUND_BREED);
         }
 
-        pet.updateFields(petUpdateRequest.name(), petUpdateRequest.gender(), petUpdateRequest.age(), petUpdateRequest.birthDate(), petUpdateRequest.breedId());
+        AgeAndBirthDate reconciled =
+                PetAgeResolver.resolve(
+                        petUpdateRequest.age(),
+                        petUpdateRequest.birthDate(),
+                        clock
+                );
+
+        pet.updateFields(petUpdateRequest.name(), petUpdateRequest.gender(), reconciled.age(), reconciled.birthDate(), petUpdateRequest.breedId());
 
         if (petUpdateRequest.diseaseIds() != null) {
             petDiseaseRepository.deleteAllByPetId(petId);

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -1,11 +1,11 @@
 package com.cocos.cocos.api.pet.service;
 
+import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
+import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.api.pet.dto.response.PetDiseaseResponse;
 import com.cocos.cocos.api.pet.dto.response.PetOwnerCheckResponse;
 import com.cocos.cocos.api.pet.dto.response.PetResponse;
 import com.cocos.cocos.api.pet.dto.response.PetSymptomResponse;
-import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
-import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.animal.entity.Animal;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
@@ -25,9 +25,9 @@ import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
 import com.cocos.cocos.external.s3.S3BucketType;
 import com.cocos.cocos.external.s3.S3PresignClient;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -60,6 +60,7 @@ public class PetService {
                         .gender(petCreateRequest.gender())
                         .image(PET_BASE_IMAGE_URL)
                         .age(petCreateRequest.age())
+                        .birthDate(petCreateRequest.birthDate())
                         .memberId(memberId)
                         .breedId(petCreateRequest.breedId())
                         .build()
@@ -110,13 +111,11 @@ public class PetService {
         if (!pet.getMemberId().equals(memberId)) {
             throw new CocosException(FailMessage.FORBIDDEN_PET_UPDATE);
         }
-        if (petUpdateRequest.breedId() != null) {
-            //TODO: 리팩 필요 (if문 제거)
-            if (!breedRepository.existsById(petUpdateRequest.breedId())) {
-                throw new CocosException(FailMessage.NOT_FOUND_BREED);
-            }
+        if (petUpdateRequest.breedId() != null && !breedRepository.existsById(petUpdateRequest.breedId())) {
+            throw new CocosException(FailMessage.NOT_FOUND_BREED);
         }
-        pet.updateFields(petUpdateRequest.name(), petUpdateRequest.gender(), petUpdateRequest.age(), petUpdateRequest.breedId());
+
+        pet.updateFields(petUpdateRequest.name(), petUpdateRequest.gender(), petUpdateRequest.age(), petUpdateRequest.birthDate(), petUpdateRequest.breedId());
 
         if (petUpdateRequest.diseaseIds() != null) {
             petDiseaseRepository.deleteAllByPetId(petId);
@@ -182,6 +181,7 @@ public class PetService {
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, pet.getImage()),
                 pet.getName(),
                 pet.getAge(),
+                pet.getBirthDate(),
                 pet.getGender(),
                 breed.getId(),
                 breed.getName(),

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -1,6 +1,15 @@
 package com.cocos.cocos.api.post.service;
 
-import com.cocos.cocos.api.post.dto.response.*;
+import com.cocos.cocos.api.post.dto.response.MemberPostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.MemberPostsResponse;
+import com.cocos.cocos.api.post.dto.response.PopularPostResponse;
+import com.cocos.cocos.api.post.dto.response.PopularPostsResponse;
+import com.cocos.cocos.api.post.dto.response.PostCategoriesResponse;
+import com.cocos.cocos.api.post.dto.response.PostCategoryResponse;
+import com.cocos.cocos.api.post.dto.response.PostDetailResponse;
+import com.cocos.cocos.api.post.dto.response.PostImagesResponse;
+import com.cocos.cocos.api.post.dto.response.PostListResponse;
+import com.cocos.cocos.api.post.dto.response.PostResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.animal.entity.Animal;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
@@ -23,7 +32,11 @@ import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostCategory;
 import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.post.entity.PostTag;
-import com.cocos.cocos.db.post.repository.*;
+import com.cocos.cocos.db.post.repository.PostCategoryRepository;
+import com.cocos.cocos.db.post.repository.PostImageRepository;
+import com.cocos.cocos.db.post.repository.PostLikeRepository;
+import com.cocos.cocos.db.post.repository.PostRepository;
+import com.cocos.cocos.db.post.repository.PostTagRepository;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.message.FailMessage;
@@ -44,6 +57,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -70,6 +84,8 @@ public class PostService {
     private final PetSymptomRepository petSymptomRepository;
     private final S3PresignClient s3PresignClient;
     private final ApplicationEventPublisher eventPublisher;
+
+    private static final Clock CLOCK = Clock.systemDefaultZone();
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostDetail(final Long postId, final Long memberId) {
@@ -126,7 +142,7 @@ public class PostService {
                 .nickname(member.getNickname())
                 .profileImage(s3PresignClient.get(S3BucketType.MEMBER_DATA, member.getImage()))
                 .breed(breed.getName())
-                .petAge(pet.getAge())
+                .petAge(pet.calculateAge(CLOCK))
                 .likeCounts(likeCounts)
                 .totalCommentCounts(commentCounts + subCommentCounts)
                 .title(post.getTitle())
@@ -424,7 +440,7 @@ public class PostService {
                             return PostResponse.builder()
                                     .id(post.getId())
                                     .breed(breed.getName())
-                                    .petAge(pet.getAge())
+                                    .petAge(pet.calculateAge(CLOCK))
                                     .title(post.getTitle())
                                     .content(post.getContent())
                                     .likeCount(post.getLikeCount())
@@ -484,7 +500,7 @@ public class PostService {
                                             () -> new CocosException(FailMessage.NOT_FOUND_CATEGORY)
                                     ).getName())
                                     .breed(breed.getName())
-                                    .age(pet.getAge())
+                                    .age(pet.calculateAge(CLOCK))
                                     .build();
                         }).toList()
         );

--- a/src/main/java/com/cocos/cocos/api/post/service/PostService.java
+++ b/src/main/java/com/cocos/cocos/api/post/service/PostService.java
@@ -84,8 +84,7 @@ public class PostService {
     private final PetSymptomRepository petSymptomRepository;
     private final S3PresignClient s3PresignClient;
     private final ApplicationEventPublisher eventPublisher;
-
-    private static final Clock CLOCK = Clock.systemDefaultZone();
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostDetail(final Long postId, final Long memberId) {
@@ -142,7 +141,7 @@ public class PostService {
                 .nickname(member.getNickname())
                 .profileImage(s3PresignClient.get(S3BucketType.MEMBER_DATA, member.getImage()))
                 .breed(breed.getName())
-                .petAge(pet.calculateAge(CLOCK))
+                .petAge(pet.calculateAge(clock))
                 .likeCounts(likeCounts)
                 .totalCommentCounts(commentCounts + subCommentCounts)
                 .title(post.getTitle())
@@ -440,7 +439,7 @@ public class PostService {
                             return PostResponse.builder()
                                     .id(post.getId())
                                     .breed(breed.getName())
-                                    .petAge(pet.calculateAge(CLOCK))
+                                    .petAge(pet.calculateAge(clock))
                                     .title(post.getTitle())
                                     .content(post.getContent())
                                     .likeCount(post.getLikeCount())
@@ -500,7 +499,7 @@ public class PostService {
                                             () -> new CocosException(FailMessage.NOT_FOUND_CATEGORY)
                                     ).getName())
                                     .breed(breed.getName())
-                                    .age(pet.calculateAge(CLOCK))
+                                    .age(pet.calculateAge(clock))
                                     .build();
                         }).toList()
         );

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -51,6 +51,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
@@ -87,6 +88,8 @@ public class ReviewService {
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
     private static final int DEFAULT_PAGE_SIZE = 4;
+
+    private static final Clock CLOCK = Clock.systemDefaultZone();
 
     @Transactional
     public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -313,7 +316,7 @@ public class ReviewService {
                             member.getId(),
                             member.getNickname(),
                             memberBreed.getName(),
-                            pet.getAge(),
+                            pet.calculateAge(CLOCK),
                             hospital.getId(),
                             hospital.getName(),
                             visitedAt,

--- a/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
+++ b/src/main/java/com/cocos/cocos/api/review/service/ReviewService.java
@@ -88,8 +88,7 @@ public class ReviewService {
     private static final String REVIEW_IMAGE_S3_PREFIX = "reviewImage";
     private static final boolean IS_GOOD_REVIEW = true;
     private static final int DEFAULT_PAGE_SIZE = 4;
-
-    private static final Clock CLOCK = Clock.systemDefaultZone();
+    private final Clock clock;
 
     @Transactional
     public ReviewAddResponse addReview(final Long memberId, final Long hospitalId, final Long breedId, final Gender gender,
@@ -316,7 +315,7 @@ public class ReviewService {
                             member.getId(),
                             member.getNickname(),
                             memberBreed.getName(),
-                            pet.calculateAge(CLOCK),
+                            pet.calculateAge(clock),
                             hospital.getId(),
                             hospital.getName(),
                             visitedAt,

--- a/src/main/java/com/cocos/cocos/config/JpaAuditingConfig.java
+++ b/src/main/java/com/cocos/cocos/config/JpaAuditingConfig.java
@@ -10,8 +10,8 @@ import java.time.Clock;
 @EnableJpaAuditing
 public class JpaAuditingConfig {
 
-    @Bean
-    public Clock clock() {
+    @Bean(name = "auditingClock")
+    public Clock auditingClock() {
         return Clock.systemUTC();
     }
 }

--- a/src/main/java/com/cocos/cocos/config/TimeConfig.java
+++ b/src/main/java/com/cocos/cocos/config/TimeConfig.java
@@ -4,12 +4,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 public class TimeConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.system(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/cocos/cocos/config/TimeConfig.java
+++ b/src/main/java/com/cocos/cocos/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.cocos.cocos.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -37,9 +37,9 @@ public class Pet extends BaseTime {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Column(name = "age", nullable = false)
+    @Column(name = "age")
     @Min(1)
-    private int age;
+    private Integer age;
 
     @Column(name = "member_id", nullable = false, unique = true)
     private Long memberId;
@@ -54,7 +54,7 @@ public class Pet extends BaseTime {
     private LocalDate birthDate;
 
     @Builder
-    public Pet(final String name, final Gender gender, final int age, final LocalDate birthDate, final Long memberId, final Long breedId,
+    public Pet(final String name, final Gender gender, final Integer age, final LocalDate birthDate, final Long memberId, final Long breedId,
                final String image) {
         this.name = name;
         this.gender = gender;

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -2,11 +2,22 @@ package com.cocos.cocos.db.pet.entity;
 
 import com.cocos.cocos.db.BaseTime;
 import com.cocos.cocos.enums.pet.Gender;
-import jakarta.persistence.*;
+import com.cocos.cocos.util.PetAgeCalculator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.Clock;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -39,18 +50,22 @@ public class Pet extends BaseTime {
     @Column(name = "image", nullable = false)
     private String image;
 
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
     @Builder
-    public Pet(final String name, final Gender gender, final int age, final Long memberId, final Long breedId,
+    public Pet(final String name, final Gender gender, final int age, final LocalDate birthDate, final Long memberId, final Long breedId,
                final String image) {
         this.name = name;
         this.gender = gender;
         this.age = age;
+        this.birthDate = birthDate;
         this.memberId = memberId;
         this.breedId = breedId;
         this.image = image;
     }
 
-    public void updateFields(final String name, final Gender gender, final Integer age, final Long breedId) {
+    public void updateFields(final String name, final Gender gender, final Integer age, final LocalDate birthDate, final Long breedId) {
         if (name != null) {
             this.name = name;
         }
@@ -60,8 +75,15 @@ public class Pet extends BaseTime {
         if (age != null) {
             this.age = age;
         }
+        if (birthDate != null) {
+            this.birthDate = birthDate;
+        }
         if (breedId != null) {
             this.breedId = breedId;
         }
+    }
+
+    public int calculateAge(final Clock clock) {
+        return PetAgeCalculator.calculate(this.birthDate, clock);
     }
 }

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -1,8 +1,8 @@
 package com.cocos.cocos.db.pet.entity;
 
 import com.cocos.cocos.db.BaseTime;
+import com.cocos.cocos.db.pet.support.PetAgeCalculator;
 import com.cocos.cocos.enums.pet.Gender;
-import com.cocos.cocos.util.PetAgeCalculator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeCalculator.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeCalculator.java
@@ -1,4 +1,4 @@
-package com.cocos.cocos.util;
+package com.cocos.cocos.db.pet.support;
 
 import java.time.Clock;
 import java.time.LocalDate;

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
@@ -17,14 +17,14 @@ public final class PetAgeResolver {
             throw new IllegalArgumentException("age 또는 birthDate 중 하나는 필수입니다.");
         }
 
-        if (birthDate != null) {
-            age = PetAgeCalculator.calculate(birthDate, clock);
-        } else {
+        if (age != null && birthDate == null) {
             birthDate = LocalDate.of(
                     LocalDate.now(clock).getYear() - age,
                     1,
                     1
             );
+        } else if (age == null) {
+            age = PetAgeCalculator.calculate(birthDate, clock);
         }
 
         return new AgeAndBirthDate(age, birthDate);

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
@@ -1,0 +1,31 @@
+package com.cocos.cocos.db.pet.support;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+public final class PetAgeResolver {
+
+    private PetAgeResolver() {
+    }
+
+    public static AgeAndBirthDate resolve(
+            Integer age,
+            LocalDate birthDate,
+            Clock clock
+    ) {
+        if (age != null && birthDate == null) {
+            birthDate = LocalDate.of(
+                    LocalDate.now(clock).getYear() - age,
+                    1,
+                    1
+            );
+        } else if (age == null && birthDate != null) {
+            age = PetAgeCalculator.calculate(birthDate, clock);
+        }
+
+        return new AgeAndBirthDate(age, birthDate);
+    }
+
+    public record AgeAndBirthDate(Integer age, LocalDate birthDate) {
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
@@ -13,14 +13,18 @@ public final class PetAgeResolver {
             LocalDate birthDate,
             Clock clock
     ) {
-        if (age != null && birthDate == null) {
+        if (age == null && birthDate == null) {
+            throw new IllegalArgumentException("age 또는 birthDate 중 하나는 필수입니다.");
+        }
+
+        if (birthDate != null) {
+            age = PetAgeCalculator.calculate(birthDate, clock);
+        } else {
             birthDate = LocalDate.of(
                     LocalDate.now(clock).getYear() - age,
                     1,
                     1
             );
-        } else if (age == null && birthDate != null) {
-            age = PetAgeCalculator.calculate(birthDate, clock);
         }
 
         return new AgeAndBirthDate(age, birthDate);

--- a/src/main/java/com/cocos/cocos/util/PetAgeCalculator.java
+++ b/src/main/java/com/cocos/cocos/util/PetAgeCalculator.java
@@ -1,0 +1,18 @@
+package com.cocos.cocos.util;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Period;
+
+public final class PetAgeCalculator {
+
+    private PetAgeCalculator() {
+    }
+
+    public static int calculate(final LocalDate birthDate, final Clock clock) {
+        return Period.between(
+                birthDate,
+                LocalDate.now(clock)
+        ).getYears();
+    }
+}

--- a/src/main/java/com/cocos/cocos/validation/pet/AgeOrBirthDateRequiredConstraint.java
+++ b/src/main/java/com/cocos/cocos/validation/pet/AgeOrBirthDateRequiredConstraint.java
@@ -1,0 +1,21 @@
+package com.cocos.cocos.validation.pet;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AgeOrBirthDateRequiredValidator.class)
+public @interface AgeOrBirthDateRequiredConstraint {
+
+    String message() default "age 또는 birthDate 중 하나는 반드시 입력되어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cocos/cocos/validation/pet/AgeOrBirthDateRequiredValidator.java
+++ b/src/main/java/com/cocos/cocos/validation/pet/AgeOrBirthDateRequiredValidator.java
@@ -1,0 +1,20 @@
+package com.cocos.cocos.validation.pet;
+
+import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AgeOrBirthDateRequiredValidator
+        implements ConstraintValidator<AgeOrBirthDateRequiredConstraint, PetCreateRequest> {
+
+    @Override
+    public boolean isValid(
+            PetCreateRequest value,
+            ConstraintValidatorContext context
+    ) {
+        if (value == null) {
+            return true;
+        }
+        return value.age() != null || value.birthDate() != null;
+    }
+}

--- a/src/main/resources/db/migration/V3__add_birth_date_and_backfill_from_age.sql
+++ b/src/main/resources/db/migration/V3__add_birth_date_and_backfill_from_age.sql
@@ -1,0 +1,16 @@
+ALTER TABLE pet
+    ADD COLUMN birth_date DATE NULL
+    COMMENT '과도기: age 기반 추정 생년월일 (1월 1일 기준)';
+
+UPDATE pet
+SET birth_date = DATE(
+    CONCAT(
+        YEAR(CURDATE()) - age,
+        '-01-01'
+    )
+)
+WHERE birth_date IS NULL
+  AND age IS NOT NULL;
+
+ALTER TABLE pet
+    MODIFY age INT NULL;

--- a/src/main/resources/db/migration/V4__pet_birth_date_not_null.sql
+++ b/src/main/resources/db/migration/V4__pet_birth_date_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pet
+MODIFY birth_date DATE NOT NULL;

--- a/src/test/java/com/cocos/cocos/pet/PetServiceTest.java
+++ b/src/test/java/com/cocos/cocos/pet/PetServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +56,7 @@ class PetServiceTest {
                 "포리",
                 Gender.M,
                 12,
+                LocalDate.parse("2014-01-01"),
                 List.of(1L,2L,3L),
                 null
         );
@@ -63,6 +65,7 @@ class PetServiceTest {
                 .name("포리")
                 .gender(Gender.M)
                 .age(12)
+                .birthDate(LocalDate.parse("2014-01-01"))
                 .memberId(memberId)
                 .breedId(breedId)
                 .build();

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -46,10 +46,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -101,12 +103,10 @@ class PostServiceTest {
     private PetSymptomRepository petSymptomRepository;
     @Mock
     private S3PresignClient s3PresignClient;
-
-    private static final Clock CLOCK = Clock.fixed(
-            LocalDate.of(2026, 7, 12)
-                    .atStartOfDay(ZoneId.systemDefault())
-                    .toInstant(),
-            ZoneId.systemDefault()
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-02-10T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
     );
 
     @Test
@@ -208,7 +208,7 @@ class PostServiceTest {
                 .nickname(member.getNickname())
                 .profileImage(member.getImage())
                 .breed(Objects.requireNonNull(breed).getName())
-                .petAge(pet.calculateAge(CLOCK))
+                .petAge(6)
                 .likeCounts(likeCounts)
                 .totalCommentCounts(commentCounts + subCommentCounts)
                 .title(Objects.requireNonNull(post).getTitle())
@@ -221,11 +221,12 @@ class PostServiceTest {
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
+
         //when
         final PostDetailResponse actual = postService.getPostDetail(postId, memberId);
 
         //then
-        Assertions.assertThat(expected).usingRecursiveComparison().isEqualTo(actual);
+        Assertions.assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -27,7 +27,6 @@ import com.cocos.cocos.db.post.entity.Post;
 import com.cocos.cocos.db.post.entity.PostCategory;
 import com.cocos.cocos.db.post.entity.PostImage;
 import com.cocos.cocos.db.post.entity.PostTag;
-
 import com.cocos.cocos.db.post.repository.PostCategoryRepository;
 import com.cocos.cocos.db.post.repository.PostImageRepository;
 import com.cocos.cocos.db.post.repository.PostLikeRepository;
@@ -38,6 +37,7 @@ import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.s3.S3BucketType;
 import com.cocos.cocos.external.s3.S3PresignClient;
+import com.cocos.cocos.util.PetAgeCalculator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -50,6 +50,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -100,6 +103,13 @@ class PostServiceTest {
     @Mock
     private S3PresignClient s3PresignClient;
 
+    private static final Clock CLOCK = Clock.fixed(
+            LocalDate.of(2026, 7, 12)
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant(),
+            ZoneId.systemDefault()
+    );
+
     @Test
     @DisplayName("게시글 세부사항을 조회할 수 있다.")
     void getPostDetail() {
@@ -123,7 +133,7 @@ class PostServiceTest {
         final Pet pet = Pet.builder()
                 .name("반려동물 이름")
                 .gender(Gender.M)
-                .age(1)
+                .birthDate(LocalDate.parse("2020-01-01"))
                 .breedId(breedId)
                 .memberId(memberId)
                 .build();
@@ -199,7 +209,7 @@ class PostServiceTest {
                 .nickname(member.getNickname())
                 .profileImage(member.getImage())
                 .breed(Objects.requireNonNull(breed).getName())
-                .petAge(pet.getAge())
+                .petAge(PetAgeCalculator.calculate(pet.getBirthDate(), CLOCK))
                 .likeCounts(likeCounts)
                 .totalCommentCounts(commentCounts + subCommentCounts)
                 .title(Objects.requireNonNull(post).getTitle())

--- a/src/test/java/com/cocos/cocos/post/PostServiceTest.java
+++ b/src/test/java/com/cocos/cocos/post/PostServiceTest.java
@@ -37,7 +37,6 @@ import com.cocos.cocos.enums.pet.Gender;
 import com.cocos.cocos.enums.tag.TagType;
 import com.cocos.cocos.external.s3.S3BucketType;
 import com.cocos.cocos.external.s3.S3PresignClient;
-import com.cocos.cocos.util.PetAgeCalculator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -209,7 +208,7 @@ class PostServiceTest {
                 .nickname(member.getNickname())
                 .profileImage(member.getImage())
                 .breed(Objects.requireNonNull(breed).getName())
-                .petAge(PetAgeCalculator.calculate(pet.getBirthDate(), CLOCK))
+                .petAge(pet.calculateAge(CLOCK))
                 .likeCounts(likeCounts)
                 .totalCommentCounts(commentCounts + subCommentCounts)
                 .title(Objects.requireNonNull(post).getTitle())

--- a/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
+++ b/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
@@ -50,11 +50,15 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -73,48 +77,39 @@ class ReviewServiceTest {
 
     @Mock
     ReviewRepository reviewRepository;
-
     @Mock
     ReviewSummaryRepository reviewSummaryRepository;
-
     @Mock
     ReviewSymptomRepository reviewSymptomRepository;
-
     @Mock
     ReviewImageRepository reviewImageRepository;
-
     @Mock
     ReviewSummaryOptionRepository reviewSummaryOptionRepository;
-
     @Mock
     HospitalRepository hospitalRepository;
-
     @Mock
     BreedRepository breedRepository;
-
     @Mock
     AnimalRepository animalRepository;
-
     @Mock
     DiseaseRepository diseaseRepository;
-
     @Mock
     MemberRepository memberRepository;
-
     @Mock
     PetRepository petRepository;
-
     @Mock
     DistrictRepository districtRepository;
-
     @Mock
     HospitalVisitPurposeRepository hospitalVisitPurposeRepository;
-
     @Mock
     SymptomRepository symptomRepository;
-
     @Mock
     S3PresignClient s3PresignClient;
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-02-10T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
 
     @Test
     @DisplayName("리뷰를 작성할 수 있다.")
@@ -470,7 +465,7 @@ class ReviewServiceTest {
         final LocalDateTime visitedAt = LocalDateTime.parse("2025-07-12T15:20:19");
 
         final Member member = Member.builder().nickname("테스트유저").build();
-        ReflectionTestUtils.setField(member, "id", 1L); // Assuming memberId 1 is always present for simplicity
+        ReflectionTestUtils.setField(member, "id", 1L);
 
         final List<Review> allReviews = new ArrayList<>();
         for (long i = 10; i >= 1; i--) {

--- a/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
+++ b/src/test/java/com/cocos/cocos/review/ReviewServiceTest.java
@@ -53,6 +53,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -355,7 +356,6 @@ class ReviewServiceTest {
     }
 
     @Test
-
     @DisplayName("병원 ID 필터링 조건으로 병원 리뷰 목록을 조회할 수 있다.")
     void getHospitalReviewListWithHospitalIdFilter() {
 
@@ -375,7 +375,7 @@ class ReviewServiceTest {
         ReflectionTestUtils.setField(hospital, "id", hospitalId);
         final Member member = Member.builder().nickname("테스트유저").build();
         ReflectionTestUtils.setField(member, "id", memberId);
-        final Pet pet = Pet.builder().memberId(memberId).breedId(breedId).age(1).build();
+        final Pet pet = Pet.builder().memberId(memberId).breedId(breedId).age(1).birthDate(LocalDate.parse("2020-01-01")).build();
         ReflectionTestUtils.setField(pet, "id", 1L);
         final Breed breed = Breed.builder().name("테스트견종").animalId(animalId).build();
         ReflectionTestUtils.setField(breed, "id", breedId);
@@ -428,7 +428,7 @@ class ReviewServiceTest {
         ReflectionTestUtils.setField(hospital, "id", reviewHospitalId);
         final Member member = Member.builder().nickname("테스트유저").build();
         ReflectionTestUtils.setField(member, "id", memberId);
-        final Pet pet = Pet.builder().memberId(memberId).breedId(breedId).age(1).build();
+        final Pet pet = Pet.builder().memberId(memberId).breedId(breedId).age(1).birthDate(LocalDate.parse("2020-01-01")).build();
         ReflectionTestUtils.setField(pet, "id", 1L);
         final Breed breed = Breed.builder().name("테스트견종").animalId(animalId).build();
         ReflectionTestUtils.setField(breed, "id", breedId);
@@ -489,7 +489,7 @@ class ReviewServiceTest {
         final Hospital hospital = Hospital.builder().name("테스트 병원").reviewCount(allReviews.size()).build();
         ReflectionTestUtils.setField(hospital, "id", hospitalId);
 
-        final Pet pet = Pet.builder().memberId(member.getId()).breedId(1L).age(1).build();
+        final Pet pet = Pet.builder().memberId(member.getId()).breedId(1L).age(1).birthDate(LocalDate.parse("2020-01-01")).build();
         ReflectionTestUtils.setField(pet, "id", 1L);
         final Breed breed = Breed.builder().name("테스트견종").animalId(1L).build();
         ReflectionTestUtils.setField(breed, "id", 1L);
@@ -577,7 +577,7 @@ class ReviewServiceTest {
 
         final Hospital hospital = Hospital.builder().name("테스트 병원").build();
         ReflectionTestUtils.setField(hospital, "id", hospitalId);
-        final Pet pet = Pet.builder().memberId(member.getId()).breedId(1L).age(1).build();
+        final Pet pet = Pet.builder().memberId(member.getId()).breedId(1L).age(1).birthDate(LocalDate.parse("2020-01-01")).build();
         ReflectionTestUtils.setField(pet, "id", 1L);
         final Breed breed = Breed.builder().name("테스트견종").animalId(1L).build();
         ReflectionTestUtils.setField(breed, "id", 1L);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #315 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 펫 생년월일 추가
- 현재 로직과 호환성을 위해 age 를 입력받는 부분은  남겨두었습니다.
- 프론트 배포 후, 레거시인 age 로직을 제거할 예정입니다.  

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 반려동물 생년월일(birthDate) 등록 및 표시 기능 추가
  * 나이·생년월일 상호 보정 기능 도입(입력값 기반 자동 보정)

* **개선 사항**
  * Clock 기반 일관된 나이 계산 적용(시간대 고정으로 일관성 확보)
  * API 응답에 생년월일 포함 및 나이 표기 개선

* **문서화**
  * 용어 통일: "애완동물" → "반려동물"로 변경

* **테스트**
  * 생년월일 반영을 위한 테스트 업데이트

* **데이터베이스**
  * 생년월일 컬럼 추가 및 기존 데이터 마이그레이션 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->