### PR TITLE
Feat: getBody 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyController.java
@@ -22,7 +22,7 @@ public class BodyController implements BodyControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<BodiesResponse>> getBodies(
-            @RequestParam final PetProblem petProblem
+            @RequestParam(required = false) final PetProblem petProblem
     ) {
         return SuccessResponse.success(SuccessMessage.OK, bodyService.getBodies(petProblem));
     }

--- a/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/body/controller/BodyControllerSwagger.java
@@ -18,6 +18,6 @@ public interface BodyControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "신체 부위 조회 성공")
-    @Parameter(name = "petProblem", description = "반려동물 문제(DISEASE or SYMPTOM)", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+    @Parameter(name = "petProblem", description = "반려동물 문제(DISEASE or SYMPTOM)", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "String"))
     public ResponseEntity<BaseResponse<BodiesResponse>> getBodies(final PetProblem petProblem);
 }

--- a/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
+++ b/src/main/java/com/cocos/cocos/api/body/service/BodyService.java
@@ -9,7 +9,6 @@ import com.cocos.cocos.db.disease.repository.DiseaseRepository;
 import com.cocos.cocos.db.symptom.entity.Symptom;
 import com.cocos.cocos.db.symptom.repository.SymptomRepository;
 import com.cocos.cocos.enums.pet.PetProblem;
-
 import com.cocos.cocos.external.s3.S3BucketType;
 import com.cocos.cocos.external.s3.S3PresignClient;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +28,22 @@ public class BodyService {
 
     @Transactional(readOnly = true)
     public BodiesResponse getBodies(final PetProblem petProblem) {
-        final List<Long> bodyIds = fetchBodyIdsByPetProblem(petProblem);
-        final List<Body> bodies = bodyRepository.findAllById(bodyIds);
+
+        final List<Body> bodies = findBodiesByPetProblem(petProblem);
         return BodiesResponse.of(
                 bodies.stream()
                         .map(body -> BodyResponse.of(body.getId(), body.getName(), s3PresignClient.get(S3BucketType.APP_DATA, body.getImage())))
                         .toList()
         );
+    }
+
+    private List<Body> findBodiesByPetProblem(final PetProblem petProblem) {
+        if (petProblem == null) {
+            return bodyRepository.findAll();
+        } else {
+            final List<Long> bodyIds = fetchBodyIdsByPetProblem(petProblem);
+            return bodyRepository.findAllById(bodyIds);
+        }
     }
 
     private List<Long> fetchBodyIdsByPetProblem(final PetProblem petProblem) {

--- a/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
+++ b/src/main/java/com/cocos/cocos/enums/message/FailMessage.java
@@ -44,6 +44,7 @@ public enum FailMessage {
     BAD_REQUEST_INVALID_NOTIFICATION_ID(HttpStatus.BAD_REQUEST, 40030, "유효하지 않은 알림 아이디입니다. "),
     BAD_REQUEST_INVALID_S3_OBJECT_KEY(HttpStatus.BAD_REQUEST, 40031, "유효하지 않은 S3 Object key 입니다. "),
     BAD_REQUEST_INVALID_VISITED_AT_FORMAT(HttpStatus.BAD_REQUEST, 40032, "유효하지 않은 방문 날짜 포맷입니다. "),
+    BAD_REQUEST_INVALID_PET_PROBLEM(HttpStatus.BAD_REQUEST, 40033, "유효하지 않은 펫 문제입니다. "),
     /**
      * 401
      */

--- a/src/main/java/com/cocos/cocos/enums/pet/PetProblem.java
+++ b/src/main/java/com/cocos/cocos/enums/pet/PetProblem.java
@@ -1,5 +1,7 @@
 package com.cocos.cocos.enums.pet;
 
+import com.cocos.cocos.common.exception.CocosException;
+import com.cocos.cocos.enums.message.FailMessage;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,7 +20,6 @@ public enum PetProblem {
                 return value;
             }
         }
-        //ToDo: IllegalStateException 보다 커스텀 Exception 사용이 더 좋아보임
-        throw new IllegalStateException("일치하는 카테고리가 존재하지 않습니다.");
+        throw new CocosException(FailMessage.BAD_REQUEST_INVALID_PET_PROBLEM);
     }
 }

--- a/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
+++ b/src/test/java/com/cocos/cocos/body/BodyServiceTest.java
@@ -87,4 +87,38 @@ class BodyServiceTest {
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("petProblem이 null일 때 전체 부위 리스트를 조회할 수 있다.")
+    void getAllBodies() {
+        final Body body1 = Body.builder()
+                .name("이름1")
+                .image("이미지1")
+                .build();
+        final Body body2 = Body.builder()
+                .name("이름2")
+                .image("이미지2")
+                .build();
+
+        final List<Body> bodies = List.of(body1, body2);
+        final BodiesResponse expected = BodiesResponse.of(
+                bodies.stream()
+                        .map(body -> BodyResponse.of(body.getId(), body.getName(), "image"))
+                        .toList()
+        );
+
+        BDDMockito.given(bodyRepository.findAll()).willReturn(bodies);
+        BDDMockito.given(
+                s3PresignClient.get(
+                        eq(S3BucketType.APP_DATA),
+                        any()
+                )
+        ).willReturn("image");
+
+        //when
+        final BodiesResponse actual = bodyService.getBodies(null);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #331

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 전체 body 조회가 가능하도록 변경했습니다. (petProblem required = false 로 수정)

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신체 목록 조회 엔드포인트가 선택적 필터링을 지원합니다. 이제 필터 없이 모든 신체 정보를 조회할 수 있습니다.

* **버그 수정**
  * 유효하지 않은 입력에 대한 오류 처리를 개선했습니다.

* **테스트**
  * 신체 목록 전체 조회 시나리오에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->