### PR TITLE
Feat: symptom/disease bodyIds null 처리

### DIFF
--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseController.java
@@ -24,7 +24,7 @@ public class DiseaseController implements DiseaseControllerSwagger{
 
     @GetMapping
     public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(
-            @RequestParam(name = "bodyIds") @BodyIdsConstraint final List<Long> bodyIds
+            @RequestParam(name = "bodyIds", required = false) @BodyIdsConstraint final List<Long> bodyIds
     ) {
         return SuccessResponse.success(SuccessMessage.OK, diseaseService.getDiseases(bodyIds));
     }

--- a/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/disease/controller/DiseaseControllerSwagger.java
@@ -20,6 +20,6 @@ public interface DiseaseControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "질병 리스트 조회 성공")
-    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
+    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "List<Long>"))
     public ResponseEntity<BaseResponse<DiseasesOfBodiesResponse>> getDiseases(@BodyIdsConstraint final List<Long> bodyIds);
 }

--- a/src/main/java/com/cocos/cocos/api/disease/service/DiseaseService.java
+++ b/src/main/java/com/cocos/cocos/api/disease/service/DiseaseService.java
@@ -24,14 +24,21 @@ public class DiseaseService {
 
     @Transactional(readOnly = true)
     public DiseasesOfBodiesResponse getDiseases(final List<Long> bodyIds) {
+
+        if (bodyIds == null || bodyIds.isEmpty()) {
+            return DiseasesOfBodiesResponse.of(List.of());
+        }
+
         return DiseasesOfBodiesResponse.of(
                 bodyIds.stream()
                         .map(bodyId -> {
-                            //ToDo: 의미에 따라 코드 간격 조절 필요 (ex: 조회하는 코드, DTO 만드는 코드, 로직 구현 코드)
+
                             final Body body = bodyRepository.findById(bodyId).orElseThrow(
                                     () -> new CocosException(FailMessage.NOT_FOUND_BODY)
                             );
+
                             final List<Disease> diseases = diseaseRepository.findAllByBodyId(bodyId);
+
                             return DiseasesOfBodyResponse.of(bodyId, body.getName(),
                                     diseases.stream()
                                             .map(disease -> DiseaseResponse.of(disease.getId(), disease.getName()))

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomController.java
@@ -24,7 +24,7 @@ public class SymptomController implements SymptomControllerSwagger {
 
     @GetMapping
     public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(
-            @RequestParam(name = "bodyIds") @BodyIdsConstraint final List<Long> bodyIds
+            @RequestParam(name = "bodyIds", required = false) @BodyIdsConstraint final List<Long> bodyIds
     ) {
         return SuccessResponse.success(SuccessMessage.OK, symptomService.getSymptoms(bodyIds));
     }

--- a/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/controller/SymptomControllerSwagger.java
@@ -20,6 +20,6 @@ public interface SymptomControllerSwagger {
     @ApiResponse(
             responseCode = "200",
             description = "증상 리스트 조회 성공")
-    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "List<Long>"))
+    @Parameter(name = "bodyIds", description = "신체 부위 아이디 리스트", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "List<Long>"))
     public ResponseEntity<BaseResponse<SymptomsOfBodiesResponse>> getSymptoms(@BodyIdsConstraint final List<Long> bodyIds);
 }

--- a/src/main/java/com/cocos/cocos/api/symptom/service/SymptomService.java
+++ b/src/main/java/com/cocos/cocos/api/symptom/service/SymptomService.java
@@ -24,6 +24,10 @@ public class SymptomService {
 
     @Transactional(readOnly = true)
     public SymptomsOfBodiesResponse getSymptoms(final List<Long> bodyIds) {
+        if (bodyIds == null || bodyIds.isEmpty()) {
+            return SymptomsOfBodiesResponse.of(List.of());
+        }
+
         return SymptomsOfBodiesResponse.of(
                 bodyIds.stream()
                         .map(bodyId -> {

--- a/src/test/java/com/cocos/cocos/diseases/DiseaseServiceTest.java
+++ b/src/test/java/com/cocos/cocos/diseases/DiseaseServiceTest.java
@@ -93,4 +93,22 @@ public class DiseaseServiceTest {
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("bodyIds가 null일 때 빈 배열을 반환한다. ")
+    void returnEmptyListWhenBodyIdsIsNull() {
+        //given
+
+        final List<Long> bodyIds = null;
+
+        final DiseasesOfBodiesResponse expected = DiseasesOfBodiesResponse.of(
+                List.of()
+        );
+
+        //when
+        final DiseasesOfBodiesResponse actual = diseaseService.getDiseases(bodyIds);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
 }

--- a/src/test/java/com/cocos/cocos/symptom/SymptomServiceTest.java
+++ b/src/test/java/com/cocos/cocos/symptom/SymptomServiceTest.java
@@ -93,4 +93,22 @@ public class SymptomServiceTest {
         //then
         Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("bodyIds가 null일 때 빈 배열을 반환한다. ")
+    void returnEmptyListWhenBodyIdsIsNull() {
+        //given
+
+        final List<Long> bodyIds = null;
+
+        final SymptomsOfBodiesResponse expected = SymptomsOfBodiesResponse.of(
+                List.of()
+        );
+
+        //when
+        final SymptomsOfBodiesResponse actual = symptomService.getSymptoms(bodyIds);
+
+        //then
+        Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #333

## 👷 **작업한 내용**
- symptom/disease 조회 API에서 `bodyIds` 쿼리 파라미터를 optional(`required = false`)로 변경했습니다.
- `bodyIds`가 `null` 또는 빈 값일 때 예외 대신 빈 배열을 반환하도록 서비스 로직을 수정했습니다.
- Swagger 문서에서 `bodyIds`의 required 값을 `false`로 반영했습니다.
- symptom/disease 서비스 테스트에 `bodyIds == null`일 때 빈 배열 반환 케이스를 추가했습니다.

## 🚨 **참고 사항**
- 커밋 분리:
  - `Fix: symptom bodyIds가 null일 때 빈 배열 반환`
  - `Fix: disease bodyIds가 null일 때 빈 배열 반환`
- 실행 테스트:
  - `./gradlew test --tests "com.cocos.cocos.symptom.SymptomServiceTest" --tests "com.cocos.cocos.diseases.DiseaseServiceTest"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 질병 및 증상 조회 API에서 신체 부위 필터가 선택사항으로 변경되어, 신체 부위 지정 없이도 API를 호출할 수 있습니다.

* **Bug Fixes**
  * 신체 부위 미지정 시 안정적으로 빈 결과를 반환하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->