### PR TITLE
Feat: 관심 부위 추가

### DIFF
--- a/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/cocos/cocos/api/pet/dto/response/PetResponse.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.api.pet.dto.response;
 
+import com.cocos.cocos.api.body.dto.response.BodyResponse;
 import com.cocos.cocos.enums.pet.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -30,9 +31,11 @@ public record PetResponse(
         @Schema(description = "질병 리스트")
         List<PetDiseaseResponse> diseases,
         @Schema(description = "증상 리스트")
-        List<PetSymptomResponse> symptoms
+        List<PetSymptomResponse> symptoms,
+        @Schema(description = "관심 부위 리스트")
+        List<BodyResponse> concernBodies
 ) {
-    public static PetResponse of(final Long petId, final String petImage, final String petName, final Integer petAge, final LocalDate petBirthDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms) {
-        return new PetResponse(petId, petImage, petName, petAge, petBirthDate, petGender, breedId, breed, animalId, animal, diseases, symptoms);
+        public static PetResponse of(final Long petId, final String petImage, final String petName, final Integer petAge, final LocalDate petBirthDate, final Gender petGender, final Long breedId, final String breed, final Long animalId, final String animal, final List<PetDiseaseResponse> diseases, final List<PetSymptomResponse> symptoms, List<BodyResponse> concernBodies) {
+                return new PetResponse(petId, petImage, petName, petAge, petBirthDate, petGender, breedId, breed, animalId, animal, diseases, symptoms, concernBodies);
     }
 }

--- a/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
+++ b/src/main/java/com/cocos/cocos/api/pet/service/PetService.java
@@ -1,5 +1,6 @@
 package com.cocos.cocos.api.pet.service;
 
+import com.cocos.cocos.api.body.dto.response.BodyResponse;
 import com.cocos.cocos.api.pet.dto.request.PetCreateRequest;
 import com.cocos.cocos.api.pet.dto.request.PetUpdateRequest;
 import com.cocos.cocos.api.pet.dto.response.PetDiseaseResponse;
@@ -9,6 +10,8 @@ import com.cocos.cocos.api.pet.dto.response.PetSymptomResponse;
 import com.cocos.cocos.common.exception.CocosException;
 import com.cocos.cocos.db.animal.entity.Animal;
 import com.cocos.cocos.db.animal.repository.AnimalRepository;
+import com.cocos.cocos.db.body.entity.Body;
+import com.cocos.cocos.db.body.repository.BodyRepository;
 import com.cocos.cocos.db.breed.entity.Breed;
 import com.cocos.cocos.db.breed.repository.BreedRepository;
 import com.cocos.cocos.db.disease.entity.Disease;
@@ -33,6 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +52,7 @@ public class PetService {
     private final MemberRepository memberRepository;
     private final S3PresignClient s3PresignClient;
     private final Clock clock;
+    private final BodyRepository bodyRepository;
 
     //ToDo: yml에 추가하는 방향 고민 중
     private static final String PET_BASE_IMAGE_URL = "member/basePetImage.png";
@@ -152,9 +158,6 @@ public class PetService {
 
     @Transactional(readOnly = true)
     public PetResponse getPet(final String nickname, final Long memberId) {
-        if (nickname != null && !memberRepository.existsByNickname(nickname)) {
-            throw new CocosException(FailMessage.NOT_FOUND_MEMBER);
-        }
 
         //ToDo: 메소드로 통일시켜도 좋을 것 같음(이전 다른 곳에서 사용되었던 코드와 통일 시키는 것이 좋아보임)
         final Long selectedMemberId = (nickname != null)
@@ -190,6 +193,17 @@ public class PetService {
                         )
                 ).toList();
 
+        final List<Long> concernBodyIds = Stream.concat(
+                        symptoms.stream().map(Symptom::getBodyId),
+                        diseases.stream().map(Disease::getBodyId)
+                )
+                .filter(Objects::nonNull)
+                .distinct()
+                .limit(2)
+                .toList();
+
+        final List<Body> concernBodies = bodyRepository.findAllById(concernBodyIds);
+
         return PetResponse.of(
                 pet.getId(),
                 s3PresignClient.get(S3BucketType.MEMBER_DATA, pet.getImage()),
@@ -202,7 +216,8 @@ public class PetService {
                 animal.getId(),
                 animal.getName(),
                 diseases.stream().map(disease -> PetDiseaseResponse.of(disease.getId(), disease.getName())).toList(),
-                symptoms.stream().map(symptom -> PetSymptomResponse.of(symptom.getId(), symptom.getName())).toList()
+                symptoms.stream().map(symptom -> PetSymptomResponse.of(symptom.getId(), symptom.getName())).toList(),
+                concernBodies.stream().map(body -> BodyResponse.of(body.getId(), body.getName(), s3PresignClient.get(S3BucketType.APP_DATA, body.getImage()))).toList()
         );
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #341

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 펫 조회 API 응답에 관심 부위를 추가했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
- 관심 부위는 랜덤 2개 선택
- 이미지는 변경될 수도 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 반려동물 상세 정보에 증상 및 질환과 관련된 신체 부위 정보를 함께 제공합니다.
  - 관련 신체 부위는 최대 2개까지 표시되며, 각 부위의 이미지도 확인할 수 있습니다.
  - 닉네임으로 반려동물 정보를 조회할 때 검색 결과에 따라 보다 일관되게 상세 정보가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->