### PR TITLE
Fix: pet 정보 수정 시, age, birthDate가 둘다 null일 수 있도록 변경

### DIFF
--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -127,11 +127,7 @@ public class PetService {
         }
 
         AgeAndBirthDate reconciled =
-                PetAgeResolver.resolve(
-                        petUpdateRequest.age() != null ? petUpdateRequest.age() : pet.getAge(),
-                        petUpdateRequest.birthDate() != null ? petUpdateRequest.birthDate() : pet.getBirthDate(),
-                        clock
-                );
+                PetAgeResolver.resolve(petUpdateRequest.age(), petUpdateRequest.birthDate(), clock);
 
         pet.updateFields(petUpdateRequest.name(), petUpdateRequest.gender(), reconciled.age(), reconciled.birthDate(), petUpdateRequest.breedId());
 

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -128,8 +128,8 @@ public class PetService {
 
         AgeAndBirthDate reconciled =
                 PetAgeResolver.resolve(
-                        petUpdateRequest.age(),
-                        petUpdateRequest.birthDate(),
+                        petUpdateRequest.age() != null ? petUpdateRequest.age() : pet.getAge(),
+                        petUpdateRequest.birthDate() != null ? petUpdateRequest.birthDate() : pet.getBirthDate(),
                         clock
                 );
 

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
@@ -13,10 +13,6 @@ public final class PetAgeResolver {
             LocalDate birthDate,
             Clock clock
     ) {
-        if (age == null && birthDate == null) {
-            throw new IllegalArgumentException("age 또는 birthDate 중 하나는 필수입니다.");
-        }
-
         if (age != null && birthDate == null) {
             birthDate = LocalDate.of(
                     LocalDate.now(clock).getYear() - age,

--- a/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
+++ b/src/main/java/com/cocos/cocos/db/pet/support/PetAgeResolver.java
@@ -13,7 +13,9 @@ public final class PetAgeResolver {
             LocalDate birthDate,
             Clock clock
     ) {
-        if (age != null && birthDate == null) {
+        if (age == null && birthDate == null) {
+            return new AgeAndBirthDate(null, null);
+        } else if (age != null && birthDate == null) {
             birthDate = LocalDate.of(
                     LocalDate.now(clock).getYear() - age,
                     1,


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #328

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- pet 정보 수정 시, age, birthDate가 둘다 null일 수 있도록 변경

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="480" height="167" alt="image" src="https://github.com/user-attachments/assets/e3c68e30-54b0-4dd0-918c-c1f45ff1c523" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 펫 정보(나이/생년월일) 처리 로직을 개선하여, 업데이트 요청에서 해당 필드를 생략해도 기존 값이 유지되거나 null 상태가 안전하게 처리됩니다.
  * 입력값이 모두 비어있는 경우 더 이상 예외가 발생하지 않아 업데이트가 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->