### PR TITLE
Fix: 펫 age 제약 조건 제거

### DIFF
--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetCreateRequest.java
@@ -6,7 +6,6 @@ import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.pet.AgeOrBirthDateRequiredConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
@@ -26,7 +25,6 @@ public record PetCreateRequest(
         Gender gender,
 
         @Schema(description = "나이", example = "12", nullable = true)
-        @Min(1)
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
         @Schema(description = "생년월일", example = "2020-01-01", nullable = true)

--- a/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/request/PetUpdateRequest.java
@@ -5,7 +5,6 @@ import com.cocos.cocos.validation.breed.BreedIdConstraint;
 import com.cocos.cocos.validation.disease.DiseaseIdsConstraint;
 import com.cocos.cocos.validation.symptom.SymptomIdsConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
@@ -24,7 +23,6 @@ public record PetUpdateRequest(
         Gender gender,
 
         @Schema(description = "나이", example = "12", nullable = true)
-        @Min(1)
         Integer age, // [TODO] 프론트 배포 후 제거 필요
 
         @Schema(description = "생년월일", example = "2020-01-01", nullable = true)

--- a/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cocos/cocos/common/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -116,6 +118,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<?>> handleGeneralException(Exception e) {
+        log.error("Unhandled exception occurred", e);
         return FailResponse.failure(FailMessage.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
+++ b/src/main/java/com/cocos/cocos/db/pet/entity/Pet.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,7 +37,6 @@ public class Pet extends BaseTime {
     private Gender gender;
 
     @Column(name = "age")
-    @Min(1)
     private Integer age;
 
     @Column(name = "member_id", nullable = false, unique = true)

--- a/src/main/resources/db/migration/V5__drop_age_check_from_pet.sql
+++ b/src/main/resources/db/migration/V5__drop_age_check_from_pet.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pet
+DROP CHECK pet_chk_1;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #335

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 0살이 가능해짐에 따라 기존에 있던 나이 >=1 제약 조건을 제거했습니다.
- db, validation 제약 제거

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 펫 나이 검증 제약 조건을 제거하여 입력 가능한 나이 범위를 확대했습니다.
  * 시스템 오류 로깅 기능을 추가하여 예외 상황 추적 및 모니터링을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->