### PR TITLE
Fix: S3 key 가 null일 때 빈 문자열 반환하도록 변경

### DIFF
--- a/src/main/java/com/cocos/cocos/external/s3/S3PresignClient.java
+++ b/src/main/java/com/cocos/cocos/external/s3/S3PresignClient.java
@@ -21,7 +21,9 @@ public class S3PresignClient {
     private final S3BucketResolver bucketResolver;
 
     public String get(final S3BucketType bucketType, final String key) {
-        validateKey(key);
+        if (key == null || key.isBlank()) {
+            return "";
+        }
 
         final String bucket = bucketResolver.resolve(bucketType);
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #325

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- S3 key 가 null일 때 빈 문자열 반환하도록 변경

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- S3 키가 null이거나 공백일 때 예외 발생 대신 빈 문자열을 반환하도록 개선하여 오류 처리의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->