### PR TITLE
Feat: Search 저장 동시성 개선 및 성능 검증 문서 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,16 @@ application.yml
 application-local.yml
 application-dev.yml
 application-prod.yml
+
+### Local Agent/Workspace ###
+.codex/
+CODEX.md
+
+### Runtime Outputs ###
+logs/
+perf/results/
+
+### Personal Notes ###
+docs/portfolio/
+docs/adr/
+docs/troubleshooting/

--- a/docker-compose.perf.benchmark.yml
+++ b/docker-compose.perf.benchmark.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    environment:
+      SPRING_FLYWAY_LOCATIONS: filesystem:/tmp/cocos-mig-benchmark
+      SPRING_FLYWAY_ENABLED: "true"
+      API_PREFIX: /api/dev
+      AWS_REGION: ap-northeast-2
+    volumes:
+      - /tmp/cocos-mig-benchmark:/tmp/cocos-mig-benchmark:ro

--- a/docker-compose.perf.yml
+++ b/docker-compose.perf.yml
@@ -1,0 +1,71 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: cocos-perf-mysql
+    environment:
+      MYSQL_DATABASE: cocos
+      MYSQL_USER: cocos
+      MYSQL_PASSWORD: cocos
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    mem_limit: 768m
+    cpus: 1.0
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cocos-perf-app
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/cocos?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: cocos
+      SPRING_DATASOURCE_PASSWORD: cocos
+      TEST_AUTH_SECRET: perf-test-secret
+      JWT_SECRET: perf-jwt-secret-perf-jwt-secret-perf-jwt-secret-123456
+      AWS_ACCESS_KEY: test
+      AWS_SECRET_KEY: test
+      AWS_APP_DATA_S3_BUCKET_NAME: test-bucket
+      AWS_MEMBER_DATA_S3_BUCKET_NAME: test-bucket
+      KAKAO_CLIENT_ID: test-client-id
+      KAKAO_REDIRECT_URL: http://localhost:5173/auth
+      KAKAO_ADMIN_KEY: test-admin-key
+      SENTRY_DSN: ""
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    mem_limit: 1500m
+    cpus: 1.5
+
+  k6:
+    image: grafana/k6:0.49.0
+    container_name: cocos-perf-k6
+    depends_on:
+      - app
+    environment:
+      BASE_URL: http://app:8080
+      API_PREFIX: /api/dev
+      TEST_AUTH_SECRET: perf-test-secret
+      TEST_MEMBER_ID: "1"
+    volumes:
+      - ./perf/k6:/perf/k6:ro
+      - ./perf/results:/perf/results
+    entrypoint: ["k6"]
+    command:
+      [
+        "run",
+        "--summary-export=/perf/results/summary.json",
+        "/perf/k6/search-write.js"
+      ]
+    mem_limit: 512m
+    cpus: 1.0
+

--- a/docker-compose.perf.yml
+++ b/docker-compose.perf.yml
@@ -30,8 +30,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/cocos?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: cocos
       SPRING_DATASOURCE_PASSWORD: cocos
-      TEST_AUTH_SECRET: perf-test-secret
-      JWT_SECRET: perf-jwt-secret-perf-jwt-secret-perf-jwt-secret-123456
+      TEST_AUTH_SECRET: ${TEST_AUTH_SECRET:-changeme-test-auth-secret}
+      JWT_SECRET: ${JWT_SECRET:-changeme-jwt-secret-please-set-before-run-1234567890-abcdef}
       AWS_ACCESS_KEY: test
       AWS_SECRET_KEY: test
       AWS_APP_DATA_S3_BUCKET_NAME: test-bucket
@@ -54,7 +54,7 @@ services:
     environment:
       BASE_URL: http://app:8080
       API_PREFIX: /api/dev
-      TEST_AUTH_SECRET: perf-test-secret
+      TEST_AUTH_SECRET: ${TEST_AUTH_SECRET:-changeme-test-auth-secret}
       TEST_MEMBER_ID: "1"
     volumes:
       - ./perf/k6:/perf/k6:ro
@@ -68,4 +68,3 @@ services:
       ]
     mem_limit: 512m
     cpus: 1.0
-

--- a/docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md
+++ b/docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md
@@ -1,0 +1,45 @@
+# k6 Heavy Comparison (dev vs feat/#317) - 3 Repeats (2026-02-15 KST)
+
+## Scope
+- Endpoint: `/api/dev/search/hospital`
+- Scenario: `perf/k6/search-write-heavy.js`
+- Profile: member pool 1,000 / keyword pool 10,000 / max 100 VU
+- Method: `dev`, `feat/#317` 각각 3회 반복 (동일 조건)
+
+## Run Files
+### feat/#317
+- `perf/results/repeat-heavy/summary-feat-heavy-run1.json`
+- `perf/results/repeat-heavy/summary-feat-heavy-run2.json`
+- `perf/results/repeat-heavy/summary-feat-heavy-run3.json`
+
+### dev
+- `perf/results/repeat-heavy/summary-dev-heavy-run1.json`
+- `perf/results/repeat-heavy/summary-dev-heavy-run2.json`
+- `perf/results/repeat-heavy/summary-dev-heavy-run3.json`
+
+## Per-Run Snapshot
+| Branch | Run | TPS | p95 (ms) | p99 (ms) | error rate |
+|---|---:|---:|---:|---:|---:|
+| feat | 1 | 573.1453 | 163.3572 | 258.6753 | 0.0097% |
+| feat | 2 | 579.7261 | 163.1360 | 249.0858 | 0.0114% |
+| feat | 3 | 602.5003 | 160.0890 | 251.3620 | 0.0082% |
+| dev | 1 | 611.8847 | 158.4270 | 250.0735 | 0.0161% |
+| dev | 2 | 614.8951 | 152.7370 | 237.4643 | 0.0197% |
+| dev | 3 | 584.8632 | 186.6804 | 378.5734 | 0.0139% |
+
+## Aggregated Result (mean ± std)
+| Metric | dev | feat/#317 | Delta (feat vs dev) |
+|---|---:|---:|---:|
+| TPS | 603.8810 ± 13.5036 | 585.1239 ± 12.5773 | -3.1061% |
+| p95 (ms) | 165.9481 ± 14.8428 | 162.1941 ± 1.4913 | +2.2622% 개선 |
+| p99 (ms) | 288.7037 ± 63.7556 | 253.0411 ± 4.0910 | +12.3527% 개선 |
+| error rate | 0.0165% ± 0.0024% | 0.0098% ± 0.0013% | 개선 |
+
+## Interpretation
+- 3회 반복 기준으로 `feat/#317`은 평균 TPS가 낮다(-3.1%).
+- 반면 tail latency(p95/p99)와 error rate는 `feat/#317`이 더 좋다.
+- `dev`는 run3에서 p99이 크게 튀어 분산이 커졌고, `feat/#317`은 분산이 상대적으로 작아 일관성이 높다.
+
+## Conclusion
+- 처리량 절대치보다 안정성/꼬리 지연/실패율을 우선하면 `feat/#317` 채택이 합리적이다.
+- TPS가 핵심 KPI라면 추가 튜닝(예: 배치/커넥션/쿼리 경로) 후 재측정이 필요하다.

--- a/docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md
+++ b/docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md
@@ -6,17 +6,6 @@
 - Profile: member pool 1,000 / keyword pool 10,000 / max 100 VU
 - Method: `dev`, `feat/#317` 각각 3회 반복 (동일 조건)
 
-## Run Files
-### feat/#317
-- `perf/results/repeat-heavy/summary-feat-heavy-run1.json`
-- `perf/results/repeat-heavy/summary-feat-heavy-run2.json`
-- `perf/results/repeat-heavy/summary-feat-heavy-run3.json`
-
-### dev
-- `perf/results/repeat-heavy/summary-dev-heavy-run1.json`
-- `perf/results/repeat-heavy/summary-dev-heavy-run2.json`
-- `perf/results/repeat-heavy/summary-dev-heavy-run3.json`
-
 ## Per-Run Snapshot
 | Branch | Run | TPS | p95 (ms) | p99 (ms) | error rate |
 |---|---:|---:|---:|---:|---:|

--- a/docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md
+++ b/docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md
@@ -1,7 +1,7 @@
 # k6 Observability Root Cause Report (run: 20260215-021141)
 
 ## 1) Scope
-- Test run: `perf/results/observability/20260215-021141`
+- Test run: observability 1회 측정 번들(로컬 산출물, 커밋 제외)
 - Scenario: `perf/k6/search-write-heavy.js`
 - Goal: p95/p99 tail latency and TPS limiting factor를 DB/App 지표와 함께 원인 분석
 
@@ -17,7 +17,7 @@
 ## 3) Evidence
 
 ### A. Hikari pool saturation 징후 (가장 강한 근거)
-- Source: `perf/results/observability/20260215-021141/app-metrics/*`
+- Source: 자동 수집 스크립트 산출물(`app-metrics`)
 - Pool size:
   - `hikaricp.connections` max = `10` (상시 고정)
 - Active:
@@ -33,9 +33,9 @@
 - 커넥션 풀 총량 10개가 포화되는 시점에 요청 스레드가 대기열로 밀리고, 이 구간이 p95 이상 tail을 끌어올림.
 
 ### B. DB lock contention 근거 없음
-- Source: `perf/results/observability/20260215-021141/db/lock_waits.tsv`
+- Source: 자동 수집 스크립트 산출물(`db/lock_waits.tsv`)
   - `lock_wait_count` max = `0`
-- Source: `perf/results/observability/20260215-021141/db/mysql_status.tsv`
+- Source: 자동 수집 스크립트 산출물(`db/mysql_status.tsv`)
   - `innodb_row_lock_waits` max = `0`
   - `innodb_row_lock_time` max = `0`
 
@@ -43,7 +43,7 @@
 - 이번 부하에서 지연의 주원인을 row lock wait로 보기 어렵다.
 
 ### C. SQL 자체는 상대적으로 짧음 (상위 digest 기준)
-- Source: `perf/results/observability/20260215-021141/db/top_digest.tsv`
+- Source: 자동 수집 스크립트 산출물(`db/top_digest.tsv`)
 - 상위 digest:
   - `INSERT search ...` avg `0.176ms`
   - `SELECT search by member_id/keyword/type` avg `0.143ms`
@@ -55,7 +55,7 @@
 - commit/일부 update spike는 존재하지만, lock wait 지표와 결합하면 구조적 락 병목보다 **풀 대기 + 트랜잭션 경계 비용** 영향이 더 큼.
 
 ### D. Slow log window는 많지만 장시간 query는 관측되지 않음
-- Source: `perf/results/observability/20260215-021141/db/slow_log_window.tsv`
+- Source: 자동 수집 스크립트 산출물(`db/slow_log_window.tsv`)
   - `slow_count_window`는 구간별 다수 발생(예: 54)
   - `slow_max_ms_window`는 전 구간 `0`
 

--- a/docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md
+++ b/docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md
@@ -1,0 +1,80 @@
+# k6 Observability Root Cause Report (run: 20260215-021141)
+
+## 1) Scope
+- Test run: `perf/results/observability/20260215-021141`
+- Scenario: `perf/k6/search-write-heavy.js`
+- Goal: p95/p99 tail latency and TPS limiting factor를 DB/App 지표와 함께 원인 분석
+
+## 2) Key Outcome Summary
+- TPS (`http_reqs.rate`): `600.1480`
+- p95 (`http_req_duration.p(95)`): `178.9977ms`
+- error rate (`http_req_failed.value`): `0`
+
+해석:
+- 에러/락 대기 이슈 없이 throughput은 높게 유지됨.
+- tail latency는 DB row lock이 아니라 **커넥션 풀 대기(queueing)** 영향이 큰 패턴.
+
+## 3) Evidence
+
+### A. Hikari pool saturation 징후 (가장 강한 근거)
+- Source: `perf/results/observability/20260215-021141/app-metrics/*`
+- Pool size:
+  - `hikaricp.connections` max = `10` (상시 고정)
+- Active:
+  - `hikaricp.connections.active` max = `10`, avg = `6.30`
+- Pending:
+  - `hikaricp.connections.pending` max = `87`, avg = `6.91`
+  - pending peak timestamps: `20260214T171341Z(87)`, `20260214T171409Z(34)`, `20260214T171351Z(26)`
+- Acquire/usage (delta 기준):
+  - acquire avg ~= `11.79ms` (`delta_total_s / delta_count`)
+  - usage avg ~= `10.49ms`
+
+의미:
+- 커넥션 풀 총량 10개가 포화되는 시점에 요청 스레드가 대기열로 밀리고, 이 구간이 p95 이상 tail을 끌어올림.
+
+### B. DB lock contention 근거 없음
+- Source: `perf/results/observability/20260215-021141/db/lock_waits.tsv`
+  - `lock_wait_count` max = `0`
+- Source: `perf/results/observability/20260215-021141/db/mysql_status.tsv`
+  - `innodb_row_lock_waits` max = `0`
+  - `innodb_row_lock_time` max = `0`
+
+의미:
+- 이번 부하에서 지연의 주원인을 row lock wait로 보기 어렵다.
+
+### C. SQL 자체는 상대적으로 짧음 (상위 digest 기준)
+- Source: `perf/results/observability/20260215-021141/db/top_digest.tsv`
+- 상위 digest:
+  - `INSERT search ...` avg `0.176ms`
+  - `SELECT search by member_id/keyword/type` avg `0.143ms`
+  - `COMMIT` avg `4.644ms`
+  - `UPDATE search ...` avg `0.292ms` (max spike `316.213ms`)
+
+의미:
+- 핵심 CRUD SQL 평균은 짧다.
+- commit/일부 update spike는 존재하지만, lock wait 지표와 결합하면 구조적 락 병목보다 **풀 대기 + 트랜잭션 경계 비용** 영향이 더 큼.
+
+### D. Slow log window는 많지만 장시간 query는 관측되지 않음
+- Source: `perf/results/observability/20260215-021141/db/slow_log_window.tsv`
+  - `slow_count_window`는 구간별 다수 발생(예: 54)
+  - `slow_max_ms_window`는 전 구간 `0`
+
+의미:
+- `long_query_time=0.05`로 매우 민감하게 잡아 카운트가 증가한 것으로 해석 가능.
+- “long-running query”가 tail을 주도했다는 증거는 약함.
+
+## 4) Root Cause Hypothesis
+1. 1순위: **Hikari 커넥션 풀 용량(10) 대비 동시 요청량 증가로 pending queue 발생**
+2. 2순위: 트랜잭션당 commit 비용 누적 + 일부 update spike가 tail 구간에 가중
+3. 낮은 가능성: DB row lock 경합 (현재 실측 근거 없음)
+
+## 5) Improvement Backlog (Priority)
+| Priority | Problem | Evidence | Proposed Change | Expected Impact | Validation |
+|---|---|---|---|---|---|
+| P1 | 풀 포화로 pending queue 증가 | pending max 87, active max 10 | Hikari `maximumPoolSize` 단계 상향(10 -> 16/20) + DB max connections 동기화 | p95/p99 개선, TPS 유지/상향 | 동일 시나리오 3회 반복 후 tail/variance 비교 |
+| P1 | 트랜잭션 경계 비용 누적 | commit avg 4.644ms, 호출량 매우 큼 | 쓰기 경로 트랜잭션 경계/flush 타이밍 점검, 불필요 update 최소화 | tail 구간 추가 개선 | top_digest에서 commit/update total 시간 감소 확인 |
+| P2 | 관측 해상도 한계 | summary json에 p99 미포함 | k6 `--summary-trend-stats`에 `p(99)` 포함 | 보고서 정확도 향상 | summary에 p99 저장 여부 확인 |
+
+## 6) Decision Draft
+- 현재 run 기준으로 “DB 락 병목”보다 “앱 커넥션 풀 대기”가 우선 대응 대상.
+- 다음 실험은 `maximumPoolSize` 튜닝 A/B(10 vs 16 vs 20)로 고정하고, 동일 조건 3회 반복으로 판단한다.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,11 @@
+# Decisions
+
+이 디렉토리는 대안 비교, 테스트 시나리오, 검증, 결론 문서를 관리합니다.
+
+## Index
+- 2026-02-15: [k6 Heavy Comparison (dev vs feat/#317) - 3 Repeats](./2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md)
+- 2026-02-15: [k6 Heavy Comparison (dev vs feat/#317) - Local k6 / Docker DB](./2026-02-15-k6-dev-vs-feat317-heavy-local.md)
+- 2026-02-15: [k6 Observability Root Cause Report (run: 20260215-021141)](./2026-02-15-k6-observability-root-cause-20260215-021141.md)
+- 2026-02-14: [Search 개선 k6 결과 보고서](./2026-02-14-search-improvement-k6-final-report.md)
+- 2026-02-14: [k6 Comparison (dev vs feat/#317) - Migration-Fixed Docker DB](./2026-02-14-k6-dev-vs-feat317-migfixed.md)
+- 2026-02-14: [Search Write k6 성능 검증 리포트](./2026-02-14-k6-search-write-report.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,8 +4,4 @@
 
 ## Index
 - 2026-02-15: [k6 Heavy Comparison (dev vs feat/#317) - 3 Repeats](./2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md)
-- 2026-02-15: [k6 Heavy Comparison (dev vs feat/#317) - Local k6 / Docker DB](./2026-02-15-k6-dev-vs-feat317-heavy-local.md)
-- 2026-02-15: [k6 Observability Root Cause Report (run: 20260215-021141)](./2026-02-15-k6-observability-root-cause-20260215-021141.md)
-- 2026-02-14: [Search 개선 k6 결과 보고서](./2026-02-14-search-improvement-k6-final-report.md)
-- 2026-02-14: [k6 Comparison (dev vs feat/#317) - Migration-Fixed Docker DB](./2026-02-14-k6-dev-vs-feat317-migfixed.md)
-- 2026-02-14: [Search Write k6 성능 검증 리포트](./2026-02-14-k6-search-write-report.md)
+- 2026-02-15: [k6 Observability Root Cause Report](./2026-02-15-k6-observability-root-cause-20260215-021141.md)

--- a/docs/performance/local-k6.md
+++ b/docs/performance/local-k6.md
@@ -1,0 +1,85 @@
+# Local k6 (Docker) Guide
+
+## 목적
+
+- 배포 전에 로컬에서 `search` 쓰기 경로 부하를 검증한다.
+- Docker 리소스 제한으로 재현 가능한 테스트 환경을 만든다.
+
+## 구성
+
+- `docker-compose.perf.yml`
+  - `mysql`: 테스트 DB
+  - `app`: Spring Boot 앱
+  - `k6`: 부하 테스트 실행기
+- `perf/k6/search-write.js`
+  - 테스트 로그인으로 JWT 발급
+  - `/api/dev/search/hospital` 쓰기 부하 수행
+
+## 실행
+
+1. 앱/DB 기동
+
+```bash
+docker compose -f docker-compose.perf.yml up -d mysql app
+```
+
+2. k6 실행
+
+```bash
+docker compose -f docker-compose.perf.yml run --rm k6
+```
+
+3. 결과 확인
+
+```bash
+cat perf/results/summary.json
+```
+
+4. 종료
+
+```bash
+docker compose -f docker-compose.perf.yml down -v
+```
+
+## 리소스 제한 조정
+
+- `docker-compose.perf.yml`에서 `mem_limit`, `cpus` 값을 변경한다.
+- 예:
+  - app: `mem_limit: 1500m`, `cpus: 1.5`
+  - mysql: `mem_limit: 768m`, `cpus: 1.0`
+  - k6: `mem_limit: 512m`, `cpus: 1.0`
+
+## 기본 검증 지표
+
+- `http_req_duration` p95/p99
+- `http_req_failed`
+- app 로그의 query count / duration (RequestLoggingFilter)
+
+## 자동 수집 실행 (k6 + DB/App 메트릭)
+
+다음 스크립트는 한 번에 아래를 수행한다.
+- k6 실행
+- Actuator(Hikari/HTTP) 메트릭 샘플링
+- MySQL 슬로우쿼리/락대기/상태값 샘플링
+- 종료 후 digest/innodb snapshot 저장
+
+```bash
+START_STACK=1 \
+ACTUATOR_PASSWORD='<actuator-basic-auth-password>' \
+K6_MODE=local \
+K6_SCRIPT_LOCAL=perf/k6/search-write-heavy.js \
+SAMPLE_INTERVAL_SECONDS=5 \
+SLOW_QUERY_THRESHOLD_SECONDS=0.05 \
+./perf/scripts/run-k6-with-metrics.sh
+```
+
+- `ACTUATOR_PASSWORD`는 필수다. 기본값이 없으므로 실행 시 반드시 지정해야 한다.
+
+결과는 `perf/results/observability/<run-id>/` 아래에 생성된다.
+- `k6-summary.json`
+- `app-metrics/*.json`
+- `db/slow_log_window.tsv`
+- `db/lock_waits.tsv`
+- `db/mysql_status.tsv`
+- `db/top_digest.tsv`
+- `db/innodb_status.txt`

--- a/docs/performance/local-k6.md
+++ b/docs/performance/local-k6.md
@@ -76,6 +76,7 @@ SLOW_QUERY_THRESHOLD_SECONDS=0.05 \
 - `ACTUATOR_PASSWORD`는 필수다. 기본값이 없으므로 실행 시 반드시 지정해야 한다.
 
 결과는 `perf/results/observability/<run-id>/` 아래에 생성된다.
+- 위 경로는 로컬 실행 산출물이며 커밋 대상이 아니다.
 - `k6-summary.json`
 - `app-metrics/*.json`
 - `db/slow_log_window.tsv`

--- a/docs/performance/local-k6.md
+++ b/docs/performance/local-k6.md
@@ -66,6 +66,7 @@ docker compose -f docker-compose.perf.yml down -v
 ```bash
 START_STACK=1 \
 ACTUATOR_PASSWORD='<actuator-basic-auth-password>' \
+TEST_AUTH_SECRET='<test-auth-secret>' \
 K6_MODE=local \
 K6_SCRIPT_LOCAL=perf/k6/search-write-heavy.js \
 SAMPLE_INTERVAL_SECONDS=5 \
@@ -74,6 +75,7 @@ SLOW_QUERY_THRESHOLD_SECONDS=0.05 \
 ```
 
 - `ACTUATOR_PASSWORD`는 필수다. 기본값이 없으므로 실행 시 반드시 지정해야 한다.
+- `TEST_AUTH_SECRET`도 필수다. 기본값이 없으므로 실행 시 반드시 지정해야 한다.
 
 결과는 `perf/results/observability/<run-id>/` 아래에 생성된다.
 - 위 경로는 로컬 실행 산출물이며 커밋 대상이 아니다.

--- a/docs/wiki/2026-02-15-search-performance-technical-decisions.md
+++ b/docs/wiki/2026-02-15-search-performance-technical-decisions.md
@@ -6,7 +6,7 @@
 - 목표: 검색 write 경로의 안정성(p95/p99/error)과 처리량(TPS) 균형 개선
 - 조건 통일:
   - 동일 부하 시나리오
-  - 동일 benchmark migration 경로(`/tmp/cocos-mig-benchmark`)
+  - 동일 benchmark migration 경로(벤치마크 전용 임시 경로)
   - 실행 전 `docker compose ... down -v` 초기화
 
 ## Experiments
@@ -19,7 +19,7 @@
   - error rate: dev 0.0165% / feat 0.0098% (feat 개선)
 
 2. 원인 분석 실험 (observability 1회)
-- run: `perf/results/observability/20260215-021141`
+- run: observability 1회 측정 번들(로컬 산출물, 커밋 제외)
 - 보고서: `docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md`
 - 핵심 관측:
   - `hikaricp.connections.pending` max 87

--- a/docs/wiki/2026-02-15-search-performance-technical-decisions.md
+++ b/docs/wiki/2026-02-15-search-performance-technical-decisions.md
@@ -1,0 +1,55 @@
+# Search 성능 개선 기술 결정 기록 (2026-02-15)
+
+## Decision Context
+- 비교 대상: `dev` vs `feat/#317`
+- 엔드포인트: `/api/dev/search/hospital`
+- 목표: 검색 write 경로의 안정성(p95/p99/error)과 처리량(TPS) 균형 개선
+- 조건 통일:
+  - 동일 부하 시나리오
+  - 동일 benchmark migration 경로(`/tmp/cocos-mig-benchmark`)
+  - 실행 전 `docker compose ... down -v` 초기화
+
+## Experiments
+1. 비교 실험 (heavy profile, 3회 반복)
+- 보고서: `docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md`
+- 결과(평균):
+  - TPS: dev 603.88 / feat 585.12 (feat -3.11%)
+  - p95: dev 165.95ms / feat 162.19ms (feat 개선)
+  - p99: dev 288.70ms / feat 253.04ms (feat 개선)
+  - error rate: dev 0.0165% / feat 0.0098% (feat 개선)
+
+2. 원인 분석 실험 (observability 1회)
+- run: `perf/results/observability/20260215-021141`
+- 보고서: `docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md`
+- 핵심 관측:
+  - `hikaricp.connections.pending` max 87
+  - `lock_wait_count` max 0
+  - `innodb_row_lock_waits` max 0
+
+## Technical Decisions
+### D1. feat/#317을 안정성 개선안으로 채택
+- 이유: TPS는 소폭 하락했지만, p95/p99/error/분산 안정성 개선이 확인됨
+- 적용 범위: 검색 write 경로 개선 효과 판단 기준을 tail latency + failure 중심으로 설정
+
+### D2. 현 시점 1순위 병목을 DB lock이 아닌 connection pool 대기로 규정
+- 근거: lock wait 지표 0, 반면 Hikari pending 피크가 크게 관측됨
+- 결론: 다음 튜닝의 중심은 lock SQL보다 커넥션 점유 시간/큐잉 완화
+
+### D3. 운영 제약(db.t4g.micro, 2 vCPU) 하에서 “풀 대폭 확대”는 보류
+- 이유: 과도한 풀 확장은 DB 경합/컨텍스트 스위칭 증가 리스크
+- 방침: `maximumPoolSize`는 소폭(예: 10->12) 검증만 허용
+
+### D4. 다음 개선 우선순위
+1. 트랜잭션 점유 시간 단축
+2. 불필요 update/flush/commit 비용 절감
+3. 소폭 pool 튜닝 + 동일 조건 반복 측정
+
+## Why This Decision
+- 단일 수치(TPS)만으로 판단하면 안정성 리스크를 놓칠 수 있음
+- 실제 사용자 체감과 장애 리스크를 고려하면 tail latency/error 개선이 우선
+- 반복 실험 + 관측 데이터를 근거로 재현 가능한 의사결정 가능
+
+## Follow-up
+- [ ] `maximumPoolSize` 10 vs 12 A/B (동일 시나리오 3회)
+- [ ] write 경로 트랜잭션 경계 재점검
+- [ ] commit/update 비중 감소 후 재측정

--- a/perf/k6/search-write-heavy.js
+++ b/perf/k6/search-write-heavy.js
@@ -3,7 +3,7 @@ import { check, sleep } from "k6";
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
 const API_PREFIX = __ENV.API_PREFIX || "/api/dev";
-const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "perf-test-secret";
+const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "changeme-test-auth-secret";
 
 const MEMBER_POOL_START = Number(__ENV.MEMBER_POOL_START || "1");
 const MEMBER_POOL_SIZE = Number(__ENV.MEMBER_POOL_SIZE || "1000");

--- a/perf/k6/search-write-heavy.js
+++ b/perf/k6/search-write-heavy.js
@@ -1,0 +1,120 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const API_PREFIX = __ENV.API_PREFIX || "/api/dev";
+const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "perf-test-secret";
+
+const MEMBER_POOL_START = Number(__ENV.MEMBER_POOL_START || "1");
+const MEMBER_POOL_SIZE = Number(__ENV.MEMBER_POOL_SIZE || "1000");
+const KEYWORD_POOL_SIZE = Number(__ENV.KEYWORD_POOL_SIZE || "10000");
+const LOGIN_BATCH_SIZE = Number(__ENV.LOGIN_BATCH_SIZE || "200");
+const SLEEP_SECONDS = Number(__ENV.SLEEP_SECONDS || "0.05");
+
+const DEFAULT_STAGES = [
+  { duration: "30s", target: 50 },
+  { duration: "60s", target: 50 },
+  { duration: "30s", target: 100 },
+  { duration: "120s", target: 100 },
+  { duration: "30s", target: 0 }
+];
+
+export const options = {
+  scenarios: {
+    search_write_heavy: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: DEFAULT_STAGES
+    }
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<700", "p(99)<1200"]
+  }
+};
+
+function waitUntilHealthy(maxRetries = 60) {
+  for (let i = 0; i < maxRetries; i += 1) {
+    const res = http.get(`${BASE_URL}${API_PREFIX}/test/health-check`);
+    if (res.status === 200) {
+      return;
+    }
+    sleep(1);
+  }
+  throw new Error("app did not become healthy in time");
+}
+
+function buildMemberIds() {
+  return Array.from(
+    { length: MEMBER_POOL_SIZE },
+    (_, idx) => MEMBER_POOL_START + idx
+  );
+}
+
+function issueAccessTokens(memberIds) {
+  const accessTokens = [];
+
+  for (let i = 0; i < memberIds.length; i += LOGIN_BATCH_SIZE) {
+    const batch = memberIds.slice(i, i + LOGIN_BATCH_SIZE);
+    const payload = JSON.stringify({ memberIds: batch });
+    const res = http.post(`${BASE_URL}${API_PREFIX}/test/auth/login`, payload, {
+      headers: {
+        "Content-Type": "application/json",
+        "X-Test-Auth-Secret": TEST_AUTH_SECRET
+      }
+    });
+
+    check(res, {
+      "login status is 200": (r) => r.status === 200
+    });
+
+    if (res.status !== 200) {
+      throw new Error(`login failed: status=${res.status} body=${res.body}`);
+    }
+
+    const tokens = res.json();
+    if (!Array.isArray(tokens) || tokens.length !== batch.length) {
+      throw new Error("unexpected token response length");
+    }
+
+    for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
+      const tokenObj = tokens[tokenIndex];
+      const token = tokenObj && tokenObj.accessToken;
+      if (!token) {
+        throw new Error("access token missing from test login response");
+      }
+      accessTokens.push(token);
+    }
+  }
+
+  return accessTokens;
+}
+
+export function setup() {
+  waitUntilHealthy();
+  const memberIds = buildMemberIds();
+  const accessTokens = issueAccessTokens(memberIds);
+  return { accessTokens };
+}
+
+export default function (data) {
+  const tokenIndex = Math.floor(Math.random() * data.accessTokens.length);
+  const keywordIndex = Math.floor(Math.random() * KEYWORD_POOL_SIZE);
+  const keyword = `k6-heavy-${keywordIndex}`;
+
+  const res = http.post(
+    `${BASE_URL}${API_PREFIX}/search/hospital?keyword=${encodeURIComponent(keyword)}`,
+    null,
+    {
+      headers: {
+        Authorization: `Bearer ${data.accessTokens[tokenIndex]}`
+      }
+    }
+  );
+
+  check(res, {
+    "search write status is 200": (r) => r.status === 200
+  });
+
+  sleep(SLEEP_SECONDS);
+}

--- a/perf/k6/search-write.js
+++ b/perf/k6/search-write.js
@@ -1,0 +1,88 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const API_PREFIX = __ENV.API_PREFIX || "/api/dev";
+const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "perf-test-secret";
+const TEST_MEMBER_ID = Number(__ENV.TEST_MEMBER_ID || "1");
+
+export const options = {
+  scenarios: {
+    search_write_load: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: 20 },
+        { duration: "60s", target: 20 },
+        { duration: "30s", target: 0 }
+      ]
+    }
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<500", "p(99)<900"]
+  }
+};
+
+function waitUntilHealthy(maxRetries = 60) {
+  for (let i = 0; i < maxRetries; i += 1) {
+    const res = http.get(`${BASE_URL}${API_PREFIX}/test/health-check`);
+    if (res.status === 200) {
+      return;
+    }
+    sleep(1);
+  }
+  throw new Error("app did not become healthy in time");
+}
+
+function issueAccessToken(memberId) {
+  const payload = JSON.stringify({ memberIds: [memberId] });
+  const res = http.post(`${BASE_URL}${API_PREFIX}/test/auth/login`, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      "X-Test-Auth-Secret": TEST_AUTH_SECRET
+    }
+  });
+
+  check(res, {
+    "login status is 200": (r) => r.status === 200
+  });
+
+  if (res.status !== 200) {
+    throw new Error(`login failed: status=${res.status} body=${res.body}`);
+  }
+
+  const tokens = res.json();
+  if (!Array.isArray(tokens) || tokens.length === 0 || !tokens[0].accessToken) {
+    throw new Error("access token missing from test login response");
+  }
+  return tokens[0].accessToken;
+}
+
+let accessToken = "";
+
+export function setup() {
+  waitUntilHealthy();
+  accessToken = issueAccessToken(TEST_MEMBER_ID);
+  return { accessToken };
+}
+
+export default function (data) {
+  const keyword = `k6-${Math.floor(Math.random() * 100)}`;
+  const res = http.post(
+    `${BASE_URL}${API_PREFIX}/search/hospital?keyword=${encodeURIComponent(keyword)}`,
+    null,
+    {
+      headers: {
+        Authorization: `Bearer ${data.accessToken}`
+      }
+    }
+  );
+
+  check(res, {
+    "search write status is 200": (r) => r.status === 200
+  });
+
+  sleep(0.1);
+}
+

--- a/perf/k6/search-write.js
+++ b/perf/k6/search-write.js
@@ -3,7 +3,7 @@ import { check, sleep } from "k6";
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
 const API_PREFIX = __ENV.API_PREFIX || "/api/dev";
-const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "perf-test-secret";
+const TEST_AUTH_SECRET = __ENV.TEST_AUTH_SECRET || "changeme-test-auth-secret";
 const TEST_MEMBER_ID = Number(__ENV.TEST_MEMBER_ID || "1");
 
 export const options = {
@@ -85,4 +85,3 @@ export default function (data) {
 
   sleep(0.1);
 }
-

--- a/perf/scripts/run-k6-with-metrics.sh
+++ b/perf/scripts/run-k6-with-metrics.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end perf runner:
+# 1) optional docker compose up
+# 2) enable/clear MySQL observability tables
+# 3) sample Actuator + MySQL metrics while k6 runs
+# 4) export snapshots and k6 summary into a timestamped folder
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+OUT_DIR="${OUT_DIR:-perf/results/observability/$RUN_ID}"
+APP_METRICS_DIR="$OUT_DIR/app-metrics"
+DB_DIR="$OUT_DIR/db"
+STOP_FILE="$OUT_DIR/.stop"
+
+START_STACK="${START_STACK:-0}"
+SAMPLE_INTERVAL_SECONDS="${SAMPLE_INTERVAL_SECONDS:-5}"
+SLOW_QUERY_THRESHOLD_SECONDS="${SLOW_QUERY_THRESHOLD_SECONDS:-0.05}"
+
+K6_MODE="${K6_MODE:-local}" # local | docker
+K6_BIN="${K6_BIN:-k6}"
+K6_SCRIPT_LOCAL="${K6_SCRIPT_LOCAL:-perf/k6/search-write-heavy.js}"
+K6_SCRIPT_DOCKER="${K6_SCRIPT_DOCKER:-/perf/k6/search-write-heavy.js}"
+K6_SUMMARY_FILE="$OUT_DIR/k6-summary.json"
+K6_EXTRA_ARGS="${K6_EXTRA_ARGS:-}"
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+API_PREFIX="${API_PREFIX:-/api/dev}"
+TEST_AUTH_SECRET="${TEST_AUTH_SECRET:-perf-test-secret}"
+
+ACTUATOR_BASE_URL="${ACTUATOR_BASE_URL:-http://localhost:9090/actuator}"
+ACTUATOR_USER="${ACTUATOR_USER:-cocos}"
+ACTUATOR_PASSWORD="${ACTUATOR_PASSWORD:-}"
+
+MYSQL_SERVICE="${MYSQL_SERVICE:-mysql}"
+MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
+
+if [ -n "${COMPOSE_ARGS:-}" ]; then
+  # shellcheck disable=SC2206
+  COMPOSE=( ${COMPOSE_ARGS} )
+else
+  COMPOSE=(docker compose -f docker-compose.perf.yml -f docker-compose.perf.benchmark.yml)
+fi
+
+mkdir -p "$APP_METRICS_DIR" "$DB_DIR"
+
+if [ -z "$ACTUATOR_PASSWORD" ]; then
+  echo "ACTUATOR_PASSWORD is required. Set it explicitly before running."
+  exit 1
+fi
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+mysql_exec() {
+  local sql="$1"
+  "${COMPOSE[@]}" exec -T "$MYSQL_SERVICE" \
+    mysql -u"$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" --batch --raw --skip-column-names -e "$sql"
+}
+
+collect_actuator_metrics_once() {
+  local ts="$1"
+  local metrics=(
+    "hikaricp.connections"
+    "hikaricp.connections.acquire"
+    "hikaricp.connections.pending"
+    "hikaricp.connections.active"
+    "hikaricp.connections.idle"
+    "hikaricp.connections.usage"
+    "http.server.requests"
+  )
+
+  for metric in "${metrics[@]}"; do
+    local file="$APP_METRICS_DIR/${ts}_${metric//\//_}.json"
+    if ! curl -fsS -u "$ACTUATOR_USER:$ACTUATOR_PASSWORD" \
+      "$ACTUATOR_BASE_URL/metrics/$metric" > "$file"; then
+      echo "{\"error\":\"metric fetch failed\",\"metric\":\"$metric\",\"ts\":\"$ts\"}" > "$file"
+    fi
+  done
+}
+
+collect_mysql_metrics_once() {
+  local ts="$1"
+
+  # Slow query log stats for the recent window
+  local slow_line
+  if slow_line="$(mysql_exec "
+SELECT COUNT(*),
+       IFNULL(ROUND(AVG(TIME_TO_SEC(query_time))*1000,3),0),
+       IFNULL(ROUND(MAX(TIME_TO_SEC(query_time))*1000,3),0)
+FROM mysql.slow_log
+WHERE start_time >= NOW() - INTERVAL ${SAMPLE_INTERVAL_SECONDS} SECOND;
+" 2>/dev/null)"; then
+    echo -e "${ts}\t${slow_line}" >> "$DB_DIR/slow_log_window.tsv"
+  else
+    echo -e "${ts}\tERR\tERR\tERR" >> "$DB_DIR/slow_log_window.tsv"
+  fi
+
+  # Lock wait count (performance_schema)
+  local lock_wait_count
+  if lock_wait_count="$(mysql_exec "SELECT COUNT(*) FROM performance_schema.data_lock_waits;" 2>/dev/null)"; then
+    echo -e "${ts}\t${lock_wait_count}" >> "$DB_DIR/lock_waits.tsv"
+  else
+    echo -e "${ts}\tERR" >> "$DB_DIR/lock_waits.tsv"
+  fi
+
+  # Key MySQL/InnoDB status values
+  local status_line
+  if status_line="$(mysql_exec "
+SELECT
+  MAX(CASE WHEN variable_name = 'Threads_running' THEN variable_value END),
+  MAX(CASE WHEN variable_name = 'Innodb_row_lock_waits' THEN variable_value END),
+  MAX(CASE WHEN variable_name = 'Innodb_row_lock_time' THEN variable_value END)
+FROM performance_schema.global_status
+WHERE variable_name IN ('Threads_running','Innodb_row_lock_waits','Innodb_row_lock_time');
+" 2>/dev/null)"; then
+    echo -e "${ts}\t${status_line}" >> "$DB_DIR/mysql_status.tsv"
+  else
+    echo -e "${ts}\tERR\tERR\tERR" >> "$DB_DIR/mysql_status.tsv"
+  fi
+}
+
+sampling_loop() {
+  echo -e "ts\tslow_count_window\tslow_avg_ms_window\tslow_max_ms_window" > "$DB_DIR/slow_log_window.tsv"
+  echo -e "ts\tlock_wait_count" > "$DB_DIR/lock_waits.tsv"
+  echo -e "ts\tthreads_running\tinnodb_row_lock_waits\tinnodb_row_lock_time" > "$DB_DIR/mysql_status.tsv"
+
+  while [ ! -f "$STOP_FILE" ]; do
+    local ts
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    collect_actuator_metrics_once "$ts"
+    collect_mysql_metrics_once "$ts"
+    sleep "$SAMPLE_INTERVAL_SECONDS"
+  done
+}
+
+collect_final_db_snapshots() {
+  mysql_exec "
+SELECT digest_text, count_star,
+       ROUND(sum_timer_wait/1e12,3) AS total_s,
+       ROUND(avg_timer_wait/1e9,3) AS avg_ms,
+       ROUND(max_timer_wait/1e9,3) AS max_ms
+FROM performance_schema.events_statements_summary_by_digest
+ORDER BY sum_timer_wait DESC
+LIMIT 30;
+" > "$DB_DIR/top_digest.tsv" 2>/dev/null || true
+
+  mysql_exec "SELECT * FROM performance_schema.data_lock_waits;" > "$DB_DIR/data_lock_waits.tsv" 2>/dev/null || true
+
+  "${COMPOSE[@]}" exec -T "$MYSQL_SERVICE" \
+    mysql -u"$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" -e "SHOW ENGINE INNODB STATUS\\G" \
+    > "$DB_DIR/innodb_status.txt" 2>/dev/null || true
+}
+
+write_metadata() {
+  cat > "$OUT_DIR/metadata.env" <<META
+RUN_ID=$RUN_ID
+K6_MODE=$K6_MODE
+K6_SCRIPT_LOCAL=$K6_SCRIPT_LOCAL
+K6_SCRIPT_DOCKER=$K6_SCRIPT_DOCKER
+BASE_URL=$BASE_URL
+API_PREFIX=$API_PREFIX
+SAMPLE_INTERVAL_SECONDS=$SAMPLE_INTERVAL_SECONDS
+SLOW_QUERY_THRESHOLD_SECONDS=$SLOW_QUERY_THRESHOLD_SECONDS
+ACTUATOR_BASE_URL=$ACTUATOR_BASE_URL
+MYSQL_SERVICE=$MYSQL_SERVICE
+META
+}
+
+cleanup() {
+  touch "$STOP_FILE" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [ "$START_STACK" = "1" ]; then
+  log "Starting docker compose stack (mysql, app)"
+  "${COMPOSE[@]}" up -d mysql app
+fi
+
+log "Preparing MySQL observability knobs"
+mysql_exec "SET GLOBAL slow_query_log = 'ON';"
+mysql_exec "SET GLOBAL log_output = 'TABLE';"
+mysql_exec "SET GLOBAL long_query_time = ${SLOW_QUERY_THRESHOLD_SECONDS};"
+mysql_exec "TRUNCATE TABLE mysql.slow_log;"
+mysql_exec "TRUNCATE TABLE performance_schema.events_statements_summary_by_digest;" 2>/dev/null || true
+
+write_metadata
+
+log "Starting sampler (interval=${SAMPLE_INTERVAL_SECONDS}s)"
+sampling_loop &
+SAMPLER_PID=$!
+
+run_k6_local() {
+  local -a extra_args=()
+  if [ -n "$K6_EXTRA_ARGS" ]; then
+    # shellcheck disable=SC2206
+    extra_args=( $K6_EXTRA_ARGS )
+  fi
+
+  if [ "${#extra_args[@]}" -gt 0 ]; then
+    BASE_URL="$BASE_URL" API_PREFIX="$API_PREFIX" TEST_AUTH_SECRET="$TEST_AUTH_SECRET" \
+      "$K6_BIN" run --summary-export "$K6_SUMMARY_FILE" "${extra_args[@]}" "$K6_SCRIPT_LOCAL"
+  else
+    BASE_URL="$BASE_URL" API_PREFIX="$API_PREFIX" TEST_AUTH_SECRET="$TEST_AUTH_SECRET" \
+      "$K6_BIN" run --summary-export "$K6_SUMMARY_FILE" "$K6_SCRIPT_LOCAL"
+  fi
+}
+
+run_k6_docker() {
+  local summary_container="/perf/results/summary-auto-${RUN_ID}.json"
+  "${COMPOSE[@]}" run --rm \
+    -e BASE_URL="$BASE_URL" \
+    -e API_PREFIX="$API_PREFIX" \
+    -e TEST_AUTH_SECRET="$TEST_AUTH_SECRET" \
+    k6 run --summary-export="$summary_container" "$K6_SCRIPT_DOCKER"
+
+  if [ -f "perf/results/summary-auto-${RUN_ID}.json" ]; then
+    cp "perf/results/summary-auto-${RUN_ID}.json" "$K6_SUMMARY_FILE"
+  fi
+}
+
+log "Running k6 (${K6_MODE})"
+if [ "$K6_MODE" = "local" ]; then
+  run_k6_local
+elif [ "$K6_MODE" = "docker" ]; then
+  run_k6_docker
+else
+  log "Unsupported K6_MODE: $K6_MODE"
+  exit 1
+fi
+
+log "Stopping sampler"
+touch "$STOP_FILE"
+wait "$SAMPLER_PID" || true
+
+log "Collecting final DB snapshots"
+collect_final_db_snapshots
+
+log "Done. Observability bundle: $OUT_DIR"
+log "- k6 summary: $K6_SUMMARY_FILE"
+log "- app metrics json: $APP_METRICS_DIR"
+log "- db metrics: $DB_DIR"

--- a/perf/scripts/run-k6-with-metrics.sh
+++ b/perf/scripts/run-k6-with-metrics.sh
@@ -29,7 +29,7 @@ K6_EXTRA_ARGS="${K6_EXTRA_ARGS:-}"
 
 BASE_URL="${BASE_URL:-http://localhost:8080}"
 API_PREFIX="${API_PREFIX:-/api/dev}"
-TEST_AUTH_SECRET="${TEST_AUTH_SECRET:-perf-test-secret}"
+TEST_AUTH_SECRET="${TEST_AUTH_SECRET:-}"
 
 ACTUATOR_BASE_URL="${ACTUATOR_BASE_URL:-http://localhost:9090/actuator}"
 ACTUATOR_USER="${ACTUATOR_USER:-cocos}"
@@ -50,6 +50,11 @@ mkdir -p "$APP_METRICS_DIR" "$DB_DIR"
 
 if [ -z "$ACTUATOR_PASSWORD" ]; then
   echo "ACTUATOR_PASSWORD is required. Set it explicitly before running."
+  exit 1
+fi
+
+if [ -z "$TEST_AUTH_SECRET" ]; then
+  echo "TEST_AUTH_SECRET is required. Set it explicitly before running."
   exit 1
 fi
 

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -6,7 +6,7 @@ import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.search.SearchType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +22,7 @@ public class SearchService {
     public void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
         try {
             searchWriteTxExecutor.saveOrUpdateExisting(memberId, keyword, searchType);
-        } catch (DuplicateKeyException exception) {
+        } catch (DataIntegrityViolationException exception) {
             final boolean recovered = searchWriteTxExecutor.recoverDuplicate(memberId, keyword, searchType);
             if (!recovered) {
                 throw exception;

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -6,7 +6,7 @@ import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.search.SearchType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,29 +17,16 @@ import java.util.List;
 public class SearchService {
 
     private final SearchRepository searchRepository;
+    private final SearchWriteTxExecutor searchWriteTxExecutor;
 
-    @Transactional
     public void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
-        final Search search = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
-
-        if (search != null) {
-            search.updateTime();
-            return;
-        }
-
         try {
-            searchRepository.save(Search.builder()
-                    .memberId(memberId)
-                    .keyword(keyword)
-                    .searchType(searchType)
-                    .build());
-        } catch (DataIntegrityViolationException exception) {
-            final Search existingSearch = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
-            if (existingSearch != null) {
-                existingSearch.updateTime();
-                return;
+            searchWriteTxExecutor.saveOrUpdateExisting(memberId, keyword, searchType);
+        } catch (DuplicateKeyException exception) {
+            final boolean recovered = searchWriteTxExecutor.recoverDuplicate(memberId, keyword, searchType);
+            if (!recovered) {
+                throw exception;
             }
-            throw exception;
         }
     }
 

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchService.java
@@ -6,6 +6,7 @@ import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.search.SearchType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,16 +20,26 @@ public class SearchService {
 
     @Transactional
     public void addSearch(final Long memberId, final String keyword, final SearchType searchType) {
-        final Search search = searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+        final Search search = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
 
         if (search != null) {
             search.updateTime();
-        } else {
+            return;
+        }
+
+        try {
             searchRepository.save(Search.builder()
                     .memberId(memberId)
                     .keyword(keyword)
                     .searchType(searchType)
                     .build());
+        } catch (DataIntegrityViolationException exception) {
+            final Search existingSearch = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+            if (existingSearch != null) {
+                existingSearch.updateTime();
+                return;
+            }
+            throw exception;
         }
     }
 

--- a/src/main/java/com/cocos/cocos/api/search/service/SearchWriteTxExecutor.java
+++ b/src/main/java/com/cocos/cocos/api/search/service/SearchWriteTxExecutor.java
@@ -1,0 +1,42 @@
+package com.cocos.cocos.api.search.service;
+
+import com.cocos.cocos.db.search.entity.Search;
+import com.cocos.cocos.db.search.repository.SearchRepository;
+import com.cocos.cocos.enums.search.SearchType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SearchWriteTxExecutor {
+
+    private final SearchRepository searchRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveOrUpdateExisting(final Long memberId, final String keyword, final SearchType searchType) {
+        final Search existingSearch = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+        if (existingSearch != null) {
+            existingSearch.updateTime();
+            return;
+        }
+
+        searchRepository.save(Search.builder()
+                .memberId(memberId)
+                .keyword(keyword)
+                .searchType(searchType)
+                .build());
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean recoverDuplicate(final Long memberId, final String keyword, final SearchType searchType) {
+        final Search existingSearch = searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType);
+        if (existingSearch == null) {
+            return false;
+        }
+
+        existingSearch.updateTime();
+        return true;
+    }
+}

--- a/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
+++ b/src/main/java/com/cocos/cocos/db/search/repository/SearchRepository.java
@@ -2,9 +2,7 @@ package com.cocos.cocos.db.search.repository;
 
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.enums.search.SearchType;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,9 +10,7 @@ import java.util.List;
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
-    //TODO: 안정적인 상황 확인 후 동시성 제어 제거
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Search findWithLockByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
+    Search findByMemberIdAndKeywordAndSearchType(final Long memberId, final String keyword, final SearchType searchType);
 
     List<Search> findTop5ByMemberIdAndSearchTypeOrderByUpdatedAtDesc(final Long memberId, final SearchType searchType);
 

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -3,11 +3,14 @@ package com.cocos.cocos.search;
 import com.cocos.cocos.api.search.service.SearchService;
 import com.cocos.cocos.config.JpaAuditingConfig;
 import com.cocos.cocos.config.QuerydslConfig;
+import com.cocos.cocos.db.member.entity.Member;
 import com.cocos.cocos.db.member.repository.MemberRepository;
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
+import com.cocos.cocos.enums.member.Platform;
 import com.cocos.cocos.enums.search.SearchType;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +35,21 @@ class SearchConcurrencyTest {
     @Autowired
     private SearchRepository searchRepository;
 
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        final Member member = memberRepository.save(
+                Member.builder()
+                        .sub("search-concurrency-member")
+                        .platform(Platform.KAKAO)
+                        .image("member/baseProfileImage.png")
+                        .isAdmin(false)
+                        .build()
+        );
+        this.memberId = member.getId();
+    }
+
     @Test
     @DisplayName("동시에 검색어 저장 요청이 와도 insert는 한 번만 발생한다")
     void addSearchConcurrency() throws InterruptedException {
@@ -39,8 +57,6 @@ class SearchConcurrencyTest {
         final int threadCount = 10;
         final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         final CountDownLatch latch = new CountDownLatch(threadCount);
-        final Long memberId = 1L;
-
         final String keyword = "피부과";
         final SearchType type = SearchType.HOSPITAL;
 

--- a/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.cocos.cocos.search;
 
 import com.cocos.cocos.api.search.service.SearchService;
+import com.cocos.cocos.api.search.service.SearchWriteTxExecutor;
 import com.cocos.cocos.config.JpaAuditingConfig;
 import com.cocos.cocos.config.QuerydslConfig;
 import com.cocos.cocos.db.member.entity.Member;
@@ -23,7 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @DataJpaTest
-@Import({SearchService.class,JpaAuditingConfig.class, QuerydslConfig.class })
+@Import({SearchService.class, SearchWriteTxExecutor.class, JpaAuditingConfig.class, QuerydslConfig.class })
 class SearchConcurrencyTest {
 
     @Autowired

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -3,6 +3,7 @@ package com.cocos.cocos.search;
 import com.cocos.cocos.api.search.dto.response.KeywordResponse;
 import com.cocos.cocos.api.search.dto.response.SearchResponse;
 import com.cocos.cocos.api.search.service.SearchService;
+import com.cocos.cocos.api.search.service.SearchWriteTxExecutor;
 import com.cocos.cocos.db.search.entity.Search;
 import com.cocos.cocos.db.search.repository.SearchRepository;
 import com.cocos.cocos.enums.search.SearchType;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
@@ -32,6 +34,9 @@ class SearchServiceTest {
 
     @Mock
     private SearchRepository searchRepository;
+
+    @Mock
+    private SearchWriteTxExecutor searchWriteTxExecutor;
 
     @Test
     @DisplayName("최근에 검색한 커뮤니티 검색어 5개를 보여줄 수 있다.")
@@ -67,41 +72,21 @@ class SearchServiceTest {
     }
 
     @Test
-    @DisplayName("이미 존재하는 검색어가 있을 경우 업데이트가 된다")
-    void addSearch() {
+    @DisplayName("정상 저장(또는 기존 검색어 업데이트)은 저장 트랜잭션에서 처리한다")
+    void addSearchSuccess() {
         // given
         final Long memberId = 1L;
         final String keyword = "피부과";
         final SearchType searchType = SearchType.HOSPITAL;
 
-        final Search existingSearch = Mockito.mock(Search.class);
-        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
-                .willReturn(existingSearch);
-
         // when
         searchService.addSearch(memberId, keyword, searchType);
 
         // then
-        Mockito.verify(existingSearch, Mockito.times(1)).updateTime();
-        Mockito.verify(searchRepository, Mockito.never()).save(Mockito.any());
-    }
-
-    @Test
-    @DisplayName("동일한 검색어가 없으면 새로 저장한다")
-    void addSearchIfSearchDoesNotExist() {
-        // given
-        final Long memberId = 1L;
-        final String keyword = "피부과";
-        final SearchType searchType = SearchType.HOSPITAL;
-
-        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
-                .willReturn(null);
-
-        // when
-        searchService.addSearch(memberId, keyword, searchType);
-
-        // then
-        Mockito.verify(searchRepository, Mockito.times(1)).save(Mockito.any(Search.class));
+        Mockito.verify(searchWriteTxExecutor, Mockito.times(1))
+                .saveOrUpdateExisting(memberId, keyword, searchType);
+        Mockito.verify(searchWriteTxExecutor, Mockito.never())
+                .recoverDuplicate(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
     }
 
     @Test
@@ -111,18 +96,58 @@ class SearchServiceTest {
         final Long memberId = 1L;
         final String keyword = "피부과";
         final SearchType searchType = SearchType.HOSPITAL;
-        final Search existingSearch = Mockito.mock(Search.class);
 
-        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
-                .willReturn(null, existingSearch);
-        BDDMockito.willThrow(new DataIntegrityViolationException("duplicate key"))
-                .given(searchRepository).save(Mockito.any(Search.class));
+        BDDMockito.willThrow(new DuplicateKeyException("duplicate key"))
+                .given(searchWriteTxExecutor).saveOrUpdateExisting(memberId, keyword, searchType);
+        BDDMockito.given(searchWriteTxExecutor.recoverDuplicate(memberId, keyword, searchType))
+                .willReturn(true);
 
         // when
         searchService.addSearch(memberId, keyword, searchType);
 
         // then
-        Mockito.verify(existingSearch, Mockito.times(1)).updateTime();
-        Mockito.verify(searchRepository, Mockito.times(1)).save(Mockito.any(Search.class));
+        Mockito.verify(searchWriteTxExecutor, Mockito.times(1))
+                .saveOrUpdateExisting(memberId, keyword, searchType);
+        Mockito.verify(searchWriteTxExecutor, Mockito.times(1))
+                .recoverDuplicate(memberId, keyword, searchType);
+    }
+
+    @Test
+    @DisplayName("중복키 충돌 후 복구에 실패하면 원래 예외를 다시 던진다")
+    void throwExceptionWhenDuplicateRecoveryFails() {
+        // given
+        final Long memberId = 1L;
+        final String keyword = "피부과";
+        final SearchType searchType = SearchType.HOSPITAL;
+        final DuplicateKeyException duplicateException = new DuplicateKeyException("duplicate key");
+
+        BDDMockito.willThrow(duplicateException)
+                .given(searchWriteTxExecutor).saveOrUpdateExisting(memberId, keyword, searchType);
+        BDDMockito.given(searchWriteTxExecutor.recoverDuplicate(memberId, keyword, searchType))
+                .willReturn(false);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> searchService.addSearch(memberId, keyword, searchType))
+                .isSameAs(duplicateException);
+    }
+
+    @Test
+    @DisplayName("중복키가 아닌 무결성 예외는 복구 시도 없이 그대로 던진다")
+    void throwExceptionWhenIntegrityViolationIsNotDuplicate() {
+        // given
+        final Long memberId = 1L;
+        final String keyword = "피부과";
+        final SearchType searchType = SearchType.HOSPITAL;
+        final DataIntegrityViolationException integrityException =
+                new DataIntegrityViolationException("NOT NULL constraint failed");
+
+        BDDMockito.willThrow(integrityException)
+                .given(searchWriteTxExecutor).saveOrUpdateExisting(memberId, keyword, searchType);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> searchService.addSearch(memberId, keyword, searchType))
+                .isSameAs(integrityException);
+        Mockito.verify(searchWriteTxExecutor, Mockito.never())
+                .recoverDuplicate(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
     }
 }

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
@@ -97,7 +96,7 @@ class SearchServiceTest {
         final String keyword = "피부과";
         final SearchType searchType = SearchType.HOSPITAL;
 
-        BDDMockito.willThrow(new DuplicateKeyException("duplicate key"))
+        BDDMockito.willThrow(new DataIntegrityViolationException("duplicate key"))
                 .given(searchWriteTxExecutor).saveOrUpdateExisting(memberId, keyword, searchType);
         BDDMockito.given(searchWriteTxExecutor.recoverDuplicate(memberId, keyword, searchType))
                 .willReturn(true);
@@ -119,7 +118,8 @@ class SearchServiceTest {
         final Long memberId = 1L;
         final String keyword = "피부과";
         final SearchType searchType = SearchType.HOSPITAL;
-        final DuplicateKeyException duplicateException = new DuplicateKeyException("duplicate key");
+        final DataIntegrityViolationException duplicateException =
+                new DataIntegrityViolationException("duplicate key");
 
         BDDMockito.willThrow(duplicateException)
                 .given(searchWriteTxExecutor).saveOrUpdateExisting(memberId, keyword, searchType);
@@ -132,7 +132,7 @@ class SearchServiceTest {
     }
 
     @Test
-    @DisplayName("중복키가 아닌 무결성 예외는 복구 시도 없이 그대로 던진다")
+    @DisplayName("중복키가 아닌 무결성 예외는 복구를 시도하고 실패 시 그대로 던진다")
     void throwExceptionWhenIntegrityViolationIsNotDuplicate() {
         // given
         final Long memberId = 1L;
@@ -147,7 +147,7 @@ class SearchServiceTest {
         // when & then
         Assertions.assertThatThrownBy(() -> searchService.addSearch(memberId, keyword, searchType))
                 .isSameAs(integrityException);
-        Mockito.verify(searchWriteTxExecutor, Mockito.never())
-                .recoverDuplicate(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+        Mockito.verify(searchWriteTxExecutor, Mockito.times(1))
+                .recoverDuplicate(memberId, keyword, searchType);
     }
 }

--- a/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
+++ b/src/test/java/com/cocos/cocos/search/SearchServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -74,7 +75,7 @@ class SearchServiceTest {
         final SearchType searchType = SearchType.HOSPITAL;
 
         final Search existingSearch = Mockito.mock(Search.class);
-        BDDMockito.given(searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
+        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
                 .willReturn(existingSearch);
 
         // when
@@ -93,13 +94,35 @@ class SearchServiceTest {
         final String keyword = "피부과";
         final SearchType searchType = SearchType.HOSPITAL;
 
-        BDDMockito.given(searchRepository.findWithLockByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
+        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
                 .willReturn(null);
 
         // when
         searchService.addSearch(memberId, keyword, searchType);
 
         // then
+        Mockito.verify(searchRepository, Mockito.times(1)).save(Mockito.any(Search.class));
+    }
+
+    @Test
+    @DisplayName("중복키 충돌이 발생하면 기존 검색어를 조회해 업데이트한다")
+    void addSearchOnDuplicateKey() {
+        // given
+        final Long memberId = 1L;
+        final String keyword = "피부과";
+        final SearchType searchType = SearchType.HOSPITAL;
+        final Search existingSearch = Mockito.mock(Search.class);
+
+        BDDMockito.given(searchRepository.findByMemberIdAndKeywordAndSearchType(memberId, keyword, searchType))
+                .willReturn(null, existingSearch);
+        BDDMockito.willThrow(new DataIntegrityViolationException("duplicate key"))
+                .given(searchRepository).save(Mockito.any(Search.class));
+
+        // when
+        searchService.addSearch(memberId, keyword, searchType);
+
+        // then
+        Mockito.verify(existingSearch, Mockito.times(1)).updateTime();
         Mockito.verify(searchRepository, Mockito.times(1)).save(Mockito.any(Search.class));
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #317

## 👷 **작업한 내용**
- Search 저장 동시성 로직 개선
  - `SearchService` 저장 흐름 개선
  - `SearchRepository` 조회/저장 경로 정리
- 동시성/중복키 회귀 테스트 보강
  - `SearchConcurrencyTest`
  - `SearchServiceTest`
- 성능 재현 및 검증 체계 정리
  - k6 시나리오 추가: `perf/k6/search-write.js`, `perf/k6/search-write-heavy.js`
  - 로컬 부하 환경 구성: `docker-compose.perf.yml`, `docker-compose.perf.benchmark.yml`
  - 관측 자동수집 스크립트/가이드 추가: `perf/scripts/run-k6-with-metrics.sh`, `docs/performance/local-k6.md`
- 의사결정 문서 정리
  - 3회 반복 비교 결과: `docs/decisions/2026-02-15-k6-dev-vs-feat317-heavy-local-repeat3.md`
  - 원인 분석 리포트: `docs/decisions/2026-02-15-k6-observability-root-cause-20260215-021141.md`
  - 위키/결정 인덱스 정리: `docs/wiki/2026-02-15-search-performance-technical-decisions.md`, `docs/decisions/README.md`
- 추적 정책 정리
  - `.gitignore`에서 실행 산출물/개인 로컬 문서 미추적 처리

## 🚨 **참고 사항**
- 성능 비교 결과는 TPS 단독이 아니라 p95/p99/error 안정성까지 포함해 판단했습니다.
- 문서 내 로컬 산출물(`perf/results/*`, `/tmp/*`) 고정 경로는 제거/일반화했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 동시성 검색 쓰기 안정성 강화 및 중복 키 복구 로직 추가

* **성능 개선**
  * 로컬 성능 테스트 스택 구성 추가(DB·앱·로드제너레이터 포함)
  * k6 기반 무거운 시나리오로 반복 성능 측정 지원

* **문서**
  * 실험 결과, 관찰·원인 분석 보고서 및 실행 가이드 문서화

* **테스트**
  * k6 테스트 스크립트 및 통합 실행·메트릭 수집 스크립트 추가

* **잡무**
  * 개발자 로컬 산출물 무시 규칙(.gitignore) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->